### PR TITLE
refactor(go): replace interface{} with idiomatic any alias

### DIFF
--- a/cli/src/cmd/app/commands/core_helpers.go
+++ b/cli/src/cmd/app/commands/core_helpers.go
@@ -382,7 +382,7 @@ func readFileSecure(path string) ([]byte, error) {
 }
 
 // unmarshalYaml unmarshals YAML data into a struct.
-func unmarshalYaml(data []byte, v interface{}) error {
+func unmarshalYaml(data []byte, v any) error {
 	return yaml.Unmarshal(data, v)
 }
 

--- a/cli/src/cmd/app/commands/generate.go
+++ b/cli/src/cmd/app/commands/generate.go
@@ -740,9 +740,9 @@ func mergeReqs(azureYamlPath string, detected []DetectedRequirement) (int, int, 
 	existingCount := len(azureYaml.Reqs)
 
 	// Convert detected requirements to generic map format for yamlutil
-	items := make([]map[string]interface{}, 0, len(detected))
+	items := make([]map[string]any, 0, len(detected))
 	for _, det := range detected {
-		item := map[string]interface{}{
+		item := map[string]any{
 			"name":       det.Name,
 			"minVersion": det.MinVersion,
 		}
@@ -775,7 +775,7 @@ func mergeReqs(azureYamlPath string, detected []DetectedRequirement) (int, int, 
 }
 
 // formatReqItem formats a requirement item as YAML text.
-func formatReqItem(item map[string]interface{}, arrayIndent string) string {
+func formatReqItem(item map[string]any, arrayIndent string) string {
 	var builder strings.Builder
 
 	// Array item with Name

--- a/cli/src/cmd/app/commands/health_e2e_test.go
+++ b/cli/src/cmd/app/commands/health_e2e_test.go
@@ -166,7 +166,7 @@ func TestHealthCommandE2E_FullWorkflow(t *testing.T) {
 		}
 
 		output := stdout.Bytes()
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal(output, &result); err != nil {
 			t.Fatalf("Invalid JSON output: %v\nOutput: %s", err, output)
 		}
@@ -179,7 +179,7 @@ func TestHealthCommandE2E_FullWorkflow(t *testing.T) {
 			t.Error("JSON output missing 'summary' field")
 		}
 
-		t.Logf("JSON output valid: %d services", len(result["services"].([]interface{})))
+		t.Logf("JSON output valid: %d services", len(result["services"].([]any)))
 	})
 
 	// Test 4: Table output format
@@ -455,12 +455,12 @@ func TestHealthCommandE2E_CrossPlatform(t *testing.T) {
 		}
 
 		output := stdout.Bytes()
-		var result map[string]interface{}
+		var result map[string]any
 		if err := json.Unmarshal(output, &result); err != nil {
 			t.Fatalf("Invalid JSON: %v", err)
 		}
 
-		services := result["services"].([]interface{})
+		services := result["services"].([]any)
 		if len(services) == 0 {
 			t.Error("No services detected on " + runtime.GOOS)
 		}

--- a/cli/src/cmd/app/commands/health_test.go
+++ b/cli/src/cmd/app/commands/health_test.go
@@ -151,7 +151,7 @@ func TestDisplayJSONReport(t *testing.T) {
 	}
 
 	// Verify it's valid JSON
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &result); err == nil {
 		// Only test if we captured output
 		if len(buf.Bytes()) > 0 {

--- a/cli/src/cmd/app/commands/info.go
+++ b/cli/src/cmd/app/commands/info.go
@@ -111,7 +111,7 @@ func printInfoJSON(projectDir string, services []*serviceinfo.ServiceInfo, azure
 		outputServices = append(outputServices, *svc) // Dereference pointer
 	}
 
-	return cliout.PrintJSON(map[string]interface{}{
+	return cliout.PrintJSON(map[string]any{
 		"project":  projectDir,
 		"services": outputServices,
 	})

--- a/cli/src/cmd/app/commands/logs_display_test.go
+++ b/cli/src/cmd/app/commands/logs_display_test.go
@@ -134,7 +134,7 @@ func TestDisplayLogsJSON(t *testing.T) {
 		}
 
 		for i, line := range lines {
-			var entry map[string]interface{}
+			var entry map[string]any
 			if err := json.Unmarshal([]byte(line), &entry); err != nil {
 				t.Errorf("Line %d is not valid JSON: %v", i, err)
 			}
@@ -149,7 +149,7 @@ func TestDisplayLogsJSON(t *testing.T) {
 		var buf bytes.Buffer
 		displayLogsJSON(specialLogs, &buf)
 
-		var entry map[string]interface{}
+		var entry map[string]any
 		if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
 			t.Errorf("Output is not valid JSON: %v", err)
 		}

--- a/cli/src/cmd/app/commands/logs_executor_test.go
+++ b/cli/src/cmd/app/commands/logs_executor_test.go
@@ -478,7 +478,7 @@ func TestLogsExecutor_Execute(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		var entry map[string]interface{}
+		var entry map[string]any
 		if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
 			t.Errorf("Output should be valid JSON: %v", err)
 		}

--- a/cli/src/cmd/app/commands/mcp.go
+++ b/cli/src/cmd/app/commands/mcp.go
@@ -144,12 +144,12 @@ This server complements azd's core MCP capabilities:
 }
 
 // executeAzdAppCommand executes an azd app command and returns JSON output
-func executeAzdAppCommand(ctx context.Context, command string, args []string) (map[string]interface{}, error) {
+func executeAzdAppCommand(ctx context.Context, command string, args []string) (map[string]any, error) {
 	return executeAzdAppCommandWithTimeout(ctx, command, args, defaultCommandTimeout)
 }
 
 // executeAzdAppCommandWithTimeout executes an azd app command with a custom timeout
-func executeAzdAppCommandWithTimeout(ctx context.Context, command string, args []string, timeout time.Duration) (map[string]interface{}, error) {
+func executeAzdAppCommandWithTimeout(ctx context.Context, command string, args []string, timeout time.Duration) (map[string]any, error) {
 	// Check if context is already canceled
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("command canceled before execution: %w", err)
@@ -181,7 +181,7 @@ func executeAzdAppCommandWithTimeout(ctx context.Context, command string, args [
 		return nil, fmt.Errorf("failed to execute azd app %s: %w\nOutput: %s", command, err, string(output))
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal(output, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON output: %w\nRaw output: %s", err, string(output))
 	}
@@ -215,7 +215,7 @@ func extractValidatedProjectDir(args azdext.ToolArgs) (string, error) {
 
 // marshalToolResult marshals data to JSON and returns an MCP tool result with structured content.
 // This is for tools with output schemas that need to return structured data.
-func marshalToolResult(data interface{}) (*mcp.CallToolResult, error) {
+func marshalToolResult(data any) (*mcp.CallToolResult, error) {
 	jsonBytes, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return azdext.MCPErrorResult("Failed to marshal result: %v", err), nil
@@ -397,7 +397,7 @@ func getProjectDir() string {
 
 // ServiceInfo represents the output schema for get_services tool
 type ServiceInfo struct {
-	Project  map[string]interface{} `json:"project" jsonschema:"description=Project metadata including name and directory"`
+	Project  map[string]any `json:"project" jsonschema:"description=Project metadata including name and directory"`
 	Services []ServiceDetails       `json:"services" jsonschema:"description=List of services with their status and configuration"`
 }
 
@@ -417,7 +417,7 @@ type ServiceDetails struct {
 
 // ProjectInfo represents the output schema for get_project_info tool
 type ProjectInfo struct {
-	Project  map[string]interface{}  `json:"project" jsonschema:"description=Project metadata"`
+	Project  map[string]any  `json:"project" jsonschema:"description=Project metadata"`
 	Services []ProjectServiceSummary `json:"services" jsonschema:"description=Summary of services defined in the project"`
 }
 

--- a/cli/src/cmd/app/commands/mcp_info.go
+++ b/cli/src/cmd/app/commands/mcp_info.go
@@ -25,9 +25,9 @@ import (
 // process environment is scanned for SERVICE_<NAME>_* / <NAME>_* keys and
 // secret-like values are masked via redactSecretValue. Result is JSON
 // round-tripped so MCP tool handlers continue to consume
-// map[string]interface{} the way they did when the source was subprocess
+// map[string]any the way they did when the source was subprocess
 // stdout.
-func getAppInfoForMCP(ctx context.Context, projectDir string) (map[string]interface{}, error) {
+func getAppInfoForMCP(ctx context.Context, projectDir string) (map[string]any, error) {
 	if projectDir == "" {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -51,17 +51,17 @@ func getAppInfoForMCP(ctx context.Context, projectDir string) (map[string]interf
 		outputServices = append(outputServices, *svc)
 	}
 
-	// JSON round-trip so callers see map[string]interface{} (MCP handlers
+	// JSON round-trip so callers see map[string]any (MCP handlers
 	// index into this shape); marshalling the typed struct directly would
 	// hand back a pointer the handlers aren't prepared to type-assert.
-	raw, err := json.Marshal(map[string]interface{}{
+	raw, err := json.Marshal(map[string]any{
 		"project":  projectDir,
 		"services": outputServices,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode service info: %w", err)
 	}
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(raw, &decoded); err != nil {
 		return nil, fmt.Errorf("failed to decode service info: %w", err)
 	}

--- a/cli/src/cmd/app/commands/mcp_resources.go
+++ b/cli/src/cmd/app/commands/mcp_resources.go
@@ -101,15 +101,15 @@ func newServiceConfigResource() server.ServerResource {
 			}
 
 			// Extract just the configuration parts (not runtime status)
-			configs := make(map[string]interface{})
-			if services, ok := result["services"].([]interface{}); ok {
+			configs := make(map[string]any)
+			if services, ok := result["services"].([]any); ok {
 				for _, svc := range services {
-					if svcMap, ok := svc.(map[string]interface{}); ok {
+					if svcMap, ok := svc.(map[string]any); ok {
 						svcName, _ := svcMap["name"].(string)
 						if svcName == "" {
 							continue // Skip services without names
 						}
-						config := map[string]interface{}{
+						config := map[string]any{
 							"name":      svcMap["name"],
 							"language":  svcMap["language"],
 							"framework": svcMap["framework"],

--- a/cli/src/cmd/app/commands/mcp_test.go
+++ b/cli/src/cmd/app/commands/mcp_test.go
@@ -23,7 +23,7 @@ func testBuildServer(t *testing.T) *server.MCPServer {
 }
 
 // testToolArgs creates ToolArgs from a map for use in handler tests.
-func testToolArgs(args map[string]interface{}) azdext.ToolArgs {
+func testToolArgs(args map[string]any) azdext.ToolArgs {
 	return azdext.ParseToolArgs(mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Arguments: args,
@@ -108,7 +108,7 @@ func TestGetProjectInfoToolDefinition(t *testing.T) {
 
 func TestGetServicesToolHandlerBehavior(t *testing.T) {
 	ctx := context.Background()
-	args := testToolArgs(map[string]interface{}{})
+	args := testToolArgs(map[string]any{})
 
 	result, err := handleGetServices(ctx, args)
 	if err != nil {
@@ -126,7 +126,7 @@ func TestGetServicesToolHandlerBehavior(t *testing.T) {
 
 func TestGetServiceLogsToolHandlerBehavior(t *testing.T) {
 	ctx := context.Background()
-	args := testToolArgs(map[string]interface{}{"tail": float64(10)})
+	args := testToolArgs(map[string]any{"tail": float64(10)})
 
 	result, err := handleGetServiceLogs(ctx, args)
 	if err != nil {
@@ -144,7 +144,7 @@ func TestGetServiceLogsToolHandlerBehavior(t *testing.T) {
 
 func TestGetProjectInfoToolHandlerBehavior(t *testing.T) {
 	ctx := context.Background()
-	args := testToolArgs(map[string]interface{}{})
+	args := testToolArgs(map[string]any{})
 
 	result, err := handleGetProjectInfo(ctx, args)
 	if err != nil {
@@ -285,12 +285,12 @@ func TestServiceConfigResourceDefinition(t *testing.T) {
 func TestMarshalToolResult(t *testing.T) {
 	tests := []struct {
 		name      string
-		data      interface{}
+		data      any
 		wantError bool
 	}{
 		{
 			name:      "Valid map",
-			data:      map[string]interface{}{"key": "value"},
+			data:      map[string]any{"key": "value"},
 			wantError: false,
 		},
 		{
@@ -300,7 +300,7 @@ func TestMarshalToolResult(t *testing.T) {
 		},
 		{
 			name:      "Empty map",
-			data:      map[string]interface{}{},
+			data:      map[string]any{},
 			wantError: false,
 		},
 	}
@@ -341,31 +341,31 @@ func TestExtractProjectDirArg(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		args      map[string]interface{}
+		args      map[string]any
 		wantLen   int
 		wantError bool
 	}{
 		{
 			name:      "With valid project dir",
-			args:      map[string]interface{}{"projectDir": tempDir},
+			args:      map[string]any{"projectDir": tempDir},
 			wantLen:   2, // --cwd and the path
 			wantError: false,
 		},
 		{
 			name:      "Without project dir",
-			args:      map[string]interface{}{},
+			args:      map[string]any{},
 			wantLen:   0,
 			wantError: false,
 		},
 		{
 			name:      "Empty project dir",
-			args:      map[string]interface{}{"projectDir": ""},
+			args:      map[string]any{"projectDir": ""},
 			wantLen:   0,
 			wantError: false,
 		},
 		{
 			name:      "With non-existent project dir",
-			args:      map[string]interface{}{"projectDir": "/nonexistent/path/that/does/not/exist"},
+			args:      map[string]any{"projectDir": "/nonexistent/path/that/does/not/exist"},
 			wantLen:   0,
 			wantError: true,
 		},
@@ -605,15 +605,15 @@ func TestGetServicesToolHandlerWithParams(t *testing.T) {
 
 	tests := []struct {
 		name string
-		args map[string]interface{}
+		args map[string]any
 	}{
 		{
 			name: "With project dir",
-			args: map[string]interface{}{"projectDir": "/test/project"},
+			args: map[string]any{"projectDir": "/test/project"},
 		},
 		{
 			name: "Without project dir",
-			args: map[string]interface{}{},
+			args: map[string]any{},
 		},
 	}
 
@@ -638,27 +638,27 @@ func TestGetServiceLogsToolHandlerWithParams(t *testing.T) {
 
 	tests := []struct {
 		name string
-		args map[string]interface{}
+		args map[string]any
 	}{
 		{
 			name: "With service name",
-			args: map[string]interface{}{"serviceName": "api"},
+			args: map[string]any{"serviceName": "api"},
 		},
 		{
 			name: "With tail parameter",
-			args: map[string]interface{}{"tail": float64(50)},
+			args: map[string]any{"tail": float64(50)},
 		},
 		{
 			name: "With level parameter",
-			args: map[string]interface{}{"level": "error"},
+			args: map[string]any{"level": "error"},
 		},
 		{
 			name: "With since parameter",
-			args: map[string]interface{}{"since": "5m"},
+			args: map[string]any{"since": "5m"},
 		},
 		{
 			name: "No parameters",
-			args: map[string]interface{}{},
+			args: map[string]any{},
 		},
 	}
 
@@ -679,7 +679,7 @@ func TestGetServiceLogsToolHandlerWithParams(t *testing.T) {
 
 func TestGetProjectInfoToolHandlerWithParams(t *testing.T) {
 	ctx := context.Background()
-	args := testToolArgs(map[string]interface{}{})
+	args := testToolArgs(map[string]any{})
 
 	result, err := handleGetProjectInfo(ctx, args)
 	if err != nil {
@@ -696,17 +696,17 @@ func TestRestartServiceToolHandler(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		args        map[string]interface{}
+		args        map[string]any
 		expectError bool
 	}{
 		{
 			name:        "With service name",
-			args:        map[string]interface{}{"serviceName": "api"},
+			args:        map[string]any{"serviceName": "api"},
 			expectError: false,
 		},
 		{
 			name:        "Without service name (should show guidance)",
-			args:        map[string]interface{}{},
+			args:        map[string]any{},
 			expectError: false,
 		},
 	}
@@ -866,37 +866,37 @@ func TestGetServiceLogsToolValidation(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		args           map[string]interface{}
+		args           map[string]any
 		expectErrorMsg string
 	}{
 		{
 			name:           "Invalid level parameter",
-			args:           map[string]interface{}{"level": "invalid_level"},
+			args:           map[string]any{"level": "invalid_level"},
 			expectErrorMsg: "invalid level",
 		},
 		{
 			name:           "Invalid since format - missing unit",
-			args:           map[string]interface{}{"since": "30"},
+			args:           map[string]any{"since": "30"},
 			expectErrorMsg: "Invalid 'since' format",
 		},
 		{
 			name:           "Invalid since format - invalid unit",
-			args:           map[string]interface{}{"since": "30x"},
+			args:           map[string]any{"since": "30x"},
 			expectErrorMsg: "Invalid 'since' format",
 		},
 		{
 			name:           "Invalid service name - injection attempt",
-			args:           map[string]interface{}{"serviceName": "api; rm -rf /"},
+			args:           map[string]any{"serviceName": "api; rm -rf /"},
 			expectErrorMsg: "service name",
 		},
 		{
 			name:           "Invalid project dir - non-existent",
-			args:           map[string]interface{}{"projectDir": "/nonexistent/path/xyz123"},
+			args:           map[string]any{"projectDir": "/nonexistent/path/xyz123"},
 			expectErrorMsg: "project directory",
 		},
 		{
 			name:           "Tail parameter exceeds max - should be capped",
-			args:           map[string]interface{}{"tail": float64(20000)},
+			args:           map[string]any{"tail": float64(20000)},
 			expectErrorMsg: "", // Should succeed but cap at 10000
 		},
 	}
@@ -929,37 +929,37 @@ func TestRunServicesToolValidation(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		args           map[string]interface{}
+		args           map[string]any
 		expectErrorMsg string
 	}{
 		{
 			name:           "Invalid runtime parameter",
-			args:           map[string]interface{}{"runtime": "invalid_runtime"},
+			args:           map[string]any{"runtime": "invalid_runtime"},
 			expectErrorMsg: "invalid runtime",
 		},
 		{
 			name:           "Valid runtime - azd",
-			args:           map[string]interface{}{"runtime": "azd"},
+			args:           map[string]any{"runtime": "azd"},
 			expectErrorMsg: "",
 		},
 		{
 			name:           "Valid runtime - aspire",
-			args:           map[string]interface{}{"runtime": "aspire"},
+			args:           map[string]any{"runtime": "aspire"},
 			expectErrorMsg: "",
 		},
 		{
 			name:           "Valid runtime - pnpm",
-			args:           map[string]interface{}{"runtime": "pnpm"},
+			args:           map[string]any{"runtime": "pnpm"},
 			expectErrorMsg: "",
 		},
 		{
 			name:           "Valid runtime - docker-compose",
-			args:           map[string]interface{}{"runtime": "docker-compose"},
+			args:           map[string]any{"runtime": "docker-compose"},
 			expectErrorMsg: "",
 		},
 		{
 			name:           "Invalid project dir",
-			args:           map[string]interface{}{"projectDir": "/nonexistent/path/xyz123"},
+			args:           map[string]any{"projectDir": "/nonexistent/path/xyz123"},
 			expectErrorMsg: "project directory",
 		},
 	}
@@ -994,42 +994,42 @@ func TestSetEnvironmentVariableToolValidation(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		args           map[string]interface{}
+		args           map[string]any
 		expectErrorMsg string
 	}{
 		{
 			name:           "Missing name parameter",
-			args:           map[string]interface{}{"value": "test"},
+			args:           map[string]any{"value": "test"},
 			expectErrorMsg: "required argument \"name\" not found",
 		},
 		{
 			name:           "Missing value parameter",
-			args:           map[string]interface{}{"name": "TEST_VAR"},
+			args:           map[string]any{"name": "TEST_VAR"},
 			expectErrorMsg: "required argument \"value\" not found",
 		},
 		{
 			name:           "Invalid env var name - starts with hyphen",
-			args:           map[string]interface{}{"name": "-INVALID", "value": "test"},
+			args:           map[string]any{"name": "-INVALID", "value": "test"},
 			expectErrorMsg: "Invalid environment variable name",
 		},
 		{
 			name:           "Invalid env var name - special chars",
-			args:           map[string]interface{}{"name": "VAR;DROP TABLE", "value": "test"},
+			args:           map[string]any{"name": "VAR;DROP TABLE", "value": "test"},
 			expectErrorMsg: "Invalid environment variable name",
 		},
 		{
 			name:           "Invalid service name",
-			args:           map[string]interface{}{"name": "TEST_VAR", "value": "test", "serviceName": "; rm -rf /"},
+			args:           map[string]any{"name": "TEST_VAR", "value": "test", "serviceName": "; rm -rf /"},
 			expectErrorMsg: "service name",
 		},
 		{
 			name:           "Valid parameters",
-			args:           map[string]interface{}{"name": "MY_VAR", "value": "my_value"},
+			args:           map[string]any{"name": "MY_VAR", "value": "my_value"},
 			expectErrorMsg: "",
 		},
 		{
 			name:           "Valid with service name",
-			args:           map[string]interface{}{"name": "MY_VAR", "value": "my_value", "serviceName": "api"},
+			args:           map[string]any{"name": "MY_VAR", "value": "my_value", "serviceName": "api"},
 			expectErrorMsg: "",
 		},
 	}
@@ -1063,22 +1063,22 @@ func TestGetEnvironmentVariablesToolValidation(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		args           map[string]interface{}
+		args           map[string]any
 		expectErrorMsg string
 	}{
 		{
 			name:           "Invalid service name - injection",
-			args:           map[string]interface{}{"serviceName": "api; rm -rf /"},
+			args:           map[string]any{"serviceName": "api; rm -rf /"},
 			expectErrorMsg: "service name",
 		},
 		{
 			name:           "Invalid project dir",
-			args:           map[string]interface{}{"projectDir": "/nonexistent/path/xyz123"},
+			args:           map[string]any{"projectDir": "/nonexistent/path/xyz123"},
 			expectErrorMsg: "project directory",
 		},
 		{
 			name:           "Valid service name",
-			args:           map[string]interface{}{"serviceName": "api"},
+			args:           map[string]any{"serviceName": "api"},
 			expectErrorMsg: "",
 		},
 	}
@@ -1112,22 +1112,22 @@ func TestRestartServiceToolValidation(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		args           map[string]interface{}
+		args           map[string]any
 		expectErrorMsg string
 	}{
 		{
 			name:           "Missing service name",
-			args:           map[string]interface{}{},
+			args:           map[string]any{},
 			expectErrorMsg: "required argument \"serviceName\" not found",
 		},
 		{
 			name:           "Invalid service name - injection",
-			args:           map[string]interface{}{"serviceName": "api; rm -rf /"},
+			args:           map[string]any{"serviceName": "api; rm -rf /"},
 			expectErrorMsg: "service name",
 		},
 		{
 			name:           "Valid service name",
-			args:           map[string]interface{}{"serviceName": "api"},
+			args:           map[string]any{"serviceName": "api"},
 			expectErrorMsg: "",
 		},
 	}
@@ -1158,7 +1158,7 @@ func TestRestartServiceToolValidation(t *testing.T) {
 // TestStopServicesToolHandler tests the stop_services tool handler
 func TestStopServicesToolHandler(t *testing.T) {
 	ctx := context.Background()
-	args := testToolArgs(map[string]interface{}{})
+	args := testToolArgs(map[string]any{})
 
 	result, err := handleStopServices(ctx, args)
 	if err != nil {
@@ -1185,17 +1185,17 @@ func TestCheckRequirementsToolValidation(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		args           map[string]interface{}
+		args           map[string]any
 		expectErrorMsg string
 	}{
 		{
 			name:           "Invalid project dir",
-			args:           map[string]interface{}{"projectDir": "/nonexistent/path/xyz123"},
+			args:           map[string]any{"projectDir": "/nonexistent/path/xyz123"},
 			expectErrorMsg: "project directory",
 		},
 		{
 			name:           "No parameters",
-			args:           map[string]interface{}{},
+			args:           map[string]any{},
 			expectErrorMsg: "",
 		},
 	}
@@ -1229,12 +1229,12 @@ func TestInstallDependenciesToolValidation(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		args           map[string]interface{}
+		args           map[string]any
 		expectErrorMsg string
 	}{
 		{
 			name:           "Invalid project dir",
-			args:           map[string]interface{}{"projectDir": "/nonexistent/path/xyz123"},
+			args:           map[string]any{"projectDir": "/nonexistent/path/xyz123"},
 			expectErrorMsg: "project directory",
 		},
 	}
@@ -1268,7 +1268,7 @@ func TestContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	args := testToolArgs(map[string]interface{}{})
+	args := testToolArgs(map[string]any{})
 	result, err := handleGetServiceLogs(ctx, args)
 	if err != nil {
 		t.Fatalf("Handler returned Go error: %v", err)
@@ -1457,7 +1457,7 @@ func TestRateLimitIntegration(t *testing.T) {
 		request := mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
 				Name:      "run_services",
-				Arguments: map[string]interface{}{},
+				Arguments: map[string]any{},
 			},
 		}
 		result, _ := tool.Handler(ctx, request)
@@ -1474,7 +1474,7 @@ func TestRateLimitIntegration(t *testing.T) {
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name:      "run_services",
-			Arguments: map[string]interface{}{},
+			Arguments: map[string]any{},
 		},
 	}
 	result, _ := tool.Handler(ctx, request)

--- a/cli/src/cmd/app/commands/mcp_tools.go
+++ b/cli/src/cmd/app/commands/mcp_tools.go
@@ -274,8 +274,8 @@ func handleGetServiceErrors(ctx context.Context, args azdext.ToolArgs) (*mcp.Cal
 	}
 
 	entries := collected.EntriesWithContext
-	result := map[string]interface{}{
-		"summary": map[string]interface{}{
+	result := map[string]any{
+		"summary": map[string]any{
 			"totalErrors": len(entries),
 			"since":       opts.since,
 		},
@@ -316,16 +316,16 @@ func handleGetProjectInfo(ctx context.Context, args azdext.ToolArgs) (*mcp.CallT
 	}
 
 	// Extract just project-level info
-	projectInfo := map[string]interface{}{
+	projectInfo := map[string]any{
 		"project": result["project"],
 	}
 
 	// Extract service metadata (name, language, framework, project path)
-	if services, ok := result["services"].([]interface{}); ok {
-		simplifiedServices := []map[string]interface{}{}
+	if services, ok := result["services"].([]any); ok {
+		simplifiedServices := []map[string]any{}
 		for _, svc := range services {
-			if svcMap, ok := svc.(map[string]interface{}); ok {
-				simplified := map[string]interface{}{
+			if svcMap, ok := svc.(map[string]any); ok {
+				simplified := map[string]any{
 					"name":      svcMap["name"],
 					"language":  svcMap["language"],
 					"framework": svcMap["framework"],
@@ -427,7 +427,7 @@ func handleRunServices(ctx context.Context, args azdext.ToolArgs) (*mcp.CallTool
 		_ = cmd.Wait()
 	}()
 
-	result := map[string]interface{}{
+	result := map[string]any{
 		"status":  "started",
 		"message": "Services are starting in the background. Use get_services to check their status.",
 	}
@@ -623,7 +623,7 @@ func handleInstallDependencies(ctx context.Context, args azdext.ToolArgs) (*mcp.
 		return azdext.MCPErrorResult("Failed to install dependencies: %v\nOutput: %s", err, string(output)), nil
 	}
 
-	result := map[string]interface{}{
+	result := map[string]any{
 		"status":  "completed",
 		"message": "Dependencies installed successfully",
 		"output":  string(output),
@@ -706,15 +706,15 @@ func handleGetEnvironmentVariables(ctx context.Context, args azdext.ToolArgs) (*
 		return azdext.MCPErrorResult("Failed to get environment variables: %v", err), nil
 	}
 
-	envVars := make(map[string]interface{})
-	if services, ok := result["services"].([]interface{}); ok {
+	envVars := make(map[string]any)
+	if services, ok := result["services"].([]any); ok {
 		for _, svc := range services {
-			if svcMap, ok := svc.(map[string]interface{}); ok {
+			if svcMap, ok := svc.(map[string]any); ok {
 				svcName, _ := svcMap["name"].(string)
 				if hasFilter && svcName != serviceName {
 					continue
 				}
-				if env, ok := svcMap["env"].(map[string]interface{}); ok {
+				if env, ok := svcMap["env"].(map[string]any); ok {
 					envVars[svcName] = env
 				}
 			}
@@ -799,7 +799,7 @@ After updating, restart services for changes to take effect.`,
 		name, value,
 		name, value)
 
-	result := map[string]interface{}{
+	result := map[string]any{
 		"status":   "guidance",
 		"message":  guidance,
 		"variable": name,

--- a/cli/src/cmd/app/commands/notifications_test.go
+++ b/cli/src/cmd/app/commands/notifications_test.go
@@ -363,7 +363,7 @@ func TestDatabaseIntegration(t *testing.T) {
 		Message:     "Test notification",
 		Severity:    "info",
 		Timestamp:   time.Now(),
-		Metadata:    map[string]interface{}{"key": "value"},
+		Metadata:    map[string]any{"key": "value"},
 	}
 
 	if err := db.Save(ctx, event); err != nil {

--- a/cli/src/cmd/app/commands/reqs.go
+++ b/cli/src/cmd/app/commands/reqs.go
@@ -710,7 +710,7 @@ func runClearCache() error {
 	}
 
 	if cliout.IsJSON() {
-		return cliout.PrintJSON(map[string]interface{}{
+		return cliout.PrintJSON(map[string]any{
 			"success": true,
 			"message": "Reqs cache cleared successfully",
 		})
@@ -759,7 +759,7 @@ func runReqsFix() error {
 
 	if len(failedReqs) == 0 {
 		if cliout.IsJSON() {
-			return cliout.PrintJSON(map[string]interface{}{
+			return cliout.PrintJSON(map[string]any{
 				"success": true,
 				"message": "All requirements already satisfied",
 			})
@@ -893,7 +893,7 @@ func runReqsFix() error {
 
 	// JSON output
 	if cliout.IsJSON() {
-		return cliout.PrintJSON(map[string]interface{}{
+		return cliout.PrintJSON(map[string]any{
 			"success":      fixedCount > 0,
 			"fixed":        fixedCount,
 			"total":        len(failedReqs),

--- a/cli/src/internal/azdconfig/config.go
+++ b/cli/src/internal/azdconfig/config.go
@@ -218,7 +218,7 @@ func (c *Client) GetAllServicePorts(projectHash string) (map[string]int, error) 
 		return make(map[string]int), nil
 	}
 
-	var ports map[string]interface{}
+	var ports map[string]any
 	if err := json.Unmarshal(resp.Section, &ports); err != nil {
 		return nil, fmt.Errorf("failed to parse service ports: %w", err)
 	}
@@ -309,7 +309,7 @@ func (c *Client) ClearPreference(key string) error {
 // This allows unit tests to run without requiring a gRPC connection to azd.
 type InMemoryClient struct {
 	mu   sync.RWMutex
-	data map[string]interface{}
+	data map[string]any
 }
 
 // Ensure InMemoryClient implements ConfigClient
@@ -318,7 +318,7 @@ var _ ConfigClient = (*InMemoryClient)(nil)
 // NewInMemoryClient creates a new in-memory configuration client for testing.
 func NewInMemoryClient() *InMemoryClient {
 	return &InMemoryClient{
-		data: make(map[string]interface{}),
+		data: make(map[string]any),
 	}
 }
 

--- a/cli/src/internal/azure/diagnostics_test.go
+++ b/cli/src/internal/azure/diagnostics_test.go
@@ -30,7 +30,7 @@ func (m *simpleMockCredential) GetToken(ctx context.Context, options policy.Toke
 func TestDiagnosticSettingsChecker_CheckDiagnosticSettings(t *testing.T) {
 	tests := []struct {
 		name                string
-		mockResponse        interface{}
+		mockResponse        any
 		mockStatusCode      int
 		expectedStatus      DiagnosticSettingsStatus
 		expectedWorkspace   string

--- a/cli/src/internal/dashboard/azure_setup.go
+++ b/cli/src/internal/dashboard/azure_setup.go
@@ -561,7 +561,7 @@ func getPrincipalFromCredentials(ctx context.Context, cred azcore.TokenCredentia
 	}
 
 	// Parse JSON payload
-	var claims map[string]interface{}
+	var claims map[string]any
 	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
 		return ""
 	}

--- a/cli/src/internal/detector/detector_node.go
+++ b/cli/src/internal/detector/detector_node.go
@@ -241,7 +241,7 @@ func HasNpmWorkspaces(dir string) bool {
 	}
 
 	var pkg struct {
-		Workspaces interface{} `json:"workspaces"`
+		Workspaces any `json:"workspaces"`
 	}
 
 	if err := json.Unmarshal(data, &pkg); err != nil {
@@ -255,10 +255,10 @@ func HasNpmWorkspaces(dir string) bool {
 
 	// workspaces can be either an array or an object with packages field
 	switch v := pkg.Workspaces.(type) {
-	case []interface{}:
+	case []any:
 		return len(v) > 0
-	case map[string]interface{}:
-		if packages, ok := v["packages"].([]interface{}); ok {
+	case map[string]any:
+		if packages, ok := v["packages"].([]any); ok {
 			return len(packages) > 0
 		}
 		return false

--- a/cli/src/internal/healthcheck/checker.go
+++ b/cli/src/internal/healthcheck/checker.go
@@ -205,7 +205,7 @@ func (c *HealthChecker) CheckService(ctx context.Context, svc serviceInfo) Healt
 				}
 			}()
 
-			output, err := breaker.Execute(func() (interface{}, error) {
+			output, err := breaker.Execute(func() (any, error) {
 				res := c.performServiceCheck(ctx, svc)
 				if res.Status == HealthStatusUnhealthy {
 					return res, fmt.Errorf("health check failed: %s", res.Error)
@@ -328,7 +328,7 @@ func (c *HealthChecker) performServiceCheck(ctx context.Context, svc serviceInfo
 	if svc.Port > 0 {
 		result.CheckType = HealthCheckTypeTCP
 		result.Port = svc.Port
-		result.Details = make(map[string]interface{})
+		result.Details = make(map[string]any)
 
 		// Create a context with timeout for port check
 		portCtx, cancel := context.WithTimeout(ctx, defaultPortCheckTimeout)
@@ -359,7 +359,7 @@ func (c *HealthChecker) performServiceCheck(ctx context.Context, svc serviceInfo
 	if svc.PID > 0 {
 		result.CheckType = HealthCheckTypeProcess
 		result.PID = svc.PID
-		result.Details = make(map[string]interface{})
+		result.Details = make(map[string]any)
 
 		isRunning := isProcessRunning(svc.PID)
 		if isRunning {
@@ -484,7 +484,7 @@ func (c *HealthChecker) performHTTPCheck(ctx context.Context, urlStr string) *ht
 		Endpoint:     urlStr,
 		ResponseTime: responseTime,
 		StatusCode:   resp.StatusCode,
-		Details:      make(map[string]interface{}),
+		Details:      make(map[string]any),
 	}
 
 	// Determine status based on HTTP status code
@@ -743,7 +743,7 @@ func (c *HealthChecker) checkSingleEndpoint(ctx context.Context, port int, endpo
 		ResponseTime: responseTime,
 		StatusCode:   resp.StatusCode,
 		Status:       c.statusFromHTTPCode(resp.StatusCode),
-		Details:      make(map[string]interface{}),
+		Details:      make(map[string]any),
 	}
 
 	// Add suggestion for error responses
@@ -781,7 +781,7 @@ func (c *HealthChecker) statusFromHTTPCode(statusCode int) HealthStatus {
 
 // parseHealthResponseBody parses JSON response body for health details.
 func (c *HealthChecker) parseHealthResponseBody(body []byte, result *httpHealthCheckResult) {
-	var details map[string]interface{}
+	var details map[string]any
 	if err := json.Unmarshal(body, &details); err == nil {
 		result.Details = details
 
@@ -826,7 +826,7 @@ func (c *HealthChecker) performProcessHealthCheck(_ context.Context, svc service
 	if svc.PID > 0 {
 		result.PID = svc.PID
 		if result.Details == nil {
-			result.Details = make(map[string]interface{})
+			result.Details = make(map[string]any)
 		}
 
 		isRunning := isProcessRunning(svc.PID)
@@ -868,9 +868,9 @@ func (c *HealthChecker) performBuildTaskHealthCheck(svc serviceInfo, isInStartup
 			result.Status = HealthStatusHealthy
 		}
 		if svc.Mode == ServiceModeBuild {
-			result.Details = map[string]interface{}{"state": "building"}
+			result.Details = map[string]any{"state": "building"}
 		} else {
-			result.Details = map[string]interface{}{"state": "running"}
+			result.Details = map[string]any{"state": "running"}
 		}
 		return result
 	}
@@ -879,14 +879,14 @@ func (c *HealthChecker) performBuildTaskHealthCheck(svc serviceInfo, isInStartup
 		if *svc.ExitCode == 0 {
 			result.Status = HealthStatusHealthy
 			if svc.Mode == ServiceModeBuild {
-				result.Details = map[string]interface{}{"state": "built", "exitCode": 0}
+				result.Details = map[string]any{"state": "built", "exitCode": 0}
 			} else {
-				result.Details = map[string]interface{}{"state": statusCompleted, "exitCode": 0}
+				result.Details = map[string]any{"state": statusCompleted, "exitCode": 0}
 			}
 		} else {
 			result.Status = HealthStatusUnhealthy
 			result.Error = fmt.Sprintf("process exited with code %d", *svc.ExitCode)
-			result.Details = map[string]interface{}{"state": "failed", "exitCode": *svc.ExitCode}
+			result.Details = map[string]any{"state": "failed", "exitCode": *svc.ExitCode}
 		}
 		return result
 	}
@@ -894,9 +894,9 @@ func (c *HealthChecker) performBuildTaskHealthCheck(svc serviceInfo, isInStartup
 	if svc.PID > 0 {
 		result.Status = HealthStatusHealthy
 		if svc.Mode == ServiceModeBuild {
-			result.Details = map[string]interface{}{"state": "built", "note": "exit code not captured"}
+			result.Details = map[string]any{"state": "built", "note": "exit code not captured"}
 		} else {
-			result.Details = map[string]interface{}{"state": statusCompleted, "note": "exit code not captured"}
+			result.Details = map[string]any{"state": statusCompleted, "note": "exit code not captured"}
 		}
 		return result
 	}
@@ -915,7 +915,7 @@ func (c *HealthChecker) performBuildTaskHealthCheck(svc serviceInfo, isInStartup
 func (c *HealthChecker) performOutputHealthCheck(svc serviceInfo, isInStartupGracePeriod bool, result HealthCheckResult) HealthCheckResult {
 	pattern := svc.HealthCheck.Pattern
 	result.PID = svc.PID
-	result.Details = map[string]interface{}{
+	result.Details = map[string]any{
 		"checkType": "output",
 		"pattern":   pattern,
 	}
@@ -1056,7 +1056,7 @@ func parseErrorDetailsFromBody(body []byte) string {
 	}
 
 	// Try to parse as JSON
-	var jsonData map[string]interface{}
+	var jsonData map[string]any
 	if err := json.Unmarshal(body, &jsonData); err == nil {
 		// Look for common error fields
 		for _, key := range []string{statusError, "message", "detail", "details", "error_description"} {

--- a/cli/src/internal/healthcheck/checker_test.go
+++ b/cli/src/internal/healthcheck/checker_test.go
@@ -458,7 +458,7 @@ func TestBuildResultFromHTTPCheck(t *testing.T) {
 		ResponseTime: 50 * time.Millisecond,
 		StatusCode:   200,
 		Status:       HealthStatusHealthy,
-		Details:      map[string]interface{}{"version": "1.0"},
+		Details:      map[string]any{"version": "1.0"},
 		Error:        "",
 	}
 

--- a/cli/src/internal/healthcheck/monitor.go
+++ b/cli/src/internal/healthcheck/monitor.go
@@ -383,7 +383,7 @@ func parseHealthCheckConfig(svc service.Service) *healthCheckConfig {
 	switch t := svc.Healthcheck.Test.(type) {
 	case string:
 		config.Test = []string{t}
-	case []interface{}:
+	case []any:
 		for _, item := range t {
 			if s, ok := item.(string); ok {
 				config.Test = append(config.Test, s)

--- a/cli/src/internal/healthcheck/monitor_test.go
+++ b/cli/src/internal/healthcheck/monitor_test.go
@@ -331,7 +331,7 @@ func TestParseHealthCheckConfig(t *testing.T) {
 		{
 			name: "CMD array test",
 			healthcheck: &service.HealthcheckConfig{
-				Test: []interface{}{"CMD", "curl", "-f", "http://localhost/health"},
+				Test: []any{"CMD", "curl", "-f", "http://localhost/health"},
 			},
 			expectedTest:    []string{"CMD", "curl", "-f", "http://localhost/health"},
 			expectedRetries: 3, // default
@@ -339,7 +339,7 @@ func TestParseHealthCheckConfig(t *testing.T) {
 		{
 			name: "CMD-SHELL test",
 			healthcheck: &service.HealthcheckConfig{
-				Test: []interface{}{"CMD-SHELL", "curl -f http://localhost/health || exit 1"},
+				Test: []any{"CMD-SHELL", "curl -f http://localhost/health || exit 1"},
 			},
 			expectedTest:    []string{"CMD-SHELL", "curl -f http://localhost/health || exit 1"},
 			expectedRetries: 3, // default

--- a/cli/src/internal/healthcheck/types.go
+++ b/cli/src/internal/healthcheck/types.go
@@ -97,7 +97,7 @@ type httpHealthCheckResult struct {
 	ResponseTime time.Duration
 	StatusCode   int
 	Status       HealthStatus
-	Details      map[string]interface{}
+	Details      map[string]any
 	Error        string
 }
 

--- a/cli/src/internal/installer/installer.go
+++ b/cli/src/internal/installer/installer.go
@@ -861,7 +861,7 @@ func packageJSONHasWorkspacePackages(dir string) bool {
 		return false
 	}
 
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		return false
 	}
@@ -870,15 +870,15 @@ func packageJSONHasWorkspacePackages(dir string) bool {
 	var patterns []string
 	if ws, ok := parsed["workspaces"]; ok {
 		switch v := ws.(type) {
-		case []interface{}:
+		case []any:
 			for _, it := range v {
 				if s, ok := it.(string); ok {
 					patterns = append(patterns, s)
 				}
 			}
-		case map[string]interface{}:
+		case map[string]any:
 			if pkgs, ok := v["packages"]; ok {
-				if arr, ok := pkgs.([]interface{}); ok {
+				if arr, ok := pkgs.([]any); ok {
 					for _, it := range arr {
 						if s, ok := it.(string); ok {
 							patterns = append(patterns, s)

--- a/cli/src/internal/installer/parallel.go
+++ b/cli/src/internal/installer/parallel.go
@@ -21,7 +21,7 @@ type ProjectInstallTask struct {
 	Dir         string
 	Path        string
 	Manager     string
-	Project     interface{} // Store the actual project for installation
+	Project     any // Store the actual project for installation
 }
 
 // ParallelInstaller handles parallel installation of multiple projects with progress tracking.

--- a/cli/src/internal/notifications/database.go
+++ b/cli/src/internal/notifications/database.go
@@ -36,7 +36,7 @@ type NotificationRecord struct {
 	Timestamp    time.Time              `json:"timestamp"`
 	Read         bool                   `json:"read"`
 	Acknowledged bool                   `json:"acknowledged"`
-	Metadata     map[string]interface{} `json:"metadata,omitempty"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
 }
 
 // NewDatabase creates a new notification database

--- a/cli/src/internal/notifications/database_test.go
+++ b/cli/src/internal/notifications/database_test.go
@@ -27,7 +27,7 @@ func TestDatabase(t *testing.T) {
 			Message:     "Service started",
 			Severity:    "info",
 			Timestamp:   time.Now(),
-			Metadata:    map[string]interface{}{"port": 8080},
+			Metadata:    map[string]any{"port": 8080},
 		}
 
 		err := db.Save(ctx, event)

--- a/cli/src/internal/notifications/integration.go
+++ b/cli/src/internal/notifications/integration.go
@@ -170,7 +170,7 @@ func (nm *NotificationManager) handleStateTransition(transition monitor.StateTra
 		Message:     transition.Description,
 		Severity:    severity,
 		Timestamp:   transition.Timestamp,
-		Metadata:    make(map[string]interface{}),
+		Metadata:    make(map[string]any),
 	}
 
 	// Add metadata

--- a/cli/src/internal/notifications/pipeline.go
+++ b/cli/src/internal/notifications/pipeline.go
@@ -35,7 +35,7 @@ type Event struct {
 	Message     string
 	Severity    string // "critical", "warning", "info"
 	Timestamp   time.Time
-	Metadata    map[string]interface{}
+	Metadata    map[string]any
 }
 
 // Handler processes notification events

--- a/cli/src/internal/rpc/health.go
+++ b/cli/src/internal/rpc/health.go
@@ -463,14 +463,14 @@ func toProtoResults(results []healthcheck.HealthCheckResult) []*v1.HealthCheckRe
 }
 
 // detailsToStringMap flattens healthcheck.HealthCheckResult.Details
-// (map[string]interface{}) into the proto's map<string,string>. Strings
+// (map[string]any) into the proto's map<string,string>. Strings
 // pass through; other primitives stringify via strconv; complex values
 // JSON-marshal (so a nested map shows up as the JSON literal). This is
 // lossy by design: the Details map exists for human-readable diagnostics,
 // not structured consumption, and proto's map<string,string> matches that
 // intent. Switching to google.protobuf.Struct here would force every
 // dashboard consumer through a Value-tree decoder for negligible benefit.
-func detailsToStringMap(in map[string]interface{}) map[string]string {
+func detailsToStringMap(in map[string]any) map[string]string {
 	if len(in) == 0 {
 		return nil
 	}
@@ -481,7 +481,7 @@ func detailsToStringMap(in map[string]interface{}) map[string]string {
 	return out
 }
 
-func stringifyDetailValue(v interface{}) string {
+func stringifyDetailValue(v any) string {
 	switch x := v.(type) {
 	case nil:
 		return ""

--- a/cli/src/internal/rpc/health_test.go
+++ b/cli/src/internal/rpc/health_test.go
@@ -172,7 +172,7 @@ func TestGetHealthReturnsResults(t *testing.T) {
 					Status:       healthcheck.HealthStatusHealthy,
 					ResponseTime: 12 * time.Millisecond,
 					Timestamp:    now,
-					Details:      map[string]interface{}{"statusCode": 200, "endpoint": "/health"},
+					Details:      map[string]any{"statusCode": 200, "endpoint": "/health"},
 				},
 				{
 					ServiceName:  "worker",

--- a/cli/src/internal/service/healthcheck_config_test.go
+++ b/cli/src/internal/service/healthcheck_config_test.go
@@ -35,7 +35,7 @@ func TestHealthcheckConfig_IsDisabled(t *testing.T) {
 		},
 		{
 			name:     "test NONE array",
-			config:   &HealthcheckConfig{Test: []interface{}{"NONE"}},
+			config:   &HealthcheckConfig{Test: []any{"NONE"}},
 			expected: true,
 		},
 		{

--- a/cli/src/internal/service/types.go
+++ b/cli/src/internal/service/types.go
@@ -131,7 +131,7 @@ type serviceRaw struct {
 }
 
 // UnmarshalYAML implements custom YAML unmarshaling to handle healthcheck: false.
-func (s *Service) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Service) UnmarshalYAML(unmarshal func(any) error) error {
 	var raw serviceRaw
 	if err := unmarshal(&raw); err != nil {
 		return err
@@ -439,7 +439,7 @@ type EnvVar struct {
 type Environment map[string]string
 
 // UnmarshalYAML implements custom YAML unmarshaling for Docker Compose compatibility.
-func (e *Environment) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (e *Environment) UnmarshalYAML(unmarshal func(any) error) error {
 	if *e == nil {
 		*e = make(Environment)
 	}

--- a/cli/src/internal/serviceinfo/environment_test.go
+++ b/cli/src/internal/serviceinfo/environment_test.go
@@ -295,17 +295,17 @@ func TestRefreshEnvironmentFromEvent(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		bicepOutputs  map[string]interface{}
+		bicepOutputs  map[string]any
 		wantCacheKeys map[string]string
 	}{
 		{
 			name: "bicep outputs with value field",
-			bicepOutputs: map[string]interface{}{
-				"apiUrl": map[string]interface{}{
+			bicepOutputs: map[string]any{
+				"apiUrl": map[string]any{
 					"value": "https://api.azure.com",
 					"type":  "string",
 				},
-				"webUrl": map[string]interface{}{
+				"webUrl": map[string]any{
 					"value": "https://web.azure.com",
 				},
 			},
@@ -316,14 +316,14 @@ func TestRefreshEnvironmentFromEvent(t *testing.T) {
 		},
 		{
 			name: "mixed output types - only strings extracted",
-			bicepOutputs: map[string]interface{}{
-				"apiUrl": map[string]interface{}{
+			bicepOutputs: map[string]any{
+				"apiUrl": map[string]any{
 					"value": "https://api.azure.com",
 				},
-				"port": map[string]interface{}{
+				"port": map[string]any{
 					"value": 8080, // Not a string, should be ignored
 				},
-				"enabled": map[string]interface{}{
+				"enabled": map[string]any{
 					"value": true, // Not a string, should be ignored
 				},
 			},
@@ -333,9 +333,9 @@ func TestRefreshEnvironmentFromEvent(t *testing.T) {
 		},
 		{
 			name: "outputs without value field ignored",
-			bicepOutputs: map[string]interface{}{
+			bicepOutputs: map[string]any{
 				"apiUrl": "just-a-string", // Not a map, should be ignored
-				"config": map[string]interface{}{
+				"config": map[string]any{
 					"setting": "value", // No "value" key
 				},
 			},

--- a/cli/src/internal/serviceinfo/serviceinfo.go
+++ b/cli/src/internal/serviceinfo/serviceinfo.go
@@ -48,14 +48,14 @@ func RefreshEnvironmentCache() {
 
 // RefreshEnvironmentFromEvent updates the cached environment variables from a provision event.
 // This is called by the listen command when azd fires an "environment updated" event.
-func RefreshEnvironmentFromEvent(bicepOutputs map[string]interface{}) {
+func RefreshEnvironmentFromEvent(bicepOutputs map[string]any) {
 	environmentCacheMu.Lock()
 	defer environmentCacheMu.Unlock()
 
 	// Extract environment variables from bicep outputs
 	// Bicep outputs are typically in the format: { "outputName": { "value": "actualValue" } }
 	for key, val := range bicepOutputs {
-		if outputMap, ok := val.(map[string]interface{}); ok {
+		if outputMap, ok := val.(map[string]any); ok {
 			if value, ok := outputMap["value"].(string); ok {
 				environmentCache[strings.ToUpper(key)] = value
 			}

--- a/cli/src/internal/testing/orchestrator.go
+++ b/cli/src/internal/testing/orchestrator.go
@@ -151,7 +151,7 @@ func (o *TestOrchestrator) LoadServicesFromAzureYaml(azureYamlPath string) error
 			Language string                 `yaml:"language"`
 			Project  string                 `yaml:"project"`
 			Test     *ServiceTestConfig     `yaml:"test"`
-			Config   map[string]interface{} `yaml:",inline"`
+			Config   map[string]any `yaml:",inline"`
 		} `yaml:"services"`
 	}
 


### PR DESCRIPTION
## Summary

Replace all occurrences of **interface{}** with the idiomatic **any** alias across the codebase. The **any** type alias was introduced in Go 1.18 and is the preferred spelling in modern Go code. This project targets Go 1.26.3.

This is a purely mechanical, zero-semantic-impact change — **any** is defined as **type any = interface{}** in the Go builtin package.

## Changes

36 files updated across these packages:

| Package | Files Changed |
|---|---|
| cmd/app/commands | core_helpers.go, generate.go, info.go, mcp.go, mcp_info.go, mcp_resources.go, mcp_tools.go, reqs.go, and test files |
| internal/healthcheck | checker.go, monitor.go, types.go, and test files |
| internal/notifications | database.go, integration.go, pipeline.go |
| internal/installer | installer.go, parallel.go |
| internal/azdconfig | config.go |
| internal/detector | detector_node.go |
| internal/dashboard | azure_setup.go |
| internal/rpc | health.go |
| internal/service | types.go |
| internal/serviceinfo | serviceinfo.go |
| internal/testing | orchestrator.go |

## Not Changed

- **cli/src/gen/** — auto-generated protobuf files managed by **buf**; will adopt **any** on next code generation

## Validation

- **go build ./...** passes
- **go test ./src/...** passes
- **golangci-lint run ./...** reports 0 issues

Closes #200
