### PR TITLE
Set default working directory for cleanup job in PR build workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -389,6 +389,9 @@ jobs:
     if: github.event.action == 'closed' && github.event_name == 'pull_request_target'
     permissions:
       contents: write
+    defaults:
+      run:
+        working-directory: .
     
     steps:
       - name: Delete PR registry release


### PR DESCRIPTION
Configure the default working directory for the cleanup job in the pull request build workflow to ensure consistent execution context.

# Pull Request

Thank you for your contribution!

## Description
Configure the default working directory for the cleanup job in the pull request build workflow to ensure consistent execution context.

## Checklist
- [ ] All tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
- [ ] Follows code style guidelines

