### PR TITLE
feat: Enhance `azd app reqs` command to display installation URLs for requirements

### DIFF
--- a/cli/docs/commands/reqs.md
+++ b/cli/docs/commands/reqs.md
@@ -575,6 +575,7 @@ reqs:
 | `runningCheckArgs` | []string | ❌ | Arguments for running check |
 | `runningCheckExpected` | string | ❌ | Expected substring in output |
 | `runningCheckExitCode` | int | ❌ | Expected exit code (default: 0) |
+| `installUrl` | string | ❌ | URL to installation page (shown on failure) |
 
 ## Output Formats
 
@@ -587,8 +588,59 @@ reqs:
 ✓ docker: 24.0.7 (required: 20.0.0)
   - ✓ RUNNING
 ✗ python: NOT INSTALLED (required: 3.11.0)
+   Install: https://www.python.org/downloads/
 
 ✗ Some prerequisites are not satisfied
+```
+
+### Install URLs
+
+When a requirement check fails (not installed or version too old), the command displays an install URL to help users quickly find installation instructions.
+
+**Built-in Install URLs**:
+
+The following tools have built-in install URLs:
+
+| Tool | Install URL |
+|------|-------------|
+| node | https://nodejs.org/ |
+| npm | https://nodejs.org/ |
+| pnpm | https://pnpm.io/installation |
+| yarn | https://yarnpkg.com/getting-started/install |
+| python | https://www.python.org/downloads/ |
+| pip | https://www.python.org/downloads/ |
+| poetry | https://python-poetry.org/docs/#installation |
+| uv | https://docs.astral.sh/uv/getting-started/installation/ |
+| pipenv | https://pipenv.pypa.io/en/latest/installation.html |
+| dotnet | https://dotnet.microsoft.com/download |
+| aspire | https://learn.microsoft.com/dotnet/aspire/fundamentals/setup-tooling |
+| docker | https://www.docker.com/products/docker-desktop |
+| git | https://git-scm.com/downloads |
+| go | https://go.dev/dl/ |
+| azd | https://aka.ms/install-azd |
+| az | https://aka.ms/installazurecli |
+| func | https://learn.microsoft.com/azure/azure-functions/functions-run-local |
+| java | https://adoptium.net/ |
+| mvn | https://maven.apache.org/install.html |
+| gradle | https://gradle.org/install/ |
+
+**Custom Install URLs**:
+
+For custom tools or to override the built-in URL, specify `installUrl` in your azure.yaml:
+
+```yaml
+reqs:
+  - name: mytool
+    minVersion: "1.0.0"
+    command: "mytool"
+    args: ["--version"]
+    installUrl: "https://example.com/mytool/install"
+```
+
+**Output with Custom Install URL**:
+```
+✗ mytool: NOT INSTALLED (required: 1.0.0)
+   Install: https://example.com/mytool/install
 ```
 
 ### JSON Output (`--output json`)
@@ -603,7 +655,8 @@ reqs:
       "version": "20.11.0",
       "required": "18.0.0",
       "satisfied": true,
-      "message": "Satisfied"
+      "message": "Satisfied",
+      "installUrl": "https://nodejs.org/"
     },
     {
       "name": "docker",
@@ -613,14 +666,16 @@ reqs:
       "satisfied": true,
       "running": true,
       "checkedRunning": true,
-      "message": "Running"
+      "message": "Running",
+      "installUrl": "https://www.docker.com/products/docker-desktop"
     },
     {
       "name": "python",
       "installed": false,
       "required": "3.11.0",
       "satisfied": false,
-      "message": "Not installed"
+      "message": "Not installed",
+      "installUrl": "https://www.python.org/downloads/"
     }
   ]
 }

--- a/cli/src/internal/pathutil/pathutil.go
+++ b/cli/src/internal/pathutil/pathutil.go
@@ -141,19 +141,27 @@ func SearchToolInSystemPath(toolName string) string {
 // GetInstallSuggestion returns a suggestion for how to install a missing tool.
 func GetInstallSuggestion(toolName string) string {
 	suggestions := map[string]string{
-		"node":   "Install from https://nodejs.org/ or use nvm/fnm",
-		"pnpm":   "npm install -g pnpm",
+		"node":   "Install from https://nodejs.org/",
+		"pnpm":   "Install from https://pnpm.io/installation",
 		"npm":    "Install Node.js from https://nodejs.org/",
-		"yarn":   "npm install -g yarn",
+		"yarn":   "Install from https://yarnpkg.com/getting-started/install",
 		"python": "Install from https://www.python.org/downloads/",
 		"pip":    "Install Python from https://www.python.org/downloads/",
+		"poetry": "Install from https://python-poetry.org/docs/#installation",
+		"uv":     "Install from https://docs.astral.sh/uv/getting-started/installation/",
+		"pipenv": "Install from https://pipenv.pypa.io/en/latest/installation.html",
 		"docker": "Install Docker Desktop from https://www.docker.com/products/docker-desktop",
 		"git":    "Install from https://git-scm.com/downloads",
 		"go":     "Install from https://go.dev/dl/",
 		"dotnet": "Install from https://dotnet.microsoft.com/download",
+		"aspire": "Install from https://learn.microsoft.com/dotnet/aspire/fundamentals/setup-tooling",
 		"azd":    "Install from https://aka.ms/install-azd",
-		"az":     "Install from https://learn.microsoft.com/cli/azure/install-azure-cli",
-		"air":    "go install github.com/air-verse/air@latest",
+		"az":     "Install from https://aka.ms/installazurecli",
+		"air":    "Install from https://github.com/air-verse/air#installation",
+		"func":   "Install from https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools",
+		"java":   "Install from https://adoptium.net/",
+		"mvn":    "Install from https://maven.apache.org/install.html",
+		"gradle": "Install from https://gradle.org/install/",
 		"gh":     "Install from https://cli.github.com/",
 	}
 

--- a/docs/specs/reqs-install-url/spec.md
+++ b/docs/specs/reqs-install-url/spec.md
@@ -1,0 +1,112 @@
+# Reqs Install URL Enhancement
+
+## Overview
+
+Enhance the `azd app reqs` command to display installation URLs when requirement checks fail, and allow users to specify custom install URLs for custom requirements.
+
+## Problem
+
+Currently, when a requirement check fails, users see:
+```
+❌ mytool: NOT INSTALLED (required: 1.0.0)
+```
+
+Users must then search for installation instructions, which slows down onboarding.
+
+## Solution
+
+1. Add `installUrl` field to the `requirement` schema
+2. Provide built-in install URLs for known tools
+3. Display install URL in failure messages
+4. Support custom install URLs for custom requirements
+
+## Schema Changes
+
+Add `installUrl` property to `requirement` definition in `schemas/v1.1/azure.yaml.json`:
+
+```yaml
+reqs:
+  - name: node
+    minVersion: "18.0.0"
+  - name: mytool
+    minVersion: "1.0.0"
+    command: mytool
+    args: ["--version"]
+    installUrl: "https://example.com/mytool/install"
+```
+
+## Built-in Install URLs
+
+| Tool | Install URL |
+|------|-------------|
+| node | https://nodejs.org/ |
+| npm | https://nodejs.org/ |
+| pnpm | https://pnpm.io/installation |
+| yarn | https://yarnpkg.com/getting-started/install |
+| python | https://www.python.org/downloads/ |
+| pip | https://www.python.org/downloads/ |
+| poetry | https://python-poetry.org/docs/#installation |
+| uv | https://docs.astral.sh/uv/getting-started/installation/ |
+| docker | https://www.docker.com/products/docker-desktop |
+| git | https://git-scm.com/downloads |
+| go | https://go.dev/dl/ |
+| dotnet | https://dotnet.microsoft.com/download |
+| aspire | https://learn.microsoft.com/dotnet/aspire/setup-tooling |
+| azd | https://aka.ms/install-azd |
+| az | https://aka.ms/installazurecli |
+| func | https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools |
+| java | https://adoptium.net/ |
+| mvn | https://maven.apache.org/install.html |
+| gradle | https://gradle.org/install/ |
+
+## Output Changes
+
+### Failed Requirement (Built-in Tool)
+
+```
+❌ docker: NOT INSTALLED (required: 20.0.0)
+   Install: https://www.docker.com/products/docker-desktop
+```
+
+### Failed Requirement (Custom Tool with URL)
+
+```
+❌ mytool: NOT INSTALLED (required: 1.0.0)
+   Install: https://example.com/mytool/install
+```
+
+### Failed Requirement (Custom Tool without URL)
+
+```
+❌ mytool: NOT INSTALLED (required: 1.0.0)
+```
+
+### JSON Output
+
+Add `installUrl` field to `ReqResult`:
+
+```json
+{
+  "name": "docker",
+  "installed": false,
+  "required": "20.0.0",
+  "satisfied": false,
+  "message": "Not installed",
+  "installUrl": "https://www.docker.com/products/docker-desktop"
+}
+```
+
+## Files to Modify
+
+1. `schemas/v1.1/azure.yaml.json` - Add `installUrl` property to requirement definition
+2. `cli/src/cmd/app/commands/reqs.go` - Add `InstallUrl` to `Prerequisite` and `ReqResult`, add URL registry, update output
+3. `cli/src/internal/pathutil/pathutil.go` - Consolidate install suggestions with URLs
+4. `cli/src/cmd/app/commands/reqs_test.go` - Add tests for install URL display
+5. `cli/docs/commands/reqs.md` - Document new `installUrl` field
+
+## Implementation Notes
+
+- Built-in URLs take precedence unless user specifies custom `installUrl`
+- URL display only on failure (not installed or version mismatch)
+- Keep output concise - single "Install:" line with clickable URL
+- JSON output always includes `installUrl` when available

--- a/docs/specs/reqs-install-url/tasks.md
+++ b/docs/specs/reqs-install-url/tasks.md
@@ -1,0 +1,53 @@
+<!-- NEXT: -->
+# Reqs Install URL Tasks
+
+## Done
+
+### DONE: Add installUrl to schema {#add-installurl-schema}
+**Assigned**: Developer
+**File**: `schemas/v1.1/azure.yaml.json`
+
+Added `installUrl` property to the `requirement` definition with type: string, format: uri.
+
+### DONE: Add install URL registry {#add-install-url-registry}
+**Assigned**: Developer
+**File**: `cli/src/cmd/app/commands/reqs.go`
+
+Created `installURLRegistry` map with built-in URLs for 21 tools.
+
+### DONE: Update Prerequisite struct {#update-prerequisite-struct}
+**Assigned**: Developer
+**File**: `cli/src/cmd/app/commands/reqs.go`
+
+Added `InstallUrl` field to `Prerequisite` struct with YAML tag.
+
+### DONE: Update ReqResult struct {#update-reqresult-struct}
+**Assigned**: Developer
+**File**: `cli/src/cmd/app/commands/reqs.go`
+
+Added `InstallUrl` field to `ReqResult` struct with JSON tag.
+
+### DONE: Update Check method output {#update-check-method}
+**Assigned**: Developer
+**File**: `cli/src/cmd/app/commands/reqs.go`
+
+Modified `PrerequisiteChecker.Check()` to resolve install URL and display on failure.
+
+### DONE: Consolidate pathutil suggestions {#consolidate-pathutil}
+**Assigned**: Developer
+**File**: `cli/src/internal/pathutil/pathutil.go`
+
+Updated `GetInstallSuggestion()` to use same URLs as install URL registry.
+
+### DONE: Add unit tests {#add-unit-tests}
+**Assigned**: Developer
+**File**: `cli/src/cmd/app/commands/reqs_test.go`
+
+Added tests: `TestInstallURLRegistry`, `TestGetInstallUrl`, `TestCheckPrerequisiteIncludesInstallUrl`.
+
+### DONE: Update documentation {#update-documentation}
+**Assigned**: Developer
+**File**: `cli/docs/commands/reqs.md`
+
+Documented `installUrl` field, built-in URLs table, and updated output examples.
+

--- a/schemas/v1.1/azure.yaml.json
+++ b/schemas/v1.1/azure.yaml.json
@@ -368,6 +368,12 @@
         "runningCheckExitCode": {
           "type": "integer",
           "description": "Expected exit code for running check (default: 0)"
+        },
+        "installUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to installation page for this tool. Displayed when requirement check fails. Built-in tools have default URLs that can be overridden.",
+          "examples": ["https://nodejs.org/", "https://www.docker.com/products/docker-desktop"]
         }
       }
     },
@@ -720,6 +726,13 @@
         {
           "name": "docker",
           "checkRunning": true
+        },
+        {
+          "name": "mytool",
+          "minVersion": "1.0.0",
+          "command": "mytool",
+          "args": ["--version"],
+          "installUrl": "https://example.com/mytool/install"
         }
       ],
       "hooks": {


### PR DESCRIPTION
## Summary

Enhances the `azd app reqs` command to display installation URLs when requirement checks fail, helping users quickly find installation instructions for missing tools.

## Changes

### New Feature: Install URL Display
- Added `installUrl` field to the requirement schema in `azure.yaml`
- Built-in install URLs for 18 common tools (node, python, docker, azd, etc.)
- Custom requirements can specify their own `installUrl`
- URLs displayed only when checks fail