### PR TITLE
feat: Execute hook scripts directly without requiring chmod +x

### DIFF
--- a/cli/docs/features/hooks.md
+++ b/cli/docs/features/hooks.md
@@ -326,7 +326,8 @@ Hooks have full access to:
 **Solutions**:
 - Use absolute paths or paths relative to azure.yaml
 - Verify script file exists: `ls -la scripts/setup.sh`
-- Check file permissions: `chmod +x scripts/setup.sh`
+
+> **Note**: Scripts no longer need to be executable. When you specify a script file path (like `./scripts/setup.sh`), it's executed directly via the shell (e.g., `bash ./scripts/setup.sh`) rather than requiring `chmod +x`. This makes it easier to work with repositories right after cloning.
 
 ### Hook Fails Every Time
 


### PR DESCRIPTION
## Summary

This PR improves the hook execution experience by allowing script files to run without requiring executable permissions (`chmod +x`). This makes it easier to work with repositories right after cloning.

## Changes

### Hook Execution Enhancement

- **New `isScriptFilePath()` function**: Detects when a hook's `run` value is a file path (e.g., `./scripts/setup.sh`) vs inline commands
- **Direct script execution**: For POSIX shells, script file paths are now executed as `bash ./script.sh` instead of `bash -c './script.sh'`, eliminating the need for executable permissions
- **PowerShell `.ps1` support**: Uses `-File` flag for `.ps1` scripts, which handles paths more reliably and doesn't require execution policy changes

### Detection Logic

Script file paths are identified by:
- Relative paths: `./`, `../`, `.\\`, `..\\`
- Absolute paths: `/`
- Single token only (no arguments/chained commands)

### Files Changed

- [cli/src/internal/executor/hooks.go](cli/src/internal/executor/hooks.go) - Core implementation
- [cli/src/internal/executor/hooks_test.go](cli/src/internal/executor/hooks_test.go) - Comprehensive test coverage
- [cli/docs/features/hooks.md](cli/docs/features/hooks.md) - Updated documentation

## Testing

Added tests for:
- `isScriptFilePath()` detection with various inputs (relative paths, absolute paths, inline commands, chained commands)
- `prepareHookCommand()` argument generation for different shell/script combinations
- Integration test verifying scripts execute without executable permission on POSIX systems

## Example

Before this change:
```bash
git clone repo && cd repo
azd app run  # FAILS if hooks/prerun.sh isn't executable
chmod +x scripts/setup.sh
azd app run  # Works