### PR TITLE
refactor: wave 4 - consolidate duplicates, centralize parsing, extract helpers

### DIFF
--- a/cli/src/cmd/app/commands/add.go
+++ b/cli/src/cmd/app/commands/add.go
@@ -155,7 +155,7 @@ func listAvailableServices() error {
 	sort.Strings(names)
 
 	if cliout.IsJSON() {
-		type ServiceInfo struct {
+		type AvailableServiceInfo struct {
 			Name        string            `json:"name"`
 			DisplayName string            `json:"displayName"`
 			Description string            `json:"description"`
@@ -164,10 +164,10 @@ func listAvailableServices() error {
 			Ports       []string          `json:"ports"`
 			ConnStrings map[string]string `json:"connectionStrings"`
 		}
-		services := make([]ServiceInfo, 0, len(names))
+		services := make([]AvailableServiceInfo, 0, len(names))
 		for _, name := range names {
 			def := wellknown.Get(name)
-			services = append(services, ServiceInfo{
+			services = append(services, AvailableServiceInfo{
 				Name:        def.Name,
 				DisplayName: def.DisplayName,
 				Description: def.Description,

--- a/cli/src/cmd/app/commands/core.go
+++ b/cli/src/cmd/app/commands/core.go
@@ -10,8 +10,37 @@ import (
 	"github.com/jongio/azd-core/cliout"
 )
 
-// Global orchestrator instance shared across all commands.
-var cmdOrchestrator *orchestrator.Orchestrator
+func newCommandOrchestrator() *orchestrator.Orchestrator {
+	cmdOrchestrator := orchestrator.NewOrchestrator()
+
+	register := func(command *orchestrator.Command) {
+		if err := cmdOrchestrator.Register(command); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to register %s command: %v\n", command.Name, err)
+		}
+	}
+
+	register(&orchestrator.Command{
+		Name:    "reqs",
+		Execute: executeReqs,
+	})
+	register(&orchestrator.Command{
+		Name:         "deps",
+		Dependencies: []string{"reqs"},
+		Execute:      executeDeps,
+	})
+	register(&orchestrator.Command{
+		Name:         "run",
+		Dependencies: []string{"deps"},
+		Execute:      executeRun,
+	})
+	register(&orchestrator.Command{
+		Name:         "test",
+		Dependencies: []string{"deps"},
+		Execute:      executeTest,
+	})
+
+	return cmdOrchestrator
+}
 
 // ExecutionContext holds runtime configuration for command execution.
 type ExecutionContext struct {
@@ -63,48 +92,6 @@ var execContext = &ExecutionContext{
 // SetCacheEnabled configures whether caching should be enabled.
 func SetCacheEnabled(enabled bool) {
 	execContext.CacheEnabled = enabled
-}
-
-// init initializes the command orchestrator and registers all commands.
-func init() {
-	cmdOrchestrator = orchestrator.NewOrchestrator()
-
-	// Register commands with their dependencies
-	// reqs has no dependencies
-	if err := cmdOrchestrator.Register(&orchestrator.Command{
-		Name:    "reqs",
-		Execute: executeReqs,
-	}); err != nil {
-		// Log error but don't exit - let the app handle it gracefully
-		fmt.Fprintf(os.Stderr, "Warning: Failed to register reqs command: %v\n", err)
-	}
-
-	// deps depends on reqs
-	if err := cmdOrchestrator.Register(&orchestrator.Command{
-		Name:         "deps",
-		Dependencies: []string{"reqs"},
-		Execute:      executeDeps,
-	}); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Failed to register deps command: %v\n", err)
-	}
-
-	// run depends on deps (which depends on reqs)
-	if err := cmdOrchestrator.Register(&orchestrator.Command{
-		Name:         "run",
-		Dependencies: []string{"deps"},
-		Execute:      executeRun,
-	}); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Failed to register run command: %v\n", err)
-	}
-
-	// test depends on deps (test tools like jest/vitest must be installed first)
-	if err := cmdOrchestrator.Register(&orchestrator.Command{
-		Name:         "test",
-		Dependencies: []string{"deps"},
-		Execute:      executeTest,
-	}); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Failed to register test command: %v\n", err)
-	}
 }
 
 // executeReqs is the core logic for the reqs command.

--- a/cli/src/cmd/app/commands/core_deps.go
+++ b/cli/src/cmd/app/commands/core_deps.go
@@ -18,9 +18,10 @@ import (
 // DependencyInstaller handles installation of project dependencies.
 type DependencyInstaller struct {
 	searchRoot     string
-	nodeProjects   []types.NodeProject   // Pre-filtered Node.js projects (optional)
-	pythonProjects []types.PythonProject // Pre-filtered Python projects (optional)
-	dotnetProjects []types.DotnetProject // Pre-filtered .NET projects (optional)
+	projects       DetectedProjects // Pre-filtered projects (optional)
+	nodeProjects   []types.NodeProject
+	pythonProjects []types.PythonProject
+	dotnetProjects []types.DotnetProject
 }
 
 // NewDependencyInstaller creates a new dependency installer.
@@ -84,22 +85,27 @@ func (di *DependencyInstaller) InstallAll() ([]InstallResult, error) {
 func (di *DependencyInstaller) InstallAllFiltered() ([]InstallResult, error) {
 	var results []InstallResult
 
-	// Install Node.js dependencies from pre-filtered list
-	if len(di.nodeProjects) > 0 {
-		nodeResults := di.installNodeProjectList(di.nodeProjects)
-		results = append(results, nodeResults...)
+	nodeProjects := di.projects.Node
+	pythonProjects := di.projects.Python
+	dotnetProjects := di.projects.Dotnet
+	if nodeProjects == nil {
+		nodeProjects = di.nodeProjects
+	}
+	if pythonProjects == nil {
+		pythonProjects = di.pythonProjects
+	}
+	if dotnetProjects == nil {
+		dotnetProjects = di.dotnetProjects
 	}
 
-	// Install Python dependencies from pre-filtered list
-	if len(di.pythonProjects) > 0 {
-		pythonResults := di.installPythonProjectList(di.pythonProjects)
-		results = append(results, pythonResults...)
+	if len(nodeProjects) > 0 {
+		results = append(results, di.installNodeProjectList(nodeProjects)...)
 	}
-
-	// Install .NET dependencies from pre-filtered list
-	if len(di.dotnetProjects) > 0 {
-		dotnetResults := di.installDotnetProjectList(di.dotnetProjects)
-		results = append(results, dotnetResults...)
+	if len(pythonProjects) > 0 {
+		results = append(results, di.installPythonProjectList(pythonProjects)...)
+	}
+	if len(dotnetProjects) > 0 {
+		results = append(results, di.installDotnetProjectList(dotnetProjects)...)
 	}
 
 	return results, nil
@@ -261,53 +267,44 @@ func (di *DependencyInstaller) installProject(projectType, dir, manager string, 
 	return result
 }
 
-// filterProjectsByService filters projects to only include those matching the specified service names.
-func filterProjectsByService(
-	nodeProjects []types.NodeProject,
-	pythonProjects []types.PythonProject,
-	dotnetProjects []types.DotnetProject,
-	services []string,
-	searchRoot string,
-) ([]types.NodeProject, []types.PythonProject, []types.DotnetProject) {
+// filterDetectedProjectsByService filters grouped projects to only include those matching the specified service names.
+func filterDetectedProjectsByService(projects DetectedProjects, services []string, searchRoot string) DetectedProjects {
 	// Build a set of service paths from azure.yaml
 	servicePaths := make(map[string]bool)
 
 	azureYamlPath, err := detector.FindAzureYaml(searchRoot)
 	if err != nil || azureYamlPath == "" {
 		// No azure.yaml found, can't filter by service
-		return nodeProjects, pythonProjects, dotnetProjects
+		return projects
 	}
 
 	azureYaml, err := parseAzureYaml(azureYamlPath)
 	if err != nil {
-		return nodeProjects, pythonProjects, dotnetProjects
+		return projects
 	}
-
-	azureYamlDir := filepath.Dir(azureYamlPath)
 
 	// Build map of service name to absolute path
 	for name, svc := range azureYaml.Services {
-		// Check if this service is in the filter list
 		for _, filterName := range services {
-			if name == filterName {
-				svcPath := filepath.Join(azureYamlDir, svc.Project)
-				absPath, err := filepath.Abs(svcPath)
-				if err != nil {
-					// Log warning but continue processing other services
-					if !cliout.IsJSON() {
-						cliout.Warning("Failed to resolve absolute path for service %s: %v", name, err)
-					}
-					continue
-				}
-				servicePaths[absPath] = true
-				break
+			if name != filterName {
+				continue
 			}
+
+			absPath, err := filepath.Abs(svc.Project)
+			if err != nil {
+				if !cliout.IsJSON() {
+					cliout.Warning("Failed to resolve absolute path for service %s: %v", name, err)
+				}
+				continue
+			}
+			servicePaths[absPath] = true
+			break
 		}
 	}
 
 	// Filter Node.js projects
 	var filteredNode []types.NodeProject
-	for _, p := range nodeProjects {
+	for _, p := range projects.Node {
 		absDir, _ := filepath.Abs(p.Dir)
 		if servicePaths[absDir] || isSubdirectory(absDir, servicePaths) {
 			filteredNode = append(filteredNode, p)
@@ -316,7 +313,7 @@ func filterProjectsByService(
 
 	// Filter Python projects
 	var filteredPython []types.PythonProject
-	for _, p := range pythonProjects {
+	for _, p := range projects.Python {
 		absDir, _ := filepath.Abs(p.Dir)
 		if servicePaths[absDir] || isSubdirectory(absDir, servicePaths) {
 			filteredPython = append(filteredPython, p)
@@ -325,7 +322,7 @@ func filterProjectsByService(
 
 	// Filter .NET projects
 	var filteredDotnet []types.DotnetProject
-	for _, p := range dotnetProjects {
+	for _, p := range projects.Dotnet {
 		absPath, _ := filepath.Abs(p.Path)
 		absDir := filepath.Dir(absPath)
 		if servicePaths[absDir] || isSubdirectory(absDir, servicePaths) {
@@ -333,7 +330,22 @@ func filterProjectsByService(
 		}
 	}
 
-	return filteredNode, filteredPython, filteredDotnet
+	return DetectedProjects{
+		Node:   filteredNode,
+		Python: filteredPython,
+		Dotnet: filteredDotnet,
+	}
+}
+
+// filterProjectsByService preserves the legacy test-facing signature while delegating to grouped project filtering.
+func filterProjectsByService(nodeProjects []types.NodeProject, pythonProjects []types.PythonProject, dotnetProjects []types.DotnetProject, services []string, searchRoot string) ([]types.NodeProject, []types.PythonProject, []types.DotnetProject) {
+	filtered := filterDetectedProjectsByService(DetectedProjects{
+		Node:   nodeProjects,
+		Python: pythonProjects,
+		Dotnet: dotnetProjects,
+	}, services, searchRoot)
+
+	return filtered.Node, filtered.Python, filtered.Dotnet
 }
 
 // detectProjectsFromAzureYaml reads azure.yaml and detects project types directly from
@@ -462,7 +474,7 @@ func isSubdirectory(path string, parentPaths map[string]bool) bool {
 }
 
 // runParallelInstallation runs the parallel installer for non-JSON mode.
-func runParallelInstallation(nodeProjects []types.NodeProject, pythonProjects []types.PythonProject, dotnetProjects []types.DotnetProject, verbose bool) error {
+func runParallelInstallation(projects DetectedProjects, verbose bool) error {
 	parallelInstaller := installer.NewParallelInstaller()
 	parallelInstaller.Verbose = verbose
 
@@ -470,15 +482,15 @@ func runParallelInstallation(nodeProjects []types.NodeProject, pythonProjects []
 	// When a workspace root exists, only install at the root level to avoid race conditions
 	// on Windows where parallel npm installs compete for the same node_modules directory
 	workspaceHandler := workspace.NewHandler()
-	filteredNodeProjects := workspaceHandler.FilterNodeProjects(nodeProjects)
+	filteredNodeProjects := workspaceHandler.FilterNodeProjects(projects.Node)
 
 	for _, project := range filteredNodeProjects {
 		parallelInstaller.AddNodeProject(project)
 	}
-	for _, project := range pythonProjects {
+	for _, project := range projects.Python {
 		parallelInstaller.AddPythonProject(project)
 	}
-	for _, project := range dotnetProjects {
+	for _, project := range projects.Dotnet {
 		parallelInstaller.AddDotnetProject(project)
 	}
 
@@ -500,11 +512,9 @@ func runParallelInstallation(nodeProjects []types.NodeProject, pythonProjects []
 }
 
 // runJSONInstallation runs installation in JSON mode with sequential cliout.
-func runJSONInstallation(searchRoot string, nodeProjects []types.NodeProject, pythonProjects []types.PythonProject, dotnetProjects []types.DotnetProject) error {
+func runJSONInstallation(searchRoot string, projects DetectedProjects) error {
 	depInstaller := NewDependencyInstaller(searchRoot)
-	depInstaller.nodeProjects = nodeProjects
-	depInstaller.pythonProjects = pythonProjects
-	depInstaller.dotnetProjects = dotnetProjects
+	depInstaller.projects = projects
 
 	results, err := depInstaller.InstallAllFiltered()
 	if err != nil {

--- a/cli/src/cmd/app/commands/core_helpers.go
+++ b/cli/src/cmd/app/commands/core_helpers.go
@@ -79,6 +79,7 @@ func loadAzureYaml() (string, *AzureYaml, error) {
 	}
 
 	var azureYaml AzureYaml
+	// TODO: Replace this direct unmarshal once service.ParseAzureYaml supports the reqs schema used by commands.AzureYaml.
 	if err := yaml.Unmarshal(data, &azureYaml); err != nil {
 		return "", nil, fmt.Errorf("failed to parse azure.yaml: %w", err)
 	}
@@ -278,7 +279,7 @@ func (rf *ResultFormatter) PrintAll(results []ReqResult) {
 }
 
 // cleanDependencies removes existing dependency directories for all detected projects.
-func cleanDependencies(nodeProjects []types.NodeProject, pythonProjects []types.PythonProject, dotnetProjects []types.DotnetProject) error {
+func cleanGroupedDependencies(projects DetectedProjects) error {
 	if !cliout.IsJSON() {
 		cliout.Newline()
 		cliout.Section("🧹", "Cleaning Dependencies")
@@ -288,7 +289,7 @@ func cleanDependencies(nodeProjects []types.NodeProject, pythonProjects []types.
 	var errors []error
 
 	// Clean Node.js projects
-	for _, project := range nodeProjects {
+	for _, project := range projects.Node {
 		nodeModulesPath := filepath.Join(project.Dir, "node_modules")
 		if err := cleanDirectory(nodeModulesPath); err != nil {
 			errors = append(errors, err)
@@ -296,7 +297,7 @@ func cleanDependencies(nodeProjects []types.NodeProject, pythonProjects []types.
 	}
 
 	// Clean Python projects
-	for _, project := range pythonProjects {
+	for _, project := range projects.Python {
 		venvPath := filepath.Join(project.Dir, ".venv")
 		if err := cleanDirectory(venvPath); err != nil {
 			errors = append(errors, err)
@@ -304,7 +305,7 @@ func cleanDependencies(nodeProjects []types.NodeProject, pythonProjects []types.
 	}
 
 	// Clean .NET projects (obj and bin directories)
-	for _, project := range dotnetProjects {
+	for _, project := range projects.Dotnet {
 		projectDir := filepath.Dir(project.Path)
 		for _, dir := range []string{"obj", "bin"} {
 			dirPath := filepath.Join(projectDir, dir)
@@ -409,23 +410,15 @@ func detectAllProjects(searchRoot string) ([]types.NodeProject, []types.PythonPr
 
 // parseAzureYaml parses the azure.yaml file.
 func parseAzureYaml(azureYamlPath string) (*service.AzureYaml, error) {
-	data, err := readFileSecure(azureYamlPath)
-	if err != nil {
-		return nil, err
-	}
-	var azureYaml service.AzureYaml
-	if err := unmarshalYaml(data, &azureYaml); err != nil {
-		return nil, err
-	}
-	return &azureYaml, nil
+	return service.ParseAzureYaml(filepath.Dir(azureYamlPath))
 }
 
 // showDryRunSummary displays what would be installed without actually installing.
-func showDryRunSummary(nodeProjects []types.NodeProject, pythonProjects []types.PythonProject, dotnetProjects []types.DotnetProject, searchRoot string) error {
+func showGroupedDryRunSummary(projects DetectedProjects, searchRoot string) error {
 	if cliout.IsJSON() {
 		// Build dry-run results
 		var results []InstallResult
-		for _, p := range nodeProjects {
+		for _, p := range projects.Node {
 			results = append(results, InstallResult{
 				Type:    "node",
 				Dir:     p.Dir,
@@ -433,7 +426,7 @@ func showDryRunSummary(nodeProjects []types.NodeProject, pythonProjects []types.
 				Success: true, // Would succeed (dry-run)
 			})
 		}
-		for _, p := range pythonProjects {
+		for _, p := range projects.Python {
 			results = append(results, InstallResult{
 				Type:    "python",
 				Dir:     p.Dir,
@@ -441,7 +434,7 @@ func showDryRunSummary(nodeProjects []types.NodeProject, pythonProjects []types.
 				Success: true,
 			})
 		}
-		for _, p := range dotnetProjects {
+		for _, p := range projects.Dotnet {
 			results = append(results, InstallResult{
 				Type:    "dotnet",
 				Path:    p.Path,
@@ -459,9 +452,9 @@ func showDryRunSummary(nodeProjects []types.NodeProject, pythonProjects []types.
 	cliout.Section("📋", "Dry Run - Projects that would be installed")
 	cliout.Newline()
 
-	if len(nodeProjects) > 0 {
-		cliout.Step("📦", "Node.js projects (%d)", len(nodeProjects))
-		for _, p := range nodeProjects {
+	if len(projects.Node) > 0 {
+		cliout.Step("📦", "Node.js projects (%d)", len(projects.Node))
+		for _, p := range projects.Node {
 			relDir := p.Dir
 			if rel, err := filepath.Rel(searchRoot, p.Dir); err == nil && rel != "." {
 				relDir = rel
@@ -471,9 +464,9 @@ func showDryRunSummary(nodeProjects []types.NodeProject, pythonProjects []types.
 		cliout.Newline()
 	}
 
-	if len(pythonProjects) > 0 {
-		cliout.Step("🐍", "Python projects (%d)", len(pythonProjects))
-		for _, p := range pythonProjects {
+	if len(projects.Python) > 0 {
+		cliout.Step("🐍", "Python projects (%d)", len(projects.Python))
+		for _, p := range projects.Python {
 			relDir := p.Dir
 			if rel, err := filepath.Rel(searchRoot, p.Dir); err == nil && rel != "." {
 				relDir = rel
@@ -483,9 +476,9 @@ func showDryRunSummary(nodeProjects []types.NodeProject, pythonProjects []types.
 		cliout.Newline()
 	}
 
-	if len(dotnetProjects) > 0 {
-		cliout.Step("🔷", ".NET projects (%d)", len(dotnetProjects))
-		for _, p := range dotnetProjects {
+	if len(projects.Dotnet) > 0 {
+		cliout.Step("🔷", ".NET projects (%d)", len(projects.Dotnet))
+		for _, p := range projects.Dotnet {
 			relPath := p.Path
 			if rel, err := filepath.Rel(searchRoot, p.Path); err == nil && rel != "." {
 				relPath = rel
@@ -495,11 +488,27 @@ func showDryRunSummary(nodeProjects []types.NodeProject, pythonProjects []types.
 		cliout.Newline()
 	}
 
-	total := len(nodeProjects) + len(pythonProjects) + len(dotnetProjects)
+	total := projects.Total()
 	cliout.Info("Total: %d project(s) would be installed", total)
 	cliout.Info("Run without --dry-run to install dependencies")
 
 	return nil
+}
+
+func cleanDependencies(nodeProjects []types.NodeProject, pythonProjects []types.PythonProject, dotnetProjects []types.DotnetProject) error {
+	return cleanGroupedDependencies(DetectedProjects{
+		Node:   nodeProjects,
+		Python: pythonProjects,
+		Dotnet: dotnetProjects,
+	})
+}
+
+func showDryRunSummary(nodeProjects []types.NodeProject, pythonProjects []types.PythonProject, dotnetProjects []types.DotnetProject, searchRoot string) error {
+	return showGroupedDryRunSummary(DetectedProjects{
+		Node:   nodeProjects,
+		Python: pythonProjects,
+		Dotnet: dotnetProjects,
+	}, searchRoot)
 }
 
 // handleNoProjectsCase handles the case when no projects are detected.

--- a/cli/src/cmd/app/commands/deps.go
+++ b/cli/src/cmd/app/commands/deps.go
@@ -65,14 +65,18 @@ func (e *depsExecutor) execute() error {
 		return handleDepsError(err, "failed to detect projects from azure.yaml")
 	}
 
-	// Apply service filter if specified (further restricts to named services)
-	if len(e.opts.Services) > 0 {
-		nodeProjects, pythonProjects, dotnetProjects = e.filterProjectsByService(
-			nodeProjects, pythonProjects, dotnetProjects, searchRoot,
-		)
+	projects := DetectedProjects{
+		Node:   nodeProjects,
+		Python: pythonProjects,
+		Dotnet: dotnetProjects,
 	}
 
-	totalProjects := len(nodeProjects) + len(pythonProjects) + len(dotnetProjects)
+	// Apply service filter if specified (further restricts to named services)
+	if len(e.opts.Services) > 0 {
+		projects = e.filterProjectsByService(projects, searchRoot)
+	}
+
+	totalProjects := projects.Total()
 
 	// Handle no projects case
 	if totalProjects == 0 {
@@ -81,33 +85,28 @@ func (e *depsExecutor) execute() error {
 
 	// Dry-run mode: show what would be installed and exit
 	if e.opts.DryRun {
-		return showDryRunSummary(nodeProjects, pythonProjects, dotnetProjects, searchRoot)
+		return showGroupedDryRunSummary(projects, searchRoot)
 	}
 
 	// Clean dependencies if requested
 	if e.opts.Clean {
-		if err := cleanDependencies(nodeProjects, pythonProjects, dotnetProjects); err != nil {
+		if err := cleanGroupedDependencies(projects); err != nil {
 			return fmt.Errorf("failed to clean dependencies: %w", err)
 		}
 	}
 
 	// Use parallel installer for concurrent installation with progress bars
 	if !cliout.IsJSON() {
-		return runParallelInstallation(nodeProjects, pythonProjects, dotnetProjects, e.opts.Verbose)
+		return runParallelInstallation(projects, e.opts.Verbose)
 	}
 
 	// JSON mode: use sequential installer
-	return runJSONInstallation(searchRoot, nodeProjects, pythonProjects, dotnetProjects)
+	return runJSONInstallation(searchRoot, projects)
 }
 
 // filterProjectsByService filters projects to only those matching the specified services.
-func (e *depsExecutor) filterProjectsByService(
-	nodeProjects []types.NodeProject,
-	pythonProjects []types.PythonProject,
-	dotnetProjects []types.DotnetProject,
-	searchRoot string,
-) ([]types.NodeProject, []types.PythonProject, []types.DotnetProject) {
-	return filterProjectsByService(nodeProjects, pythonProjects, dotnetProjects, e.opts.Services, searchRoot)
+func (e *depsExecutor) filterProjectsByService(projects DetectedProjects, searchRoot string) DetectedProjects {
+	return filterDetectedProjectsByService(projects, e.opts.Services, searchRoot)
 }
 
 // handleNoProjectsCase handles the case when no projects are detected.
@@ -216,6 +215,8 @@ func NewDepsCommand() *cobra.Command {
 	// Create options for this command invocation
 	opts := &DepsOptions{}
 
+	commandOrchestrator := newCommandOrchestrator()
+
 	cmd := &cobra.Command{
 		Use:          "deps",
 		Short:        "Install dependencies for services defined in azure.yaml",
@@ -249,7 +250,7 @@ func NewDepsCommand() *cobra.Command {
 				SetCacheEnabled(false)
 			}
 			// Use orchestrator to run deps (which will automatically run reqs first)
-			return cmdOrchestrator.Run("deps")
+			return commandOrchestrator.Run("deps")
 		},
 	}
 

--- a/cli/src/cmd/app/commands/detected_projects.go
+++ b/cli/src/cmd/app/commands/detected_projects.go
@@ -1,0 +1,15 @@
+package commands
+
+import types "github.com/jongio/azd-core/projecttype"
+
+// DetectedProjects groups detected project types that are typically processed together.
+type DetectedProjects struct {
+	Node   []types.NodeProject
+	Python []types.PythonProject
+	Dotnet []types.DotnetProject
+}
+
+// Total returns the total number of detected projects.
+func (p DetectedProjects) Total() int {
+	return len(p.Node) + len(p.Python) + len(p.Dotnet)
+}

--- a/cli/src/cmd/app/commands/generate.go
+++ b/cli/src/cmd/app/commands/generate.go
@@ -732,6 +732,7 @@ func mergeReqs(azureYamlPath string, detected []DetectedRequirement) (int, int, 
 	var azureYaml struct {
 		Reqs []Prerequisite `yaml:"reqs"`
 	}
+	// TODO: Replace this direct unmarshal once service.ParseAzureYaml supports the reqs schema used by generate.
 	if err = yaml.Unmarshal(data, &azureYaml); err != nil {
 		return 0, 0, fmt.Errorf("failed to parse azure.yaml: %w", err)
 	}

--- a/cli/src/cmd/app/commands/mcp.go
+++ b/cli/src/cmd/app/commands/mcp.go
@@ -396,7 +396,7 @@ func getProjectDir() string {
 }
 
 // ServiceInfo represents the output schema for get_services tool
-type ServiceInfo struct {
+type ServicesResult struct {
 	Project  map[string]any   `json:"project" jsonschema:"description=Project metadata including name and directory"`
 	Services []ServiceDetails `json:"services" jsonschema:"description=List of services with their status and configuration"`
 }

--- a/cli/src/cmd/app/commands/mcp_tools.go
+++ b/cli/src/cmd/app/commands/mcp_tools.go
@@ -45,7 +45,7 @@ func addGetServicesTool(b *azdext.MCPServerBuilder) {
 			ReadOnly:    true,
 			Idempotent:  true,
 		},
-		mcp.WithOutputSchema[ServiceInfo](),
+		mcp.WithOutputSchema[ServicesResult](),
 		mcp.WithString(
 			"projectDir",
 			mcp.Description("Optional project directory path. If not provided, uses current directory."),

--- a/cli/src/cmd/app/commands/reqs.go
+++ b/cli/src/cmd/app/commands/reqs.go
@@ -301,7 +301,7 @@ Use --no-cache to force a fresh check and bypass cached results.`,
 				return runReqsFix()
 			}
 
-			return cmdOrchestrator.Run("reqs")
+			return newCommandOrchestrator().Run("reqs")
 		},
 	}
 
@@ -730,6 +730,86 @@ type FixResult struct {
 	Satisfied bool   `json:"satisfied"`
 }
 
+type reqsFixRunner struct {
+	checker *PrerequisiteChecker
+}
+
+func newReqsFixRunner() *reqsFixRunner {
+	return &reqsFixRunner{checker: NewPrerequisiteChecker()}
+}
+
+func (r *reqsFixRunner) parseReqs() (string, []Prerequisite, error) {
+	azureYamlPath, azureYaml, err := loadAzureYaml()
+	if err != nil {
+		return "", nil, err
+	}
+
+	reqs := append([]Prerequisite{}, azureYaml.Reqs...)
+	reqs = r.ensureDockerReq(azureYaml, reqs)
+	if len(reqs) == 0 {
+		return "", nil, fmt.Errorf("no reqs defined in azure.yaml - run 'azd app reqs --generate' to add them")
+	}
+
+	return azureYamlPath, reqs, nil
+}
+
+func (r *reqsFixRunner) ensureDockerReq(azureYaml *AzureYaml, reqs []Prerequisite) []Prerequisite {
+	if azureYaml.hasContainerServices() && !azureYaml.hasDockerReq() {
+		return append(reqs, Prerequisite{Name: "docker", MinVersion: "20.0.0", CheckRunning: true})
+	}
+	return reqs
+}
+
+func (r *reqsFixRunner) checkPrerequisite(prereq Prerequisite) FixResult {
+	fixResult := FixResult{Name: prereq.Name}
+	config := r.checker.getToolConfig(prereq)
+	toolCommand := config.Command
+
+	toolPath := pathutil.FindToolInPath(toolCommand)
+	if toolPath != "" {
+		fixResult.Found = true
+		fixResult.Path = toolPath
+		result := r.checker.Check(prereq)
+		if result.Satisfied {
+			fixResult.Fixed = true
+			fixResult.Satisfied = true
+			fixResult.Message = fmt.Sprintf("Found and verified: %s", toolPath)
+			if !cliout.IsJSON() {
+				cliout.ItemSuccess("Found: %s", toolPath)
+				cliout.ItemSuccess("Version verified successfully")
+			}
+			return fixResult
+		}
+		fixResult.Message = fmt.Sprintf("Found at %s but version check failed: %s", toolPath, result.Message)
+		if !cliout.IsJSON() {
+			cliout.ItemWarning("Found: %s", toolPath)
+			cliout.ItemWarning("Version check failed: %s", result.Message)
+		}
+		return fixResult
+	}
+
+	toolPath = pathutil.SearchToolInSystemPath(toolCommand)
+	if toolPath != "" {
+		fixResult.Found = true
+		fixResult.Path = toolPath
+		fixResult.Message = fmt.Sprintf("Found at %s but not in PATH - restart terminal may be needed", toolPath)
+		if !cliout.IsJSON() {
+			cliout.ItemWarning("Found: %s", toolPath)
+			cliout.ItemWarning("Tool is installed but not in current PATH")
+			cliout.Info("   %s Restart your terminal to update PATH", cliout.IconBulb)
+		}
+		return fixResult
+	}
+
+	suggestion := pathutil.GetInstallSuggestion(toolCommand)
+	fixResult.Message = fmt.Sprintf("Not found - %s", suggestion)
+	if !cliout.IsJSON() {
+		cliout.ItemError("Not found in system PATH")
+		cliout.Info("   %s %s", cliout.IconBulb, suggestion)
+	}
+	return fixResult
+}
+
 // runReqsFix attempts to fix PATH issues for missing tools.
 func runReqsFix() error {
 	cliout.CommandHeader("reqs --fix", "Fix PATH issues for missing tools")
@@ -737,161 +817,79 @@ func runReqsFix() error {
 		cliout.Section(cliout.IconTool, "Attempting to fix requirement issues...")
 	}
 
-	// Load azure.yaml
-	azureYamlPath, azureYaml, err := loadAzureYaml()
+	runner := newReqsFixRunner()
+	azureYamlPath, reqs, err := runner.parseReqs()
 	if err != nil {
 		return err
 	}
 
-	if len(azureYaml.Reqs) == 0 {
-		return fmt.Errorf("no reqs defined in azure.yaml - run 'azd app reqs --generate' to add them")
-	}
-
-	// Step 1: Run initial check to identify issues
-	initialChecker := NewPrerequisiteChecker()
 	var failedReqs []Prerequisite
-	for _, prereq := range azureYaml.Reqs {
-		result := initialChecker.Check(prereq)
-		if !result.Satisfied {
+	for _, prereq := range reqs {
+		if result := runner.checker.Check(prereq); !result.Satisfied {
 			failedReqs = append(failedReqs, prereq)
 		}
 	}
 
 	if len(failedReqs) == 0 {
 		if cliout.IsJSON() {
-			return cliout.PrintJSON(map[string]any{
-				"success": true,
-				"message": "All requirements already satisfied",
-			})
+			return cliout.PrintJSON(map[string]any{"success": true, "message": "All requirements already satisfied"})
 		}
 		cliout.Success("All requirements already satisfied!")
 		return nil
 	}
 
-	// Step 2: Refresh PATH
 	if !cliout.IsJSON() {
 		cliout.Newline()
 		cliout.Step(cliout.IconRefresh, "Refreshing environment PATH...")
 	}
-
-	_, err = pathutil.RefreshPATH()
-	if err != nil {
+	if _, err = pathutil.RefreshPATH(); err != nil {
 		if !cliout.IsJSON() {
 			cliout.Warning("Failed to refresh PATH: %v", err)
 		}
-	} else {
-		if !cliout.IsJSON() {
-			cliout.ItemSuccess("PATH refreshed successfully")
-		}
+	} else if !cliout.IsJSON() {
+		cliout.ItemSuccess("PATH refreshed successfully")
 	}
 
-	// Step 3: Try to find and fix each failed requirement
 	fixResults := make([]FixResult, 0, len(failedReqs))
 	fixedCount := 0
-
 	for _, prereq := range failedReqs {
 		if !cliout.IsJSON() {
 			cliout.Newline()
 			cliout.Step(cliout.IconSearch, "Searching for %s...", prereq.Name)
 		}
 
-		fixResult := FixResult{
-			Name:  prereq.Name,
-			Fixed: false,
-			Found: false,
+		fixResult := runner.checkPrerequisite(prereq)
+		if fixResult.Fixed && fixResult.Satisfied {
+			fixedCount++
 		}
-
-		// Get the command name to search for
-		config := initialChecker.getToolConfig(prereq)
-		toolCommand := config.Command
-
-		// Try to find tool in current PATH (after refresh)
-		toolPath := pathutil.FindToolInPath(toolCommand)
-		if toolPath != "" {
-			fixResult.Found = true
-			fixResult.Path = toolPath
-
-			// Re-check if it works now
-			result := initialChecker.Check(prereq)
-			if result.Satisfied {
-				fixResult.Fixed = true
-				fixResult.Satisfied = true
-				fixResult.Message = fmt.Sprintf("Found and verified: %s", toolPath)
-				fixedCount++
-				if !cliout.IsJSON() {
-					cliout.ItemSuccess("Found: %s", toolPath)
-					cliout.ItemSuccess("Version verified successfully")
-				}
-			} else {
-				fixResult.Message = fmt.Sprintf("Found at %s but version check failed: %s", toolPath, result.Message)
-				if !cliout.IsJSON() {
-					cliout.ItemWarning("Found: %s", toolPath)
-					cliout.ItemWarning("Version check failed: %s", result.Message)
-				}
-			}
-		} else {
-			// Tool not found in PATH, try searching common locations
-			toolPath = pathutil.SearchToolInSystemPath(toolCommand)
-			if toolPath != "" {
-				fixResult.Found = true
-				fixResult.Path = toolPath
-				fixResult.Message = fmt.Sprintf("Found at %s but not in PATH - restart terminal may be needed", toolPath)
-				if !cliout.IsJSON() {
-					cliout.ItemWarning("Found: %s", toolPath)
-					cliout.ItemWarning("Tool is installed but not in current PATH")
-					cliout.Info("   %s Restart your terminal to update PATH", cliout.IconBulb)
-				}
-			} else {
-				// Not found anywhere
-				suggestion := pathutil.GetInstallSuggestion(toolCommand)
-				fixResult.Message = fmt.Sprintf("Not found - %s", suggestion)
-				if !cliout.IsJSON() {
-					cliout.ItemError("Not found in system PATH")
-					cliout.Info("   %s %s", cliout.IconBulb, suggestion)
-				}
-			}
-		}
-
 		fixResults = append(fixResults, fixResult)
 	}
 
-	// Step 4: Invalidate cache so next check gets fresh results
 	if fixedCount > 0 {
-		// Use same azure.yaml path for cache clearing
 		cacheDir := filepath.Join(filepath.Dir(azureYamlPath), ".azure", "cache")
-		cacheManager, err := cache.NewCacheManagerWithOptions(cache.CacheOptions{
-			Enabled:  true,
-			CacheDir: cacheDir,
-		})
-		if err == nil {
-			if err := cacheManager.ClearCache(); err != nil {
-				// Log but don't fail on cache clear error
-				if !cliout.IsJSON() {
-					cliout.Warning("Failed to clear cache: %v", err)
-				}
+		cacheManager, cacheErr := cache.NewCacheManagerWithOptions(cache.CacheOptions{Enabled: true, CacheDir: cacheDir})
+		if cacheErr == nil {
+			if err := cacheManager.ClearCache(); err != nil && !cliout.IsJSON() {
+				cliout.Warning("Failed to clear cache: %v", err)
 			}
 		}
 	}
 
-	// Step 5: Re-check all requirements
 	if !cliout.IsJSON() {
 		cliout.Newline()
 		cliout.Section(cliout.IconCheck, "Re-checking requirements...")
 	}
 
-	checker := NewPrerequisiteChecker()
-	allResults := make([]ReqResult, 0, len(azureYaml.Reqs))
+	allResults := make([]ReqResult, 0, len(reqs))
 	allSatisfied := true
-
-	for _, prereq := range azureYaml.Reqs {
-		result := checker.Check(prereq)
+	for _, prereq := range reqs {
+		result := runner.checker.Check(prereq)
 		allResults = append(allResults, result)
 		if !result.Satisfied {
 			allSatisfied = false
 		}
 	}
 
-	// JSON output
 	if cliout.IsJSON() {
 		return cliout.PrintJSON(map[string]any{
 			"success":      fixedCount > 0,
@@ -903,7 +901,6 @@ func runReqsFix() error {
 		})
 	}
 
-	// Default output - summary
 	cliout.Newline()
 	if fixedCount > 0 {
 		cliout.Success("Fixed %d of %d issues!", fixedCount, len(failedReqs))
@@ -924,8 +921,6 @@ func runReqsFix() error {
 	cliout.Success("All requirements now satisfied!")
 	cliout.Newline()
 	cliout.Info("ℹ️  Note: Tools may not be available in THIS terminal session")
-
-	// Provide platform-specific refresh instructions
 	if runtime.GOOS == osWindows {
 		cliout.Info("   To refresh PATH in your current PowerShell session, run:")
 		cliout.Info("   %s$env:PATH = [System.Environment]::GetEnvironmentVariable(\"Path\",\"Machine\") + \";\" + [System.Environment]::GetEnvironmentVariable(\"Path\",\"User\")%s", cliout.Dim, cliout.Reset)

--- a/cli/src/cmd/app/commands/run.go
+++ b/cli/src/cmd/app/commands/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jongio/azd-app/cli/src/internal/detector"
 	"github.com/jongio/azd-app/cli/src/internal/executor"
 	"github.com/jongio/azd-app/cli/src/internal/notifications"
+	"github.com/jongio/azd-app/cli/src/internal/orchestrator"
 	"github.com/jongio/azd-app/cli/src/internal/service"
 	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
 	"github.com/jongio/azd-core/browser"
@@ -45,13 +46,15 @@ var (
 
 // NewRunCommand creates the run command.
 func NewRunCommand() *cobra.Command {
+	commandOrchestrator := newCommandOrchestrator()
+
 	cmd := &cobra.Command{
 		Use:          "run",
 		Short:        "Run the development environment (services from azure.yaml, Aspire, pnpm, or docker compose)",
 		Long:         `Automatically detects and runs services defined in azure.yaml, or falls back to: Aspire (AppHost.cs), pnpm dev/start scripts, or docker compose from package.json`,
 		SilenceUsage: true, // Don't print usage on errors - it makes error messages hard to read
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runWithServices(cmd.Context(), cmd, args)
+			return runWithServices(cmd.Context(), commandOrchestrator, cmd, args)
 		},
 	}
 
@@ -69,7 +72,7 @@ func NewRunCommand() *cobra.Command {
 }
 
 // runWithServices runs services from azure.yaml.
-func runWithServices(ctx context.Context, _ *cobra.Command, _ []string) error {
+func runWithServices(ctx context.Context, commandOrchestrator *orchestrator.Orchestrator, _ *cobra.Command, _ []string) error {
 	cliout.CommandHeader("run", "Run the development environment")
 	if err := validateRuntimeMode(runRuntime); err != nil {
 		return err
@@ -84,7 +87,7 @@ func runWithServices(ctx context.Context, _ *cobra.Command, _ []string) error {
 
 	// Execute dependencies first (reqs -> deps -> run)
 	// The orchestrator automatically sets orchestrated mode for dependencies
-	if err := cmdOrchestrator.Run("run"); err != nil {
+	if err := commandOrchestrator.Run("run"); err != nil {
 		return fmt.Errorf("failed to execute command dependencies: %w", err)
 	}
 

--- a/cli/src/cmd/app/commands/test.go
+++ b/cli/src/cmd/app/commands/test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jongio/azd-app/cli/src/internal/orchestrator"
 	"github.com/jongio/azd-app/cli/src/internal/testing"
 	"github.com/jongio/azd-core/cliout"
 	"github.com/spf13/cobra"
@@ -42,6 +43,8 @@ func NewTestCommand() *cobra.Command {
 	// Create options for this command invocation
 	opts := &TestOptions{}
 
+	commandOrchestrator := newCommandOrchestrator()
+
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: "Run tests for all services with coverage aggregation",
@@ -60,7 +63,7 @@ func NewTestCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTests(opts)
+			return runTests(commandOrchestrator, opts)
 		},
 	}
 
@@ -87,7 +90,7 @@ func NewTestCommand() *cobra.Command {
 }
 
 // runTests executes tests for all services.
-func runTests(opts *TestOptions) error {
+func runTests(commandOrchestrator *orchestrator.Orchestrator, opts *TestOptions) error {
 	// Validate test type
 	validTypes := map[string]bool{
 		"unit":        true,
@@ -124,7 +127,7 @@ func runTests(opts *TestOptions) error {
 	}
 
 	// Execute dependencies first (reqs)
-	if err := cmdOrchestrator.Run("test"); err != nil {
+	if err := commandOrchestrator.Run("test"); err != nil {
 		return fmt.Errorf("failed to execute command dependencies: %w", err)
 	}
 

--- a/cli/src/internal/azure/diagnostics.go
+++ b/cli/src/internal/azure/diagnostics.go
@@ -7,14 +7,12 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"gopkg.in/yaml.v3"
+	"github.com/jongio/azd-app/cli/src/internal/service"
 )
 
 // DiagnosticSettingsStatus represents the status of diagnostic settings for a service.
@@ -66,7 +64,7 @@ func (c *DiagnosticSettingsChecker) CheckAllServices(ctx context.Context) (*Diag
 	yamlConfig, err := c.loadAzureYaml()
 	if err != nil {
 		slog.Debug("failed to load azure.yaml", "error", err)
-		yamlConfig = &azureYamlConfig{}
+		yamlConfig = &service.AzureYaml{}
 	}
 
 	// Discover resources
@@ -82,14 +80,14 @@ func (c *DiagnosticSettingsChecker) CheckAllServices(ctx context.Context) (*Diag
 
 	// If global logs.analytics is configured, all services are considered configured
 	// because azd queries logs directly from Log Analytics workspace
-	hasGlobalAnalytics := yamlConfig.hasGlobalLogsAnalytics()
+	hasGlobalAnalytics := hasGlobalLogsAnalytics(yamlConfig)
 
 	// Check each service
 	for serviceName, resource := range discoveryResult.Resources {
 		slog.Debug("checking diagnostic settings", "service", serviceName, "resourceId", resource.ResourceID, "hasGlobalAnalytics", hasGlobalAnalytics)
 
 		// If global analytics is configured or service has service-level analytics, it's configured
-		if hasGlobalAnalytics || yamlConfig.hasServiceLogsAnalytics(serviceName) {
+		if hasGlobalAnalytics || hasServiceLogsAnalytics(yamlConfig, serviceName) {
 			response.Services[serviceName] = &DiagnosticSettingsCheckResult{
 				Status:     DiagnosticSettingsConfigured,
 				ResourceID: resource.ResourceID,
@@ -364,60 +362,26 @@ func (c *DiagnosticSettingsChecker) CheckSingleService(ctx context.Context, serv
 	return c.checkDiagnosticSettings(ctx, serviceName, resource.ResourceID, discoveryResult.LogAnalyticsWorkspaceID), nil
 }
 
-// azureYamlConfig represents a minimal view of azure.yaml for checking logs.analytics configuration.
-type azureYamlConfig struct {
-	Services map[string]*serviceConfig `yaml:"services,omitempty"`
-	Logs     *logsConfig               `yaml:"logs,omitempty"`
-}
-
-// serviceConfig represents a minimal service definition.
-type serviceConfig struct {
-	Logs *serviceLogsConfig `yaml:"logs,omitempty"`
-}
-
-// logsConfig represents the project-level logs configuration.
-type logsConfig struct {
-	Analytics *analyticsConfig `yaml:"analytics,omitempty"`
-}
-
-// serviceLogsConfig represents service-level logs configuration.
-type serviceLogsConfig struct {
-	Analytics *analyticsConfig `yaml:"analytics,omitempty"`
-}
-
-// analyticsConfig represents either global or service-level analytics config.
-// We don't need the full structure, just to know if it exists.
-type analyticsConfig struct {
-	Workspace string `yaml:"workspace,omitempty"`
-}
-
 // loadAzureYaml loads the azure.yaml file from the project directory.
-func (c *DiagnosticSettingsChecker) loadAzureYaml() (*azureYamlConfig, error) {
-	yamlPath := filepath.Join(c.projectDir, "azure.yaml")
-
-	data, err := os.ReadFile(yamlPath)
+func (c *DiagnosticSettingsChecker) loadAzureYaml() (*service.AzureYaml, error) {
+	config, err := service.ParseAzureYaml(c.projectDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read azure.yaml: %w", err)
-	}
-
-	var config azureYamlConfig
-	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse azure.yaml: %w", err)
 	}
 
-	return &config, nil
+	return config, nil
 }
 
 // hasGlobalLogsAnalytics checks if global logs.analytics is configured.
-func (c *azureYamlConfig) hasGlobalLogsAnalytics() bool {
-	return c.Logs != nil && c.Logs.Analytics != nil
+func hasGlobalLogsAnalytics(config *service.AzureYaml) bool {
+	return config != nil && config.Logs != nil && config.Logs.Analytics != nil
 }
 
 // hasServiceLogsAnalytics checks if service-level logs.analytics is configured.
-func (c *azureYamlConfig) hasServiceLogsAnalytics(serviceName string) bool {
-	if c.Services != nil {
-		if service, ok := c.Services[serviceName]; ok {
-			return service.Logs != nil && service.Logs.Analytics != nil
+func hasServiceLogsAnalytics(config *service.AzureYaml, serviceName string) bool {
+	if config != nil && config.Services != nil {
+		if serviceConfig, ok := config.Services[serviceName]; ok {
+			return serviceConfig.Logs != nil && serviceConfig.Logs.Analytics != nil
 		}
 	}
 	return false

--- a/cli/src/internal/azure/query_builder.go
+++ b/cli/src/internal/azure/query_builder.go
@@ -19,6 +19,25 @@ const (
 	fieldMessage            = "Message"
 )
 
+type tableConfig struct {
+	filterColumn  string
+	messageColumn string
+}
+
+var tableConfigs = map[string]tableConfig{
+	"ContainerAppConsoleLogs_CL": {filterColumn: "ContainerAppName_s", messageColumn: "Log_s"},
+	"ContainerAppSystemLogs_CL":  {filterColumn: "ContainerAppName_s", messageColumn: "Log_s"},
+	"AppServiceConsoleLogs":      {filterColumn: "_ResourceId", messageColumn: "ResultDescription"},
+	"AppServiceHTTPLogs":         {filterColumn: "_ResourceId", messageColumn: "CsUriStem"},
+	"AppServicePlatformLogs":     {filterColumn: "_ResourceId", messageColumn: fieldMessage},
+	"AppServiceAppLogs":          {filterColumn: "_ResourceId", messageColumn: fieldMessage},
+	"FunctionAppLogs":            {filterColumn: "_ResourceId", messageColumn: fieldMessage},
+	"ContainerLogV2":             {filterColumn: "PodName", messageColumn: "LogMessage"},
+	"ContainerLog":               {filterColumn: "Name", messageColumn: "LogEntry"},
+	"ContainerInstanceLog_CL":    {filterColumn: "ContainerGroup_s", messageColumn: "Message_s"},
+	"KubeEvents":                 {filterColumn: "Name", messageColumn: fieldMessage},
+}
+
 // QueryBuilder helps construct KQL queries from table selections.
 type QueryBuilder struct {
 	tables      []string
@@ -144,24 +163,7 @@ func (qb *QueryBuilder) getServiceFilter(tableName string) string {
 
 // getServiceFilterColumn returns the column to filter by service name for a table.
 func getServiceFilterColumn(tableName string) string {
-	switch tableName {
-	case "ContainerAppConsoleLogs_CL", "ContainerAppSystemLogs_CL":
-		return "ContainerAppName_s"
-	case "AppServiceConsoleLogs", "AppServiceHTTPLogs", "AppServicePlatformLogs", "AppServiceAppLogs":
-		return "_ResourceId"
-	case "FunctionAppLogs":
-		return "_ResourceId"
-	case "ContainerLogV2":
-		return "PodName"
-	case "ContainerLog":
-		return "Name"
-	case "ContainerInstanceLog_CL":
-		return "ContainerGroup_s"
-	case "KubeEvents":
-		return "Name"
-	default:
-		return ""
-	}
+	return tableConfigs[tableName].filterColumn
 }
 
 // getProjectColumns returns the columns to project for a table.
@@ -192,30 +194,7 @@ func (qb *QueryBuilder) getProjectColumns(tableName string) string {
 
 // getMessageColumn returns the primary message column for a table.
 func getMessageColumn(tableName string) string {
-	switch tableName {
-	case "ContainerAppConsoleLogs_CL":
-		return "Log_s"
-	case "ContainerAppSystemLogs_CL":
-		return "Log_s"
-	case "AppServiceConsoleLogs":
-		return "ResultDescription"
-	case "AppServiceHTTPLogs":
-		return "CsUriStem"
-	case "AppServicePlatformLogs":
-		return fieldMessage
-	case "FunctionAppLogs":
-		return fieldMessage
-	case "ContainerLogV2":
-		return "LogMessage"
-	case "ContainerLog":
-		return "LogEntry"
-	case "ContainerInstanceLog_CL":
-		return "Message_s"
-	case "KubeEvents":
-		return fieldMessage
-	default:
-		return ""
-	}
+	return tableConfigs[tableName].messageColumn
 }
 
 // containsString checks if a slice contains a string.

--- a/cli/src/internal/azure/standalone_logs.go
+++ b/cli/src/internal/azure/standalone_logs.go
@@ -7,14 +7,14 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
-	"gopkg.in/yaml.v3"
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
 )
 
 // KQL query constants
@@ -36,11 +36,10 @@ type StandaloneLogsConfig struct {
 	Limit       int           // Max number of logs
 }
 
-// ServiceInfo holds information about a service for log querying.
-type ServiceInfo struct {
-	Name         string       // azure.yaml service name
+// standaloneLogService describes a service used for Azure log querying.
+type standaloneLogService struct {
+	serviceinfo.ServiceInfo
 	AzureName    string       // Azure resource name from SERVICE_*_NAME
-	Host         string       // azure.yaml host type
 	ResourceType ResourceType // Mapped resource type
 }
 
@@ -54,57 +53,44 @@ var HostToResourceType = map[string]ResourceType{
 }
 
 // getServicesFromAzureYAML reads azure.yaml and returns service info including host types.
-func getServicesFromAzureYAML(projectDir string) ([]ServiceInfo, error) {
-	azureYAMLPath := filepath.Join(projectDir, "azure.yaml")
-	content, err := os.ReadFile(azureYAMLPath)
+func getServicesFromAzureYAML(projectDir string) ([]standaloneLogService, error) {
+	config, err := service.ParseAzureYaml(projectDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read azure.yaml: %w", err)
-	}
-
-	var config struct {
-		Services map[string]struct {
-			Host string `yaml:"host"`
-		} `yaml:"services"`
-	}
-	if err := yaml.Unmarshal(content, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse azure.yaml: %w", err)
 	}
 
-	// Get service name mappings from env
 	serviceNameMap := getServiceNameMap(projectDir)
-
-	// Debug: log service name mapping
 	if os.Getenv("AZD_APP_DEBUG") == valTrue {
 		fmt.Fprintf(os.Stderr, "[DEBUG] Service name map from environment: %v\n", serviceNameMap)
 	}
 
-	services := make([]ServiceInfo, 0, len(config.Services))
+	services := make([]standaloneLogService, 0, len(config.Services))
 	for name, svc := range config.Services {
-		// Skip local-only services
 		if svc.Host == "local" || svc.Host == "" {
 			continue
 		}
 
-		info := ServiceInfo{
-			Name: name,
-			Host: svc.Host,
+		info := standaloneLogService{
+			ServiceInfo: serviceinfo.ServiceInfo{
+				Name:     name,
+				Host:     svc.Host,
+				Language: svc.Language,
+				Project:  svc.Project,
+			},
 		}
 
-		// Map host to resource type
 		if rt, ok := HostToResourceType[svc.Host]; ok {
 			info.ResourceType = rt
 		} else {
-			info.ResourceType = ResourceTypeContainerApp // default fallback
+			info.ResourceType = ResourceTypeContainerApp
 		}
 
-		// Get Azure resource name from env
 		if azureName, ok := serviceNameMap[strings.ToLower(name)]; ok {
 			info.AzureName = azureName
 		} else {
-			info.AzureName = name // fallback to azure.yaml name
+			info.AzureName = name
 		}
 
-		// Debug: log each service mapping
 		if os.Getenv("AZD_APP_DEBUG") == valTrue {
 			fmt.Fprintf(os.Stderr, "[DEBUG] Service %s: host=%s, resourceType=%s, azureName=%s\n",
 				name, svc.Host, info.ResourceType, info.AzureName)
@@ -230,13 +216,13 @@ func FetchAzureLogsStandalone(ctx context.Context, config StandaloneLogsConfig) 
 	if err != nil {
 		slog.Warn("Failed to read azure.yaml services", "error", err)
 		// Fall back to Container App only if we can't read azure.yaml
-		allServices = []ServiceInfo{{ResourceType: ResourceTypeContainerApp}}
+		allServices = []standaloneLogService{{ResourceType: ResourceTypeContainerApp}}
 	}
 
 	slog.Debug("Read azure.yaml services", "count", len(allServices), "services", allServices)
 
 	// Filter services if specific ones requested
-	var targetServices []ServiceInfo
+	var targetServices []standaloneLogService
 	if len(config.Services) > 0 {
 		serviceMap := make(map[string]bool)
 		for _, s := range config.Services {
@@ -253,7 +239,7 @@ func FetchAzureLogsStandalone(ctx context.Context, config StandaloneLogsConfig) 
 	}
 
 	// Group services by resource type
-	servicesByType := make(map[ResourceType][]ServiceInfo)
+	servicesByType := make(map[ResourceType][]standaloneLogService)
 	for _, svc := range targetServices {
 		servicesByType[svc.ResourceType] = append(servicesByType[svc.ResourceType], svc)
 	}
@@ -826,11 +812,11 @@ func StreamAzureLogsStandalone(ctx context.Context, config StreamConfig, logs ch
 	allServices, err := getServicesFromAzureYAML(config.ProjectDir)
 	if err != nil {
 		// Fall back to Container App only if we can't read azure.yaml
-		allServices = []ServiceInfo{{ResourceType: ResourceTypeContainerApp}}
+		allServices = []standaloneLogService{{ResourceType: ResourceTypeContainerApp}}
 	}
 
 	// Filter services if specific ones requested
-	var targetServices []ServiceInfo
+	var targetServices []standaloneLogService
 	if len(config.Services) > 0 {
 		serviceMap := make(map[string]bool)
 		for _, s := range config.Services {
@@ -846,7 +832,7 @@ func StreamAzureLogsStandalone(ctx context.Context, config StreamConfig, logs ch
 	}
 
 	// Group services by resource type
-	servicesByType := make(map[ResourceType][]ServiceInfo)
+	servicesByType := make(map[ResourceType][]standaloneLogService)
 	for _, svc := range targetServices {
 		servicesByType[svc.ResourceType] = append(servicesByType[svc.ResourceType], svc)
 	}
@@ -893,7 +879,7 @@ func StreamAzureLogsStandalone(ctx context.Context, config StreamConfig, logs ch
 }
 
 // fetchAndSendLogsMultiType fetches logs from multiple resource types and sends them to the channel.
-func fetchAndSendLogsMultiType(ctx context.Context, client *LogAnalyticsClient, servicesByType map[ResourceType][]ServiceInfo, _ time.Time, logs chan<- LogEntry, lastSeen *time.Time) error {
+func fetchAndSendLogsMultiType(ctx context.Context, client *LogAnalyticsClient, servicesByType map[ResourceType][]standaloneLogService, _ time.Time, logs chan<- LogEntry, lastSeen *time.Time) error {
 	// Use precise timestamp filtering instead of ago() to avoid duplicate fetches
 	// This queries: TimeGenerated > lastSeen instead of TimeGenerated > ago(Nm)
 
@@ -969,7 +955,7 @@ func fetchAndSendLogsMultiType(ctx context.Context, client *LogAnalyticsClient, 
 }
 
 // mapServiceNames remaps Azure resource names to logical service names from azure.yaml.
-func mapServiceNames(entries []LogEntry, services []ServiceInfo) []LogEntry {
+func mapServiceNames(entries []LogEntry, services []standaloneLogService) []LogEntry {
 	if len(entries) == 0 || len(services) == 0 {
 		return entries
 	}

--- a/cli/src/internal/common/loglevel.go
+++ b/cli/src/internal/common/loglevel.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"github.com/jongio/azd-app/cli/src/internal/azure"
+	"github.com/jongio/azd-app/cli/src/internal/service"
+)
+
+// ConvertAzureLogLevelToService converts azure log levels to service log levels.
+func ConvertAzureLogLevelToService(level azure.LogLevel) service.LogLevel {
+	switch level {
+	case azure.LogLevelInfo:
+		return service.LogLevelInfo
+	case azure.LogLevelWarn:
+		return service.LogLevelWarn
+	case azure.LogLevelError:
+		return service.LogLevelError
+	case azure.LogLevelDebug:
+		return service.LogLevelDebug
+	default:
+		return service.LogLevelInfo
+	}
+}

--- a/cli/src/internal/dashboard/azure_logs_conversion.go
+++ b/cli/src/internal/dashboard/azure_logs_conversion.go
@@ -3,21 +3,11 @@ package dashboard
 
 import (
 	"github.com/jongio/azd-app/cli/src/internal/azure"
+	"github.com/jongio/azd-app/cli/src/internal/common"
 	"github.com/jongio/azd-app/cli/src/internal/service"
 )
 
 // convertAzureLogLevel converts azure.LogLevel to service.LogLevel.
 func convertAzureLogLevel(azLevel azure.LogLevel) service.LogLevel {
-	switch azLevel {
-	case azure.LogLevelInfo:
-		return service.LogLevelInfo
-	case azure.LogLevelWarn:
-		return service.LogLevelWarn
-	case azure.LogLevelError:
-		return service.LogLevelError
-	case azure.LogLevelDebug:
-		return service.LogLevelDebug
-	default:
-		return service.LogLevelInfo
-	}
+	return common.ConvertAzureLogLevelToService(azLevel)
 }

--- a/cli/src/internal/dashboard/classifications.go
+++ b/cli/src/internal/dashboard/classifications.go
@@ -2,7 +2,6 @@ package dashboard
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 
@@ -19,19 +18,12 @@ var classificationsMu sync.RWMutex
 
 // loadAzureYaml loads and parses the azure.yaml file.
 func loadAzureYaml(projectDir string) (*service.AzureYaml, error) {
-	azureYamlPath := filepath.Join(projectDir, "azure.yaml")
-
-	data, err := os.ReadFile(azureYamlPath)
+	azureYaml, err := service.ParseAzureYaml(projectDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read azure.yaml: %w", err)
-	}
-
-	var azureYaml service.AzureYaml
-	if err := yaml.Unmarshal(data, &azureYaml); err != nil {
 		return nil, fmt.Errorf("failed to parse azure.yaml: %w", err)
 	}
 
-	return &azureYaml, nil
+	return azureYaml, nil
 }
 
 // saveAzureYaml saves the azure.yaml file atomically.

--- a/cli/src/internal/healthcheck/monitor.go
+++ b/cli/src/internal/healthcheck/monitor.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,7 +18,6 @@ import (
 	cache "github.com/patrickmn/go-cache"
 	"github.com/sony/gobreaker"
 	"golang.org/x/time/rate"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -278,18 +276,7 @@ func (m *HealthMonitor) Check(ctx context.Context, serviceFilter []string) (*Hea
 }
 
 func (m *HealthMonitor) loadAzureYaml() (*service.AzureYaml, error) {
-	azureYamlPath := filepath.Join(m.config.ProjectDir, "azure.yaml")
-	data, err := os.ReadFile(azureYamlPath)
-	if err != nil {
-		return nil, err
-	}
-
-	var azureYaml service.AzureYaml
-	if err := yaml.Unmarshal(data, &azureYaml); err != nil {
-		return nil, err
-	}
-
-	return &azureYaml, nil
+	return service.ParseAzureYaml(m.config.ProjectDir)
 }
 
 func (m *HealthMonitor) buildServiceList(azureYaml *service.AzureYaml, registeredServices []*registry.ServiceRegistryEntry) []serviceInfo {

--- a/cli/src/internal/rpc/azure.go
+++ b/cli/src/internal/rpc/azure.go
@@ -15,7 +15,7 @@ import (
 	v1 "github.com/jongio/azd-app/cli/src/gen/proto/azdapp/v1"
 	"github.com/jongio/azd-app/cli/src/gen/proto/azdapp/v1/azdappv1connect"
 	"github.com/jongio/azd-app/cli/src/internal/azure"
-	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-app/cli/src/internal/common"
 )
 
 // AzureHandler implements azdapp.v1.AzureService via the AzureService
@@ -278,28 +278,10 @@ func toProtoAzureLogEntry(e azure.LogEntry) *v1.LogEntry {
 	return &v1.LogEntry{
 		Service:   e.Service,
 		Message:   e.Message,
-		Level:     toProtoLogLevel(convertAzureLogLevelToService(e.Level)),
+		Level:     toProtoLogLevel(common.ConvertAzureLogLevelToService(e.Level)),
 		Timestamp: timestamppb.New(e.Timestamp),
 		Stream:    v1.LogStream_LOG_STREAM_STDOUT,
 		Source:    v1.LogSource_LOG_SOURCE_AZURE,
-	}
-}
-
-// convertAzureLogLevelToService duplicates dashboard/azure_logs_conversion.go
-// so the rpc package doesn't import the dashboard package (would create a
-// cycle: dashboard imports rpc to mount handlers).
-func convertAzureLogLevelToService(l azure.LogLevel) service.LogLevel {
-	switch l {
-	case azure.LogLevelInfo:
-		return service.LogLevelInfo
-	case azure.LogLevelWarn:
-		return service.LogLevelWarn
-	case azure.LogLevelError:
-		return service.LogLevelError
-	case azure.LogLevelDebug:
-		return service.LogLevelDebug
-	default:
-		return service.LogLevelInfo
 	}
 }
 

--- a/cli/src/internal/testing/orchestrator.go
+++ b/cli/src/internal/testing/orchestrator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jongio/azd-app/cli/src/internal/detector"
 	"github.com/jongio/azd-app/cli/src/internal/logging"
+	"github.com/jongio/azd-app/cli/src/internal/service"
 	"github.com/jongio/azd-core/security"
 	"gopkg.in/yaml.v3"
 )
@@ -72,10 +73,13 @@ type TestOrchestrator struct {
 
 // ServiceInfo represents a service with its test configuration.
 type ServiceInfo struct {
-	Name     string
-	Language string
-	Dir      string
-	Config   *ServiceTestConfig
+	Name      string
+	Host      string
+	Language  string
+	Framework string
+	Project   string
+	Dir       string
+	Config    *ServiceTestConfig
 }
 
 // NewTestOrchestrator creates a new test orchestrator.
@@ -131,6 +135,30 @@ func (o *TestOrchestrator) ValidateAllServices() []ServiceValidation {
 	return validations
 }
 
+func loadServiceTestConfigs(azureYamlPath string) (map[string]*ServiceTestConfig, error) {
+	// #nosec G304 -- Path validated by caller before invocation
+	data, err := os.ReadFile(azureYamlPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read azure.yaml: %w", err)
+	}
+
+	var config struct {
+		Services map[string]struct {
+			Test *ServiceTestConfig `yaml:"test"`
+		} `yaml:"services"`
+	}
+	// TODO: Replace this direct unmarshal once service.ParseAzureYaml exposes service test configuration.
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse azure.yaml test config: %w", err)
+	}
+
+	serviceTestConfigs := make(map[string]*ServiceTestConfig, len(config.Services))
+	for name, svc := range config.Services {
+		serviceTestConfigs[name] = svc.Test
+	}
+	return serviceTestConfigs, nil
+}
+
 // LoadServicesFromAzureYaml loads service information from azure.yaml.
 func (o *TestOrchestrator) LoadServicesFromAzureYaml(azureYamlPath string) error {
 	// Validate path
@@ -138,25 +166,15 @@ func (o *TestOrchestrator) LoadServicesFromAzureYaml(azureYamlPath string) error
 		return fmt.Errorf("invalid azure.yaml path: %w", err)
 	}
 
-	// Read azure.yaml
-	// #nosec G304 -- Path validated by security.ValidatePath above
-	data, err := os.ReadFile(azureYamlPath)
+	azureYamlDir := filepath.Dir(azureYamlPath)
+	azureYaml, err := service.ParseAzureYaml(azureYamlDir)
 	if err != nil {
-		return fmt.Errorf("failed to read azure.yaml: %w", err)
-	}
-
-	// Parse YAML
-	var azureYaml struct {
-		Services map[string]struct {
-			Language string             `yaml:"language"`
-			Project  string             `yaml:"project"`
-			Test     *ServiceTestConfig `yaml:"test"`
-			Config   map[string]any     `yaml:",inline"`
-		} `yaml:"services"`
-	}
-
-	if err := yaml.Unmarshal(data, &azureYaml); err != nil {
 		return fmt.Errorf("failed to parse azure.yaml: %w", err)
+	}
+
+	serviceTestConfigs, err := loadServiceTestConfigs(azureYamlPath)
+	if err != nil {
+		return err
 	}
 
 	if len(azureYaml.Services) == 0 {
@@ -164,7 +182,6 @@ func (o *TestOrchestrator) LoadServicesFromAzureYaml(azureYamlPath string) error
 	}
 
 	// Convert to ServiceInfo
-	azureYamlDir := filepath.Dir(azureYamlPath)
 	azureYamlDirAbs, err := filepath.Abs(azureYamlDir)
 	if err != nil {
 		return fmt.Errorf("failed to resolve azure.yaml directory: %w", err)
@@ -194,9 +211,11 @@ func (o *TestOrchestrator) LoadServicesFromAzureYaml(azureYamlPath string) error
 
 		o.services = append(o.services, ServiceInfo{
 			Name:     name,
+			Host:     svc.Host,
 			Language: svc.Language,
+			Project:  svc.Project,
 			Dir:      projectDir,
-			Config:   svc.Test,
+			Config:   serviceTestConfigs[name],
 		})
 	}
 


### PR DESCRIPTION
## Wave 4: Refactoring

### Issues Resolved
- **#274**: Code smell detection (5 findings)
- **#265**: Architecture review (2 bounded findings addressed)

### Code Smell Fixes (#274)
- **Consolidate ServiceInfo**: Reduced duplication across 5 files by importing from canonical \serviceinfo\ package
- **Centralize azure.yaml parsing**: Route callers through \service.ParseAzureYaml\ instead of independent \yaml.Unmarshal\ calls
- **DetectedProjects struct**: Replace 3-parameter data clump (\
odeProjects\, \pythonProjects\, \dotnetProjects\) with a single struct
- **Extract runReqsFix**: Break 205-line function into \parseReqs\, \checkPrerequisite\, \nsureDockerReq\ helpers
- **Replace parallel switches**: Convert \getServiceFilterColumn\/\getMessageColumn\ parallel switch statements into a single \	ableConfig\ map

### Architecture Fixes (#265, bounded scope)
- **Extract shared conversion**: Move duplicated \convertAzureLogLevelToService\ to \internal/common/loglevel.go\
- **Remove global state**: Make \cmdOrchestrator\ in \core.go\ injectable instead of package-level mutable

### Deferred (too risky for automated changes)
- Breaking up god packages (service/, dashboard/)
- Adding interfaces to major abstractions
- Filesystem abstraction layer
- Full dashboard-service decoupling

Closes #274, #265