### PR TITLE
ci: workflow and pipeline improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci"
+  - package-ecosystem: "npm"
+    directory: "/cli/dashboard"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'cli/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [ main ]
     paths:
@@ -53,19 +58,19 @@ jobs:
           version: 9
 
       - name: Install Mage
-        run: go install github.com/magefile/mage@latest
+        run: go install github.com/magefile/mage@v1.15.0
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Install Azure Developer CLI (azd)
         run: curl -fsSL https://aka.ms/install-azd.sh | bash
@@ -75,9 +80,41 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  dashboard:
+    name: Build Dashboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@5b4374b04084dc1f9032b52464284b769ac5059e # v4
+        with:
+          version: 9
+
+      - name: Build dashboard
+        working-directory: cli/dashboard
+        run: |
+          pnpm install
+          pnpm run build
+
+      - name: Upload dashboard dist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dashboard-dist
+          path: cli/dashboard/dist/
+          retention-days: 1
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    needs: [dashboard]
     timeout-minutes: 30
     strategy:
       matrix:
@@ -94,22 +131,11 @@ jobs:
           cache: true
           cache-dependency-path: cli/go.sum
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Download dashboard dist
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          node-version: '22'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@5b4374b04084dc1f9032b52464284b769ac5059e # v4
-        with:
-          version: 9
-
-      - name: Build dashboard
-        run: |
-          cd dashboard
-          pnpm install
-          pnpm run build
-          cd ..
+          name: dashboard-dist
+          path: cli/dashboard/dist/
 
       - name: Install Aspire CLI
         shell: pwsh
@@ -138,12 +164,9 @@ jobs:
           mkdir -p ../coverage
           # Exclude tests/test-tool (it's a standalone main package with no tests)
           PACKAGES=$(go list ./... | grep -v '/tests/test-tool')
-          # Race detector not supported on macOS without additional setup
-          if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            go test -short -v -coverprofile=../coverage/coverage.out $PACKAGES
-          else
-            go test -short -v -race -coverprofile=../coverage/coverage.out $PACKAGES
-          fi
+          go test -short -v -race -coverprofile=../coverage/coverage.out $PACKAGES
+        env:
+          CGO_ENABLED: '1'
 
       - name: Upload coverage to Codecov
         if: github.repository == 'jongio/azd-app'
@@ -172,6 +195,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: [dashboard]
     timeout-minutes: 30
     
     steps:
@@ -185,25 +209,14 @@ jobs:
           cache: true
           cache-dependency-path: cli/go.sum
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Download dashboard dist
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          node-version: '22'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@5b4374b04084dc1f9032b52464284b769ac5059e # v4
-        with:
-          version: 9
-
-      - name: Build dashboard assets
-        run: |
-          cd dashboard
-          pnpm install
-          pnpm run build
-          cd ..
+          name: dashboard-dist
+          path: cli/dashboard/dist/
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 
       - name: Run golangci-lint
         run: golangci-lint run --timeout=5m
@@ -211,7 +224,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [preflight, test, lint]
+    needs: [preflight, test, lint, dashboard]
     timeout-minutes: 30
     
     defaults:
@@ -229,22 +242,11 @@ jobs:
           cache: true
           cache-dependency-path: cli/go.sum
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Download dashboard dist
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          node-version: '22'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@5b4374b04084dc1f9032b52464284b769ac5059e # v4
-        with:
-          version: 9
-
-      - name: Build dashboard
-        run: |
-          cd dashboard
-          pnpm install
-          pnpm run build
-          cd ..
+          name: dashboard-dist
+          path: cli/dashboard/dist/
 
       - name: Build for multiple platforms
         run: |
@@ -262,7 +264,7 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ${{ matrix.os }}
-    needs: [preflight, test]
+    needs: [preflight, test, dashboard]
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -279,6 +281,12 @@ jobs:
           go-version: '${{ env.GO_VERSION }}'
           cache: true
           cache-dependency-path: cli/go.sum
+
+      - name: Download dashboard dist
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: dashboard-dist
+          path: cli/dashboard/dist/
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -335,13 +343,6 @@ jobs:
             cd ..
           done
         shell: bash
-
-      - name: Build dashboard assets
-        run: |
-          cd dashboard
-          pnpm install
-          pnpm run build
-          cd ..
 
       - name: Run port manager integration tests
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,19 +62,19 @@ jobs:
           version: 9
 
       - name: Install Mage
-        run: go install github.com/magefile/mage@latest
+        run: go install github.com/magefile/mage@v1.15.0
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Install azd
         run: curl -fsSL https://aka.ms/install-azd.sh | bash
@@ -153,12 +153,9 @@ jobs:
           mkdir -p ../coverage
           # Exclude tests/test-tool (it's a standalone main package with no tests)
           PACKAGES=$(go list ./... | grep -v '/tests/test-tool')
-          # Race detector not supported on macOS without additional setup
-          if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            go test -short -v -coverprofile=../coverage/coverage.out $PACKAGES
-          else
-            go test -short -v -race -coverprofile=../coverage/coverage.out $PACKAGES
-          fi
+          go test -short -v -race -coverprofile=../coverage/coverage.out $PACKAGES
+        env:
+          CGO_ENABLED: '1'
 
       - name: Upload coverage to Codecov
         if: github.repository == 'jongio/azd-app'
@@ -170,30 +167,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
-
-      - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: '${{ env.GO_VERSION }}'
-          cache: true
-          cache-dependency-path: cli/go.sum
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '22'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@5b4374b04084dc1f9032b52464284b769ac5059e # v4
-        with:
-          version: 9
-
-      - name: Build dashboard
-        run: |
-          cd dashboard
-          pnpm install
-          pnpm run build
-          cd ..
 
       - name: Build for multiple platforms
         if: matrix.os == 'ubuntu-latest'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,22 +93,11 @@ linters:
       - path: _test\.go
         linters:
           - dupl
-          - errcheck
           - goconst
           - unparam
-          - forcetypeassert
+          - prealloc
           - noctx
           - exhaustive
-          - prealloc
-          - gosec
-          - revive
-          - misspell
-          - bodyclose
-          - nilerr
-          - gocritic
-          - nolintlint
-          - wastedassign
-          - staticcheck
       - path: magefile\.go
         linters:
           - unparam


### PR DESCRIPTION
This PR addresses 7 CI/workflow issues:

- **Add push trigger for main branch** - CI now runs on pushes to main, not just PRs
- **Remove duplicate setup/build in release test job** - Eliminated redundant Go/Node/pnpm setup and dashboard rebuild after tests
- **Narrow linter exclusions** - Removed overly broad exclusions (errcheck, gosec, staticcheck, etc.) from test files, keeping only truly irrelevant ones (dupl, goconst, unparam, prealloc, noctx, exhaustive)
- **Enable race detector on macOS** - Removed the macOS conditional skip; race detection now runs on all platforms with CGO_ENABLED=1
- **Pin tool versions** - golangci-lint v2.1.6, staticcheck v0.6.1, gosec v2.22.4, govulncheck v1.1.4, mage v1.15.0
- **Add npm ecosystem to Dependabot** - Added entries for cli/dashboard and web directories
- **Consolidate dashboard builds** - Dashboard is now built once in a dedicated job and shared via artifacts to test/lint/build/integration jobs

Fixes #225
Fixes #224
Fixes #221
Fixes #220
Fixes #218
Fixes #217
Fixes #209