### PR TITLE
fix: replace subprocess MCP log/error tools with in-process collect() calls

### DIFF
--- a/cli/src/cmd/app/commands/logs.go
+++ b/cli/src/cmd/app/commands/logs.go
@@ -107,6 +107,37 @@ const (
 	LogSourceAll LogSource = "all"
 )
 
+// CollectedLogs holds the result of log collection, including metadata
+// for callers to make display/error decisions.
+// collect() returns this; execute() and MCP handlers consume it.
+type CollectedLogs struct {
+	// Entries holds log entries when no context extraction is needed.
+	// Initialized to empty slice (not nil) so JSON marshaling produces [] not null.
+	Entries []service.LogEntry
+
+	// EntriesWithContext holds log entries with surrounding context lines.
+	// Populated when contextLines > 0 and a level filter is active.
+	// Initialized to empty slice (not nil) so JSON marshaling produces [] not null.
+	EntriesWithContext []LogEntryWithContext
+
+	// HasContext indicates whether EntriesWithContext is populated (true)
+	// or Entries is populated (false).
+	HasContext bool
+
+	// DashboardAvailable indicates whether the dashboard was reachable.
+	DashboardAvailable bool
+
+	// ServiceCount is the number of services discovered via dashboard.
+	ServiceCount int
+
+	// Source is the log source that was used ("local", "azure", "all").
+	Source string
+
+	// Warnings holds non-fatal warning messages (e.g., "Azure logs unavailable").
+	// CLI displays these via cliout.Warning; MCP can include them in responses.
+	Warnings []string
+}
+
 // logsOptions holds the flag values for the logs command.
 // Using a struct avoids global state pollution between command invocations.
 type logsOptions struct {
@@ -170,6 +201,26 @@ func newLogsExecutorForTest(
 		outputWriter:           outputWriter,
 		signalChan:             make(chan os.Signal, 1),
 		opts:                   opts,
+	}
+}
+
+// newLogsExecutorForMCP creates a logsExecutor for MCP tool use.
+// Uses production dependencies but allows specifying a project directory.
+func newLogsExecutorForMCP(opts *logsOptions, projectDir string) *logsExecutor {
+	return &logsExecutor{
+		dashboardClientFactory: func(ctx context.Context, pd string) (DashboardClient, error) {
+			return dashboard.NewClient(ctx, pd)
+		},
+		logManagerFactory: func(pd string) LogManagerInterface {
+			return service.GetLogManager(pd)
+		},
+		getWorkingDir: func() (string, error) {
+			if projectDir != "" {
+				return projectDir, nil
+			}
+			return os.Getwd()
+		},
+		opts: opts,
 	}
 }
 
@@ -263,10 +314,104 @@ func (e *logsExecutor) execute(ctx context.Context, args []string) error {
 		e.opts.source = string(LogSourceLocal)
 	}
 
+	collected, err := e.collect(ctx, args)
+	if err != nil {
+		return err
+	}
+
+	// CLI-specific: emit informational messages based on collected status
+	if e.opts.source == string(LogSourceLocal) {
+		if !collected.DashboardAvailable || collected.ServiceCount == 0 {
+			cliout.Info("No services are currently running")
+			cliout.Item("Run 'azd app run' to start services")
+			return nil
+		}
+	}
+	// Emit any warnings collected during log retrieval
+	for _, w := range collected.Warnings {
+		cliout.Warning("%s", w)
+	}
+
+	if e.opts.source == "azure" && !e.opts.follow {
+		isEmpty := (!collected.HasContext && len(collected.Entries) == 0) ||
+			(collected.HasContext && len(collected.EntriesWithContext) == 0)
+		if isEmpty {
+			cliout.Info("No Azure logs found")
+			cliout.Item("Azure logs may take 1-5 minutes to appear in Log Analytics")
+			cliout.Item("Use --follow (-f) to wait for new logs")
+			return nil
+		}
+	}
+
+	// Setup output writer
+	outputWriter, cleanup, err := e.setupOutputWriter()
+	if err != nil {
+		return err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	// Display logs
+	if collected.HasContext {
+		if e.opts.format == "json" {
+			displayLogsWithContextJSON(collected.EntriesWithContext, outputWriter)
+		} else {
+			displayLogsWithContextText(collected.EntriesWithContext, outputWriter, e.opts.timestamps, e.opts.noColor)
+		}
+	} else {
+		if e.opts.format == "json" {
+			displayLogsJSON(collected.Entries, outputWriter)
+		} else {
+			displayLogsText(collected.Entries, outputWriter, e.opts.timestamps, e.opts.noColor)
+		}
+	}
+
+	// Follow mode - subscribe to live logs
+	if e.opts.follow {
+		// Reconstruct needed state for follow mode
+		cwd, err := e.getWorkingDir()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory for follow mode: %w", err)
+		}
+		serviceFilter := e.parseServiceFilter(args)
+		logManager := e.logManagerFactory(cwd)
+		levelFilter := parseLogLevel(e.opts.level)
+		logFilter, _ := e.buildLogFilterInternal(cwd)
+
+		dashCtx, dashCancel := context.WithTimeout(ctx, dashboardOperationTimeout)
+		dashboardClient, dashErr := e.dashboardClientFactory(dashCtx, cwd)
+		dashCancel()
+		if dashErr != nil {
+			cliout.Warning("Dashboard unavailable for follow mode: %s", dashErr)
+		}
+
+		return e.followLogs(ctx, cwd, logManager, dashboardClient, serviceFilter, levelFilter, logFilter, outputWriter)
+	}
+
+	return nil
+}
+
+// collect retrieves and filters logs, returning structured data.
+// Unlike execute(), it does NOT write to stdout, call cliout, or handle follow mode.
+// Callers (CLI execute() or MCP handlers) use the returned CollectedLogs
+// to decide what to display or return.
+func (e *logsExecutor) collect(ctx context.Context, args []string) (*CollectedLogs, error) {
+	// Default to local logs when source is not explicitly set
+	if e.opts.source == "" {
+		e.opts.source = string(LogSourceLocal)
+	}
+
+	result := &CollectedLogs{
+		Source:             e.opts.source,
+		Entries:            []service.LogEntry{},
+		EntriesWithContext: []LogEntryWithContext{},
+	}
+
 	// Get current working directory
 	cwd, err := e.getWorkingDir()
 	if err != nil {
-		return fmt.Errorf("failed to get current directory: %w", err)
+		return nil, fmt.Errorf("failed to get current directory: %w", err)
 	}
 
 	// Determine service filter
@@ -282,26 +427,16 @@ func (e *logsExecutor) execute(ctx context.Context, args []string) error {
 	// Get running services via dashboard client (works across processes)
 	dashboardClient, err := e.dashboardClientFactory(dashCtx, cwd)
 	if err != nil && e.opts.source == string(LogSourceLocal) {
-		// Local logs require dashboard; Azure can fall back to standalone
-		if os.Getenv("AZD_APP_DEBUG") == "true" {
-			fmt.Fprintf(os.Stderr, "[DEBUG] Dashboard client creation failed: %v\n", err)
-		}
-		cliout.Info("No services are currently running")
-		cliout.Item("Run 'azd app run' to start services")
-		return nil
+		// Local logs require dashboard; no dashboard = no services running
+		return result, nil
 	}
 
 	var serviceNames []string
 	if dashboardClient != nil {
 		// Check if dashboard is actually responding
 		if pingErr := dashboardClient.Ping(dashCtx); pingErr != nil {
-			if os.Getenv("AZD_APP_DEBUG") == "true" {
-				fmt.Fprintf(os.Stderr, "[DEBUG] Dashboard ping failed: %v\n", pingErr)
-			}
 			if e.opts.source == string(LogSourceLocal) {
-				cliout.Info("No services are currently running")
-				cliout.Item("Run 'azd app run' to start services")
-				return nil
+				return result, nil
 			}
 			// For Azure-only flows, continue without dashboard
 			dashboardClient = nil
@@ -310,9 +445,9 @@ func (e *logsExecutor) execute(ctx context.Context, args []string) error {
 
 	if dashboardClient != nil {
 		// Get service list from dashboard
-		services, err := dashboardClient.GetServices(dashCtx)
-		if err != nil {
-			return fmt.Errorf("failed to get services from dashboard: %w", err)
+		services, svcErr := dashboardClient.GetServices(dashCtx)
+		if svcErr != nil {
+			return nil, fmt.Errorf("failed to get services from dashboard: %w", svcErr)
 		}
 
 		// Build list of service names
@@ -323,16 +458,17 @@ func (e *logsExecutor) execute(ctx context.Context, args []string) error {
 
 		// Check if any services exist (local mode)
 		if len(serviceNames) == 0 && e.opts.source == string(LogSourceLocal) {
-			cliout.Info("No services are currently running")
-			cliout.Item("Run 'azd app run' to start services")
-			return nil
+			result.DashboardAvailable = true
+			return result, nil
 		}
 
 		// Validate service filter when we have a service list
 		if valErr := e.validateServiceFilter(serviceFilter, serviceNames); valErr != nil {
-			return valErr
+			return nil, valErr
 		}
 	}
+	result.DashboardAvailable = (dashboardClient != nil)
+	result.ServiceCount = len(serviceNames)
 
 	// Parse log level filter
 	levelFilter := parseLogLevel(e.opts.level)
@@ -340,22 +476,13 @@ func (e *logsExecutor) execute(ctx context.Context, args []string) error {
 	// Build log filter from flags and azure.yaml
 	logFilter, err := e.buildLogFilterInternal(cwd)
 	if err != nil {
-		return fmt.Errorf("failed to build log filter: %w", err)
+		return nil, fmt.Errorf("failed to build log filter: %w", err)
 	}
 
-	// Parse since duration (returns error instead of silently failing)
+	// Parse since duration
 	sinceTime, err := e.parseSinceTime()
 	if err != nil {
-		return fmt.Errorf("invalid since duration: %w", err)
-	}
-
-	// Setup output writer
-	outputWriter, cleanup, err := e.setupOutputWriter()
-	if err != nil {
-		return err
-	}
-	if cleanup != nil {
-		defer cleanup()
+		return nil, fmt.Errorf("invalid since duration: %w", err)
 	}
 
 	// Determine which services to get logs for
@@ -368,29 +495,22 @@ func (e *logsExecutor) execute(ctx context.Context, args []string) error {
 	var logs []service.LogEntry
 	switch e.opts.source {
 	case "azure":
-		logs, err = e.collectAzureLogs(ctx, cwd, dashboardClient, targetServices, sinceTime)
+		logs, err = e.collectAzureLogs(ctx, cwd, dashboardClient, targetServices, sinceTime, result)
 		if err != nil {
-			return err
-		}
-		// Show helpful message if no Azure logs found
-		if len(logs) == 0 && !e.opts.follow {
-			cliout.Info("No Azure logs found")
-			cliout.Item("Azure logs may take 1-5 minutes to appear in Log Analytics")
-			cliout.Item("Use --follow (-f) to wait for new logs")
-			return nil
+			return nil, err
 		}
 	case "all":
-		logs, err = e.collectAllLogs(ctx, cwd, dashboardClient, targetServices, logManager, sinceTime)
+		logs, err = e.collectAllLogsQuiet(ctx, cwd, dashboardClient, targetServices, logManager, sinceTime, result)
 		if err != nil {
-			return fmt.Errorf("failed to collect logs: %w", err)
+			return nil, fmt.Errorf("failed to collect logs: %w", err)
 		}
 	default: // "local"
 		if dashboardClient == nil {
-			return fmt.Errorf("cannot collect local logs: dashboard not running (run 'azd app run')")
+			return nil, fmt.Errorf("cannot collect local logs: dashboard not running (run 'azd app run')")
 		}
 		logs, err = e.collectLogs(ctx, cwd, targetServices, logManager, sinceTime)
 		if err != nil {
-			return fmt.Errorf("failed to collect logs: %w", err)
+			return nil, fmt.Errorf("failed to collect logs: %w", err)
 		}
 	}
 
@@ -410,38 +530,56 @@ func (e *logsExecutor) execute(ctx context.Context, args []string) error {
 			logsWithContext = logsWithContext[len(logsWithContext)-e.opts.tail:]
 		}
 
-		// Display logs with context
-		if e.opts.format == "json" {
-			displayLogsWithContextJSON(logsWithContext, outputWriter)
-		} else {
-			displayLogsWithContextText(logsWithContext, outputWriter, e.opts.timestamps, e.opts.noColor)
+		result.EntriesWithContext = logsWithContext
+		if result.EntriesWithContext == nil {
+			result.EntriesWithContext = []LogEntryWithContext{}
 		}
+		result.HasContext = true
 	} else {
-		// Regular mode: filter by level and display
+		// Regular mode: filter by level
 		logs = filterLogsByLevel(logs, levelFilter)
 
-		// Apply final tail limit after all filtering (for multi-service view)
+		// Apply final tail limit after all filtering
 		if e.opts.tail > 0 && len(logs) > e.opts.tail {
 			logs = logs[len(logs)-e.opts.tail:]
 		}
 
-		// Display initial logs
-		if e.opts.format == "json" {
-			displayLogsJSON(logs, outputWriter)
-		} else {
-			displayLogsText(logs, outputWriter, e.opts.timestamps, e.opts.noColor)
+		result.Entries = logs
+		if result.Entries == nil {
+			result.Entries = []service.LogEntry{}
 		}
 	}
 
-	// Follow mode - subscribe to live logs
-	if e.opts.follow {
-		return e.followLogs(ctx, cwd, logManager, dashboardClient, serviceFilter, levelFilter, logFilter, outputWriter)
-	}
-
-	return nil
+	return result, nil
 }
 
-// parseServiceFilter parses service names from args and flags.
+// collectAllLogsQuiet collects logs from both local and Azure sources,
+// appending warnings to the CollectedLogs result instead of calling cliout.
+func (e *logsExecutor) collectAllLogsQuiet(ctx context.Context, cwd string, dashboardClient DashboardClient, targetServices []string, logManager LogManagerInterface, sinceTime time.Time, result *CollectedLogs) ([]service.LogEntry, error) {
+	var allLogs []service.LogEntry
+
+	// Collect local logs (requires dashboard)
+	if dashboardClient != nil {
+		localLogs, err := e.collectLogs(ctx, cwd, targetServices, logManager, sinceTime)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to collect local logs: %s", err))
+		} else {
+			allLogs = append(allLogs, localLogs...)
+		}
+	} else {
+		result.Warnings = append(result.Warnings, "Dashboard not running; local logs unavailable. Showing Azure logs only.")
+	}
+
+	// Collect Azure logs (non-fatal if not configured)
+	azureLogs, err := e.collectAzureLogs(ctx, cwd, dashboardClient, targetServices, sinceTime, result)
+	if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("Azure logs unavailable: %s", err))
+	} else {
+		allLogs = append(allLogs, azureLogs...)
+	}
+
+	return allLogs, nil
+}
 func (e *logsExecutor) parseServiceFilter(args []string) []string {
 	var serviceFilter []string
 	if len(args) > 0 {
@@ -572,7 +710,7 @@ func (e *logsExecutor) collectLogs(ctx context.Context, cwd string, targetServic
 
 // collectAzureLogs collects logs from Azure-deployed services.
 // It first tries the dashboard API (if running), then returns an error with guidance.
-func (e *logsExecutor) collectAzureLogs(ctx context.Context, cwd string, dashboardClient DashboardClient, targetServices []string, sinceTime time.Time) ([]service.LogEntry, error) {
+func (e *logsExecutor) collectAzureLogs(ctx context.Context, cwd string, dashboardClient DashboardClient, targetServices []string, sinceTime time.Time, result *CollectedLogs) ([]service.LogEntry, error) {
 	// Prefer dashboard when available and configured
 	if dashboardClient != nil {
 		status, err := dashboardClient.GetAzureStatus(ctx)
@@ -590,7 +728,9 @@ func (e *logsExecutor) collectAzureLogs(ctx context.Context, cwd string, dashboa
 				return logs, nil
 			}
 			// If dashboard path fails, fall through to standalone for resiliency
-			cliout.Warning("Dashboard Azure logs failed, falling back to standalone: %v", err)
+			if result != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("Dashboard Azure logs failed, falling back to standalone: %v", err))
+			}
 		}
 	}
 
@@ -639,35 +779,6 @@ func (e *logsExecutor) collectAzureLogsStandalone(ctx context.Context, cwd strin
 	}
 
 	return logs, nil
-}
-
-// collectAllLogs collects logs from both local and Azure sources.
-// Azure errors are logged as warnings but don't block local log retrieval.
-func (e *logsExecutor) collectAllLogs(ctx context.Context, cwd string, dashboardClient DashboardClient, targetServices []string, logManager LogManagerInterface, sinceTime time.Time) ([]service.LogEntry, error) {
-	var allLogs []service.LogEntry
-
-	// Collect local logs (requires dashboard)
-	if dashboardClient != nil {
-		localLogs, err := e.collectLogs(ctx, cwd, targetServices, logManager, sinceTime)
-		if err != nil {
-			cliout.Warning("Failed to collect local logs: %s", err)
-		} else {
-			allLogs = append(allLogs, localLogs...)
-		}
-	} else {
-		cliout.Warning("Dashboard not running; local logs unavailable. Showing Azure logs only.")
-	}
-
-	// Collect Azure logs (non-fatal if not configured)
-	azureLogs, err := e.collectAzureLogs(ctx, cwd, dashboardClient, targetServices, sinceTime)
-	if err != nil {
-		// Only warn if Azure is expected
-		cliout.Warning("Azure logs unavailable: %s", err)
-	} else {
-		allLogs = append(allLogs, azureLogs...)
-	}
-
-	return allLogs, nil
 }
 
 // extractLogsWithContext finds log entries matching the level filter and extracts
@@ -887,6 +998,10 @@ func (e *logsExecutor) followLocalLogs(ctx context.Context, projectDir string, l
 
 // followLogsViaDashboard connects to the dashboard's WebSocket to stream logs.
 func (e *logsExecutor) followLogsViaDashboard(ctx context.Context, dashboardClient DashboardClient, serviceFilter []string, levelFilter service.LogLevel, logFilter *service.LogFilter, outputWriter io.Writer) error {
+	if dashboardClient == nil {
+		return fmt.Errorf("cannot follow logs: dashboard not available (run 'azd app run' first)")
+	}
+
 	// Check if dashboard is responding
 	if err := dashboardClient.Ping(ctx); err != nil {
 		return fmt.Errorf("cannot follow logs: dashboard not responding (run 'azd app run' first)")

--- a/cli/src/cmd/app/commands/mcp_test.go
+++ b/cli/src/cmd/app/commands/mcp_test.go
@@ -1101,6 +1101,7 @@ func TestAllToolsHaveTitles(t *testing.T) {
 	}{
 		{"get_services", newGetServicesTool, "Get Running Services"},
 		{"get_service_logs", newGetServiceLogsTool, "Get Service Logs"},
+		{"get_service_errors", newGetServiceErrorsTool, "Get Service Errors"},
 		{"get_project_info", newGetProjectInfoTool, "Get Project Information"},
 		{"run_services", newRunServicesTool, "Run Development Services"},
 		{"stop_services", newStopServicesTool, "Stop Running Services"},

--- a/cli/src/cmd/app/commands/mcp_tools.go
+++ b/cli/src/cmd/app/commands/mcp_tools.go
@@ -2,12 +2,9 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 	"time"
 
@@ -82,131 +79,82 @@ func newGetServiceLogsTool() server.ServerTool {
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			args := getArgsMap(request)
 
-			// Start with --cwd if projectDir is specified
-			cmdArgs, err := extractProjectDirArg(args)
-			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("Invalid project directory: %v", err)), nil
+			opts := &logsOptions{source: "local", tail: 100, level: "all"}
+			var serviceArgs []string
+			var projectDir string
+
+			if pd, ok := getStringParam(args, "projectDir"); ok {
+				validated, valErr := validateProjectDir(pd)
+				if valErr != nil {
+					return mcp.NewToolResultError(fmt.Sprintf("Invalid project directory: %v", valErr)), nil
+				}
+				projectDir = validated
 			}
 
 			if serviceName, ok := getStringParam(args, "serviceName"); ok {
-				// Validate service name to prevent injection
 				if valErr := security.ValidateServiceName(serviceName, true); valErr != nil {
 					return mcp.NewToolResultError(valErr.Error()), nil
 				}
-				cmdArgs = append(cmdArgs, serviceName)
+				serviceArgs = append(serviceArgs, serviceName)
 			}
 
 			if tail, ok := getFloat64Param(args, "tail"); ok && tail > 0 {
-				// Cap tail at reasonable maximum
 				if tail > float64(maxLogTailLines) {
 					tail = float64(maxLogTailLines)
 				}
-				cmdArgs = append(cmdArgs, "--tail", fmt.Sprintf("%.0f", tail))
+				opts.tail = int(tail)
 			}
 
 			if level, ok := getStringParam(args, "level"); ok {
-				// Validate level parameter
 				if valErr := validateEnumParam(level, allowedLogLevels, "level"); valErr != nil {
 					return mcp.NewToolResultError(valErr.Error()), nil
 				}
-				if level != "all" {
-					cmdArgs = append(cmdArgs, "--level", level)
-				}
+				opts.level = level
 			}
 
 			if since, ok := getStringParam(args, "since"); ok {
-				// Validate since format (should be like 5m, 1h, 30s)
 				if !isValidDuration(since) {
 					return mcp.NewToolResultError("Invalid 'since' format. Use duration like '5m', '1h', '30s'"), nil
 				}
-				cmdArgs = append(cmdArgs, "--since", since)
+				opts.since = since
 			}
 
-			// Handle source parameter for local/azure/both log sources
 			if source, ok := getStringParam(args, "source"); ok {
-				// Validate source parameter
 				allowedSources := map[string]bool{"local": true, "azure": true, "both": true}
-				if err := validateEnumParam(source, allowedSources, "source"); err != nil {
-					return mcp.NewToolResultError(err.Error()), nil
+				if valErr := validateEnumParam(source, allowedSources, "source"); valErr != nil {
+					return mcp.NewToolResultError(valErr.Error()), nil
 				}
-				if source != "local" { // local is default, only add flag for other values
-					cmdArgs = append(cmdArgs, "--source", source)
+				// Map "both" to "all" (MCP uses "both", CLI uses "all")
+				if source == "both" {
+					source = "all"
 				}
+				opts.source = source
 			}
-
-			// Add format flag for JSON output
-			cmdArgs = append(cmdArgs, "--format", "json")
 
 			// Check context before starting
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Request cancelled: %v", ctxErr)), nil
 			}
 
-			// Execute logs command with context
-			cmdCtx, cancel := context.WithTimeout(ctx, defaultCommandTimeout)
-			defer cancel()
+			collectCtx, collectCancel := context.WithTimeout(ctx, defaultCommandTimeout)
+			defer collectCancel()
 
-			cmd := exec.CommandContext(cmdCtx, azdCommand, append([]string{appSubcommand, "logs"}, cmdArgs...)...)
-			output, err := cmd.CombinedOutput()
+			executor := newLogsExecutorForMCP(opts, projectDir)
+			collected, err := executor.collect(collectCtx, serviceArgs)
 			if err != nil {
-				if errors.Is(ctx.Err(), context.Canceled) {
-					return mcp.NewToolResultError("Request was cancelled"), nil
-				}
-				if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) {
+				if collectCtx.Err() == context.DeadlineExceeded {
 					return mcp.NewToolResultError(fmt.Sprintf("Command timed out after %v", defaultCommandTimeout)), nil
 				}
-				return mcp.NewToolResultError(fmt.Sprintf("Failed to get logs: %v\nOutput: %s", err, string(output))), nil
+				return mcp.NewToolResultError(fmt.Sprintf("Failed to get logs: %v", err)), nil
 			}
 
-			// Parse line-by-line JSON output with memory limits
-			// Split output into lines but limit processing to prevent memory exhaustion
-			outputStr := strings.TrimSpace(string(output))
-			if len(outputStr) == 0 {
-				// Return empty array for no logs
-				return marshalToolResult([]map[string]interface{}{})
-			}
-
-			// Apply size limit before splitting to prevent memory exhaustion
-			maxOutputSize := maxLogTailLines * 512 // Assume ~512 bytes per log line average
-			if len(outputStr) > maxOutputSize {
-				// Truncate to reasonable size
-				outputStr = outputStr[len(outputStr)-maxOutputSize:]
-				// Find the first newline to avoid partial JSON
-				if idx := strings.Index(outputStr, "\n"); idx != -1 {
-					outputStr = outputStr[idx+1:]
-				}
-			}
-
-			logEntries := []map[string]interface{}{}
-			lines := strings.Split(outputStr, "\n")
-
-			// Limit the number of lines processed
-			lineLimit := maxLogTailLines
-			if len(lines) > lineLimit {
-				lines = lines[len(lines)-lineLimit:]
-			}
-
-			for _, line := range lines {
-				if line == "" {
-					continue
-				}
-				var entry map[string]interface{}
-				if err := json.Unmarshal([]byte(line), &entry); err == nil {
-					logEntries = append(logEntries, entry)
-				} else {
-					// Log parsing error to stderr for debugging, but continue
-					// Don't expose raw log content that might have secrets
-					fmt.Fprintf(os.Stderr, "Warning: Failed to parse log line as JSON (length: %d)\n", len(line))
-				}
-			}
-
-			return marshalToolResult(logEntries)
+			return marshalToolResult(collected.Entries)
 		},
 	}
 }
 
-// newGetServiceErrorsTool creates the get_service_errors tool for debugging
-// This tool calls the CLI with --level error --context N --format json
+// newGetServiceErrorsTool creates the get_service_errors tool for debugging.
+// Uses in-process log collection with error-level filtering and context extraction.
 func newGetServiceErrorsTool() server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool(
@@ -235,109 +183,80 @@ func newGetServiceErrorsTool() server.ServerTool {
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			args := getArgsMap(request)
 
-			// Build command arguments for logs command
-			cmdArgs, err := extractProjectDirArg(args)
-			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("Invalid project directory: %v", err)), nil
+			opts := &logsOptions{
+				source:       "local",
+				tail:         500,
+				level:        "error",
+				contextLines: service.DefaultContextLines,
+				since:        "10m",
+			}
+			var serviceArgs []string
+			var projectDir string
+
+			if pd, ok := getStringParam(args, "projectDir"); ok {
+				validated, valErr := validateProjectDir(pd)
+				if valErr != nil {
+					return mcp.NewToolResultError(fmt.Sprintf("Invalid project directory: %v", valErr)), nil
+				}
+				projectDir = validated
 			}
 
 			if serviceName, ok := getStringParam(args, "serviceName"); ok {
-				if err := security.ValidateServiceName(serviceName, true); err != nil {
-					return mcp.NewToolResultError(err.Error()), nil
+				if valErr := security.ValidateServiceName(serviceName, true); valErr != nil {
+					return mcp.NewToolResultError(valErr.Error()), nil
 				}
-				cmdArgs = append(cmdArgs, serviceName)
+				serviceArgs = append(serviceArgs, serviceName)
 			}
 
-			// Default to 10 minutes if not specified
-			since := "10m"
 			if s, ok := getStringParam(args, "since"); ok {
 				if !isValidDuration(s) {
 					return mcp.NewToolResultError("Invalid 'since' format. Use duration like '5m', '1h', '30s'"), nil
 				}
-				since = s
+				opts.since = s
 			}
-			cmdArgs = append(cmdArgs, "--since", since)
 
-			// Get tail setting (default 500)
-			tail := 500.0
 			if t, ok := getFloat64Param(args, "tail"); ok && t > 0 {
-				tail = t
-				if tail > float64(maxLogTailLines) {
-					tail = float64(maxLogTailLines)
+				if t > float64(maxLogTailLines) {
+					t = float64(maxLogTailLines)
 				}
+				opts.tail = int(t)
 			}
-			cmdArgs = append(cmdArgs, "--tail", fmt.Sprintf("%.0f", tail))
 
-			// Get context lines setting (default 3)
-			contextLines := service.DefaultContextLines
 			if cl, ok := getFloat64Param(args, "contextLines"); ok {
-				contextLines = int(cl)
+				contextLines := int(cl)
 				if contextLines < 0 {
 					contextLines = 0
 				}
 				if contextLines > service.MaxContextLines {
 					contextLines = service.MaxContextLines
 				}
+				opts.contextLines = contextLines
 			}
-
-			// Use CLI's --level error and --context flags to get errors with context
-			cmdArgs = append(cmdArgs, "--level", "error")
-			cmdArgs = append(cmdArgs, "--context", fmt.Sprintf("%d", contextLines))
-			cmdArgs = append(cmdArgs, "--format", "json")
 
 			// Check context before starting
 			if err := ctx.Err(); err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Request cancelled: %v", err)), nil
 			}
 
-			// Execute logs command with --level error --context N
-			cmdCtx, cancel := context.WithTimeout(ctx, defaultCommandTimeout)
-			defer cancel()
+			collectCtx, collectCancel := context.WithTimeout(ctx, defaultCommandTimeout)
+			defer collectCancel()
 
-			cmd := exec.CommandContext(cmdCtx, azdCommand, append([]string{appSubcommand, "logs"}, cmdArgs...)...)
-			output, err := cmd.CombinedOutput()
+			executor := newLogsExecutorForMCP(opts, projectDir)
+			collected, err := executor.collect(collectCtx, serviceArgs)
 			if err != nil {
-				if errors.Is(ctx.Err(), context.Canceled) {
-					return mcp.NewToolResultError("Request was cancelled"), nil
-				}
-				if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) {
+				if collectCtx.Err() == context.DeadlineExceeded {
 					return mcp.NewToolResultError(fmt.Sprintf("Command timed out after %v", defaultCommandTimeout)), nil
 				}
-				return mcp.NewToolResultError(fmt.Sprintf("Failed to get logs: %v\nOutput: %s", err, string(output))), nil
+				return mcp.NewToolResultError(fmt.Sprintf("Failed to get errors: %v", err)), nil
 			}
 
-			// Parse JSON output from CLI (each line is a LogEntryWithContext)
-			outputStr := strings.TrimSpace(string(output))
-			if len(outputStr) == 0 {
-				return marshalToolResult(map[string]interface{}{
-					"summary": map[string]interface{}{
-						"totalErrors": 0,
-						"since":       since,
-					},
-					"errors": []interface{}{},
-				})
-			}
-
-			// Parse the error entries from CLI output
-			var errorEntries []map[string]interface{}
-			lines := strings.Split(outputStr, "\n")
-			for _, line := range lines {
-				if line == "" {
-					continue
-				}
-				var entry map[string]interface{}
-				if err := json.Unmarshal([]byte(line), &entry); err == nil {
-					errorEntries = append(errorEntries, entry)
-				}
-			}
-
-			// Build response with summary
+			entries := collected.EntriesWithContext
 			result := map[string]interface{}{
 				"summary": map[string]interface{}{
-					"totalErrors": len(errorEntries),
-					"since":       since,
+					"totalErrors": len(entries),
+					"since":       opts.since,
 				},
-				"errors": errorEntries,
+				"errors": entries,
 			}
 
 			return marshalToolResult(result)


### PR DESCRIPTION
## Problem

The `get_service_logs` and `get_service_errors` MCP tools were broken. They shelled out to `azd app logs` as a subprocess with `--format json`, but this did **not** suppress `cliout` messages (`Info`, `Warning`, `CommandHeader`) that write directly to stdout. The resulting stdout pollution corrupted the JSON output, causing MCP clients to receive parse errors instead of log data.

## Root Cause

The CLI has two separate output flags:
- `--format json` — controls the log display format (JSON vs text)
- `--output json` (global) — suppresses `cliout` stdout messages

The MCP handlers only passed `--format json`, not `--output json`. But even adding `--output json` would be a bandaid — the subprocess architecture itself is wrong for MCP tools that already run inside the `azd` process.

## Solution

Replace the subprocess approach with direct in-process calls via a new `logsExecutor.collect()` method that returns structured `CollectedLogs` data without any stdout side effects.

### Architecture

`
Before: MCP handler → exec.Command("azd app logs --format json") → parse stdout JSON
After:  MCP handler → logsExecutor.collect(ctx, args) → CollectedLogs struct
`

This mirrors how other MCP tools (`start_services`, `stop_services`, `restart_services`) already work — they call Go methods directly rather than shelling out.

### Key Changes

**New APIs:**
- `CollectedLogs` struct — holds entries, metadata, and warnings without writing to stdout
- `collect()` method — retrieves and filters logs, returns structured data
- `newLogsExecutorForMCP()` — lightweight constructor for MCP handler use
- `collectAllLogsQuiet()` — collects from all sources, threading warnings through result

**Refactored:**
- `execute()` delegates to `collect()` for data retrieval, then handles display
- Both MCP handlers replaced: ~120 lines of subprocess code → ~15 lines of in-process calls
- `collectAzureLogs()` accepts `*CollectedLogs` parameter to avoid `cliout.Warning` leak

**Safety fixes (from dual-model code review with Opus 4.6 + Codex 5.3):**
- Nil guard in `followLogsViaDashboard` prevents panic when dashboard factory fails
- Follow-mode error handling no longer silently discards factory errors
- `CollectedLogs` slices initialized to empty (not nil) for JSON `[]` instead of `null`
- Nil-guards after slice reassignment preserve the empty-not-null invariant
- MCP `collect()` calls wrapped with `context.WithTimeout(defaultCommandTimeout)`
- "No Azure logs" detection checks both `HasContext` and non-context paths
- Warnings emitted before early-return paths so they aren't silently dropped

## Testing

- All 17 relevant tests pass (logs, MCP, tool titles)
- `go build`, `go vet`, `staticcheck` all clean
- Pre-existing hook test failures (pwsh not in PATH) are unrelated