### PR TITLE
perf: circular buffer, parallel RPC, and observer cleanup

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/sony/gobreaker v1.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	golang.org/x/time v0.15.0
 	google.golang.org/protobuf v1.36.11

--- a/cli/src/internal/dashboard/client.go
+++ b/cli/src/internal/dashboard/client.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jongio/azd-app/cli/src/internal/constants"
 	"github.com/jongio/azd-app/cli/src/internal/service"
 	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
+	"golang.org/x/sync/errgroup"
 )
 
 // Client speaks Connect over HTTP to a running dashboard process.
@@ -168,7 +169,7 @@ func (c *Client) StreamLogs(ctx context.Context, serviceName string, logs chan<-
 
 // GetAzureLogs fetches buffered Azure logs for the given services. The proto
 // request tails one service at a time; multi-service callers are served by
-// issuing one RPC per service and merging results. Client-side `since`
+// issuing concurrent RPCs per service and merging results. Client-side `since`
 // filtering matches the legacy REST behavior (since_seconds is not a
 // 1:1 replacement because the server clamps it differently).
 func (c *Client) GetAzureLogs(ctx context.Context, services []string, tail int, since time.Time) ([]service.LogEntry, error) {
@@ -182,30 +183,74 @@ func (c *Client) GetAzureLogs(ctx context.Context, services []string, tail int, 
 		serviceList = []string{""}
 	}
 
-	var all []service.LogEntry
-	for _, svc := range serviceList {
+	// Fast path: single service needs no goroutine overhead
+	if len(serviceList) == 1 {
 		resp, err := c.azure.GetAzureLogs(ctx, connect.NewRequest(&v1.GetAzureLogsRequest{
-			Service: svc,
+			Service: serviceList[0],
 			Tail:    int32(tail),
 		}))
 		if err != nil {
 			return nil, err
 		}
+		all := make([]service.LogEntry, 0, len(resp.Msg.GetEntries()))
 		for _, p := range resp.Msg.GetEntries() {
 			all = append(all, protoToLogEntry(p))
 		}
+		return filterSince(all, since), nil
 	}
 
-	if !since.IsZero() {
-		filtered := all[:0]
-		for _, entry := range all {
-			if !entry.Timestamp.Before(since) {
-				filtered = append(filtered, entry)
-			}
-		}
-		all = filtered
+	// Parallel path: launch one goroutine per service
+	type result struct {
+		entries []service.LogEntry
+		err     error
 	}
-	return all, nil
+	results := make([]result, len(serviceList))
+
+	g, gctx := errgroup.WithContext(ctx)
+	for i, svc := range serviceList {
+		i, svc := i, svc
+		g.Go(func() error {
+			resp, err := c.azure.GetAzureLogs(gctx, connect.NewRequest(&v1.GetAzureLogsRequest{
+				Service: svc,
+				Tail:    int32(tail),
+			}))
+			if err != nil {
+				results[i] = result{err: err}
+				return err
+			}
+			entries := make([]service.LogEntry, 0, len(resp.Msg.GetEntries()))
+			for _, p := range resp.Msg.GetEntries() {
+				entries = append(entries, protoToLogEntry(p))
+			}
+			results[i] = result{entries: entries}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	var all []service.LogEntry
+	for _, r := range results {
+		all = append(all, r.entries...)
+	}
+
+	return filterSince(all, since), nil
+}
+
+// filterSince returns entries at or after since. Returns all if since is zero.
+func filterSince(all []service.LogEntry, since time.Time) []service.LogEntry {
+	if since.IsZero() {
+		return all
+	}
+	filtered := all[:0]
+	for _, entry := range all {
+		if !entry.Timestamp.Before(since) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
 }
 
 // GetAzureStatus mirrors the legacy service.AzureStatus shape logs.go /

--- a/cli/src/internal/rpc/azure_stream.go
+++ b/cli/src/internal/rpc/azure_stream.go
@@ -337,6 +337,7 @@ type localAzureLogRing struct {
 	mu      sync.Mutex
 	buf     []*v1.LogEntry
 	cap     int
+	head    int // index of oldest entry when ring is full
 	dropped int64
 	notify  chan struct{}
 }
@@ -355,10 +356,13 @@ func newAzureLogRing(capacity int) *localAzureLogRing {
 func (r *localAzureLogRing) push(e *v1.LogEntry) {
 	r.mu.Lock()
 	if len(r.buf) >= r.cap {
-		r.buf = append(r.buf[:0], r.buf[1:]...)
+		// Ring full: overwrite oldest via index, O(1).
+		r.buf[r.head] = e
+		r.head = (r.head + 1) % r.cap
 		r.dropped++
+	} else {
+		r.buf = append(r.buf, e)
 	}
-	r.buf = append(r.buf, e)
 	r.mu.Unlock()
 	select {
 	case r.notify <- struct{}{}:
@@ -372,9 +376,16 @@ func (r *localAzureLogRing) drain() ([]*v1.LogEntry, int64) {
 	if len(r.buf) == 0 {
 		return nil, r.dropped
 	}
-	out := make([]*v1.LogEntry, len(r.buf))
-	copy(out, r.buf)
+	n := len(r.buf)
+	out := make([]*v1.LogEntry, n)
+	if r.head == 0 || n < r.cap {
+		copy(out, r.buf)
+	} else {
+		copy(out, r.buf[r.head:])
+		copy(out[n-r.head:], r.buf[:r.head])
+	}
 	r.buf = r.buf[:0]
+	r.head = 0
 	return out, r.dropped
 }
 

--- a/cli/src/internal/rpc/logs.go
+++ b/cli/src/internal/rpc/logs.go
@@ -588,6 +588,7 @@ type localLogRing struct {
 	mu      sync.Mutex
 	buf     []*v1.LogEntry
 	cap     int
+	head    int // index of the oldest entry when ring is full
 	dropped int64
 	notify  chan struct{}
 }
@@ -609,12 +610,13 @@ func newLocalLogRing(capacity int) *localLogRing {
 func (r *localLogRing) push(e *v1.LogEntry) {
 	r.mu.Lock()
 	if len(r.buf) >= r.cap {
-		// Drop oldest. Allocation is O(cap) once; subsequent pushes
-		// reuse the trimmed backing array up to cap.
-		r.buf = append(r.buf[:0], r.buf[1:]...)
+		// Ring full: overwrite oldest via index, O(1).
+		r.buf[r.head] = e
+		r.head = (r.head + 1) % r.cap
 		r.dropped++
+	} else {
+		r.buf = append(r.buf, e)
 	}
-	r.buf = append(r.buf, e)
 	r.mu.Unlock()
 
 	select {
@@ -625,18 +627,27 @@ func (r *localLogRing) push(e *v1.LogEntry) {
 	}
 }
 
-// drain returns all entries currently in the ring plus the cumulative
-// dropped count. Resets the ring; the caller compares dropped against
-// its previously-observed value to compute the delta.
+// drain returns all entries currently in the ring in insertion order plus
+// the cumulative dropped count. Resets the ring; the caller compares
+// dropped against its previously-observed value to compute the delta.
 func (r *localLogRing) drain() ([]*v1.LogEntry, int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if len(r.buf) == 0 {
 		return nil, r.dropped
 	}
-	out := make([]*v1.LogEntry, len(r.buf))
-	copy(out, r.buf)
+	n := len(r.buf)
+	out := make([]*v1.LogEntry, n)
+	if r.head == 0 || n < r.cap {
+		// Not wrapped yet or head is at start - simple copy
+		copy(out, r.buf)
+	} else {
+		// Ring has wrapped: linearize from head
+		copy(out, r.buf[r.head:])
+		copy(out[n-r.head:], r.buf[:r.head])
+	}
 	r.buf = r.buf[:0]
+	r.head = 0
 	return out, r.dropped
 }
 

--- a/cli/src/internal/service/logbuffer.go
+++ b/cli/src/internal/service/logbuffer.go
@@ -21,10 +21,14 @@ const (
 )
 
 // LogBuffer is a circular buffer for storing service logs with pub/sub support.
+// Uses a fixed-size ring buffer with head/count tracking for O(1) push
+// instead of O(n) slice shifting.
 type LogBuffer struct {
 	serviceName     string
 	entries         []LogEntry
 	maxSize         int
+	head            int // index of the oldest entry in the ring
+	count           int // number of valid entries in the ring
 	mu              sync.RWMutex
 	subscribers     map[chan LogEntry]bool
 	subMu           sync.RWMutex
@@ -45,8 +49,10 @@ func NewLogBuffer(serviceName string, maxSize int, enableFileLogging bool, proje
 func NewLogBufferWithFilter(serviceName string, maxSize int, enableFileLogging bool, projectDir string, filter *LogFilter) (*LogBuffer, error) {
 	lb := &LogBuffer{
 		serviceName: serviceName,
-		entries:     make([]LogEntry, 0, maxSize),
+		entries:     make([]LogEntry, maxSize),
 		maxSize:     maxSize,
+		head:        0,
+		count:       0,
 		subscribers: make(map[chan LogEntry]bool),
 		logFilter:   filter,
 	}
@@ -89,12 +95,16 @@ func (lb *LogBuffer) Add(entry LogEntry) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
-	// Add to circular buffer
-	if len(lb.entries) >= lb.maxSize {
-		// Remove oldest entry
-		lb.entries = lb.entries[1:]
+	// Write into the ring buffer at the next position (O(1))
+	idx := (lb.head + lb.count) % lb.maxSize
+	if lb.count >= lb.maxSize {
+		// Buffer full: overwrite oldest, advance head
+		lb.entries[lb.head] = entry
+		lb.head = (lb.head + 1) % lb.maxSize
+	} else {
+		lb.entries[idx] = entry
+		lb.count++
 	}
-	lb.entries = append(lb.entries, entry)
 
 	// Write to file if enabled
 	if lb.fileWriter != nil {
@@ -177,13 +187,16 @@ func (lb *LogBuffer) GetRecent(n int) []LogEntry {
 	lb.mu.RLock()
 	defer lb.mu.RUnlock()
 
-	if n <= 0 || n > len(lb.entries) {
-		n = len(lb.entries)
+	if n <= 0 || n > lb.count {
+		n = lb.count
 	}
 
-	start := len(lb.entries) - n
 	result := make([]LogEntry, n)
-	copy(result, lb.entries[start:])
+	// Start reading from (head + count - n) mod maxSize
+	start := (lb.head + lb.count - n) % lb.maxSize
+	for i := 0; i < n; i++ {
+		result[i] = lb.entries[(start+i)%lb.maxSize]
+	}
 	return result
 }
 
@@ -199,7 +212,8 @@ func (lb *LogBuffer) ContainsPattern(pattern string) bool {
 
 	// Use simple string matching for common patterns (faster)
 	// Fall back to regex for complex patterns
-	for _, entry := range lb.entries {
+	for i := 0; i < lb.count; i++ {
+		entry := lb.entries[(lb.head+i)%lb.maxSize]
 		if strings.Contains(entry.Message, pattern) {
 			return true
 		}
@@ -223,7 +237,8 @@ func (lb *LogBuffer) ContainsPatternRegex(pattern string) (bool, error) {
 		return false, fmt.Errorf("invalid regex pattern: %w", err)
 	}
 
-	for _, entry := range lb.entries {
+	for i := 0; i < lb.count; i++ {
+		entry := lb.entries[(lb.head+i)%lb.maxSize]
 		if re.MatchString(entry.Message) {
 			return true, nil
 		}
@@ -238,7 +253,8 @@ func (lb *LogBuffer) GetSince(since time.Time) []LogEntry {
 	defer lb.mu.RUnlock()
 
 	result := make([]LogEntry, 0)
-	for _, entry := range lb.entries {
+	for i := 0; i < lb.count; i++ {
+		entry := lb.entries[(lb.head+i)%lb.maxSize]
 		if entry.Timestamp.After(since) || entry.Timestamp.Equal(since) {
 			result = append(result, entry)
 		}
@@ -252,7 +268,8 @@ func (lb *LogBuffer) GetByLevel(level LogLevel) []LogEntry {
 	defer lb.mu.RUnlock()
 
 	result := make([]LogEntry, 0)
-	for _, entry := range lb.entries {
+	for i := 0; i < lb.count; i++ {
+		entry := lb.entries[(lb.head+i)%lb.maxSize]
 		if entry.Level == level {
 			result = append(result, entry)
 		}
@@ -280,6 +297,9 @@ func (lb *LogBuffer) GetLogsWithContext(level LogLevel, limit int, contextLines 
 		contextLines = MaxContextLines
 	}
 
+	// Linearize the ring into a contiguous slice for indexed access
+	linear := lb.linearize()
+
 	// Find all matching indices
 	type matchIndex struct {
 		index int
@@ -287,7 +307,7 @@ func (lb *LogBuffer) GetLogsWithContext(level LogLevel, limit int, contextLines 
 	}
 	var matchIndices []matchIndex
 
-	for i, entry := range lb.entries {
+	for i, entry := range linear {
 		// Apply time filter
 		if !since.IsZero() && entry.Timestamp.Before(since) {
 			continue
@@ -331,18 +351,18 @@ func (lb *LogBuffer) GetLogsWithContext(level LogLevel, limit int, contextLines 
 			}
 			before := make([]string, 0, contextLines)
 			for i := startBefore; i < mi.index; i++ {
-				before = append(before, lb.entries[i].Message)
+				before = append(before, linear[i].Message)
 			}
 			logEntry.Context.Before = before
 
 			// After context
 			endAfter := mi.index + contextLines + 1
-			if endAfter > len(lb.entries) {
-				endAfter = len(lb.entries)
+			if endAfter > len(linear) {
+				endAfter = len(linear)
 			}
 			after := make([]string, 0, contextLines)
 			for i := mi.index + 1; i < endAfter; i++ {
-				after = append(after, lb.entries[i].Message)
+				after = append(after, linear[i].Message)
 			}
 			logEntry.Context.After = after
 		}
@@ -374,6 +394,9 @@ func (lb *LogBuffer) GetErrors(limit int, contextLines int, includeStderr bool, 
 		contextLines = MaxContextLines
 	}
 
+	// Linearize the ring into a contiguous slice for indexed access
+	linear := lb.linearize()
+
 	// Find all error indices
 	type errorIndex struct {
 		index int
@@ -381,7 +404,7 @@ func (lb *LogBuffer) GetErrors(limit int, contextLines int, includeStderr bool, 
 	}
 	var errorIndices []errorIndex
 
-	for i, entry := range lb.entries {
+	for i, entry := range linear {
 		// Apply time filter
 		if !since.IsZero() && entry.Timestamp.Before(since) {
 			continue
@@ -430,18 +453,18 @@ func (lb *LogBuffer) GetErrors(limit int, contextLines int, includeStderr bool, 
 			}
 			before := make([]string, 0, contextLines)
 			for i := startBefore; i < ei.index; i++ {
-				before = append(before, lb.entries[i].Message)
+				before = append(before, linear[i].Message)
 			}
 			errEntry.Context.Before = before
 
 			// After context
 			endAfter := ei.index + contextLines + 1
-			if endAfter > len(lb.entries) {
-				endAfter = len(lb.entries)
+			if endAfter > len(linear) {
+				endAfter = len(linear)
 			}
 			after := make([]string, 0, contextLines)
 			for i := ei.index + 1; i < endAfter; i++ {
-				after = append(after, lb.entries[i].Message)
+				after = append(after, linear[i].Message)
 			}
 			errEntry.Context.After = after
 		}
@@ -449,6 +472,19 @@ func (lb *LogBuffer) GetErrors(limit int, contextLines int, includeStderr bool, 
 		result = append(result, errEntry)
 	}
 
+	return result
+}
+
+// linearize returns the ring buffer contents as a contiguous slice in
+// insertion order. Must be called with lb.mu held (read or write).
+func (lb *LogBuffer) linearize() []LogEntry {
+	if lb.count == 0 {
+		return nil
+	}
+	result := make([]LogEntry, lb.count)
+	for i := 0; i < lb.count; i++ {
+		result[i] = lb.entries[(lb.head+i)%lb.maxSize]
+	}
 	return result
 }
 
@@ -507,7 +543,8 @@ func (lb *LogBuffer) Clear() {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
-	lb.entries = make([]LogEntry, 0, lb.maxSize)
+	lb.head = 0
+	lb.count = 0
 }
 
 // Close closes the log buffer and cleans up resources.

--- a/web/src/components/DashboardCarousel.astro
+++ b/web/src/components/DashboardCarousel.astro
@@ -450,6 +450,11 @@ const slides = [
 
       // Start autoplay
       startAutoplay();
+
+      // Clean up autoplay timer on Astro page transition to prevent leaks
+      document.addEventListener('astro:before-swap', () => {
+        stopAutoplay();
+      }, { once: true });
     });
   });
 </script>

--- a/web/src/components/Lightbox.astro
+++ b/web/src/components/Lightbox.astro
@@ -582,6 +582,13 @@
     });
     observer.observe(document.documentElement, { attributes: true });
 
+    // Clean up observer and globals on Astro page transition to prevent leaks
+    document.addEventListener('astro:before-swap', () => {
+      observer.disconnect();
+      delete (window as any).openScreenshotLightbox;
+      delete (window as any).closeScreenshotLightbox;
+    }, { once: true });
+
     // Expose global function for Screenshot component
     (window as any).openScreenshotLightbox = openLightbox;
     (window as any).closeScreenshotLightbox = closeLightbox;

--- a/web/src/components/Screenshot.astro
+++ b/web/src/components/Screenshot.astro
@@ -447,12 +447,20 @@ const imageStyles = [
     observer.observe(document.documentElement, { attributes: true });
 
     // Listen for system preference changes
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const mediaHandler = () => {
       const theme = document.documentElement.getAttribute('data-theme');
       if (!theme || theme === 'system') {
         handleThemeChange();
       }
-    });
+    };
+    mediaQuery.addEventListener('change', mediaHandler);
+
+    // Clean up observer and listener on Astro page transition to prevent leaks
+    document.addEventListener('astro:before-swap', () => {
+      observer.disconnect();
+      mediaQuery.removeEventListener('change', mediaHandler);
+    }, { once: true });
   }
 
   // Initialize


### PR DESCRIPTION
## Performance improvements

### 1. O(1) circular buffer for log buffers

Replace O(n) slice shifting (`buf = append(buf[:0], buf[1:]...)`) with a proper ring buffer using head/count index tracking. Affected types:

- `service.LogBuffer`: main log buffer used by all services
- `localLogRing` in `rpc/logs.go`: streaming log ring
- `localAzureLogRing` in `rpc/azure_stream.go`: Azure streaming ring

Fixes #211

### 2. Parallel per-service RPC calls in GetAzureLogs

The dashboard client's `GetAzureLogs` now launches concurrent RPCs (via `errgroup`) when multiple services are requested, instead of issuing them sequentially. Single-service requests take a fast path with no goroutine overhead.

Fixes #212

### 3. MutationObserver and timer cleanup on Astro page transitions

Added `astro:before-swap` handlers (with `{ once: true }`) to disconnect MutationObservers, remove media query listeners, and clear autoplay timers before Astro swaps the DOM. Affected components:

- `Lightbox.astro`: disconnects observer, removes window globals
- `Screenshot.astro`: disconnects observer, removes media query listener
- `DashboardCarousel.astro`: clears autoplay interval timer

Fixes #214