### PR TITLE
fix: wave 5 - security hardening, CI permissions, and test health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: cli
@@ -29,6 +32,8 @@ jobs:
     name: Preflight Checks
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code
@@ -84,6 +89,8 @@ jobs:
     name: Build Dashboard
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -116,6 +123,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [dashboard]
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -197,6 +206,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dashboard]
     timeout-minutes: 30
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code
@@ -226,6 +237,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [preflight, test, lint, dashboard]
     timeout-minutes: 30
+    permissions:
+      contents: read
     
     defaults:
       run:
@@ -266,6 +279,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [preflight, test, dashboard]
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dashboard-dist
-          path: cli/dashboard/dist/
+          path: cli/src/internal/dashboard/dist/
           retention-days: 1
 
   test:
@@ -144,7 +144,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dashboard-dist
-          path: cli/dashboard/dist/
+          path: cli/src/internal/dashboard/dist/
 
       - name: Install Aspire CLI
         shell: pwsh
@@ -224,7 +224,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dashboard-dist
-          path: cli/dashboard/dist/
+          path: cli/src/internal/dashboard/dist/
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
@@ -259,7 +259,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dashboard-dist
-          path: cli/dashboard/dist/
+          path: cli/src/internal/dashboard/dist/
 
       - name: Build for multiple platforms
         run: |
@@ -301,7 +301,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dashboard-dist
-          path: cli/dashboard/dist/
+          path: cli/src/internal/dashboard/dist/
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,9 +46,8 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@dd677812177e0c29f9c970a6c58d8607ae1bfefd # v4
-        continue-on-error: true
         with:
-          upload: false
+          upload: always
 
       - name: Upload SARIF (if Code Scanning enabled)
         uses: github/codeql-action/upload-sarif@dd677812177e0c29f9c970a6c58d8607ae1bfefd # v4

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.pr.outputs.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || steps.pr.outputs.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     name: Preflight Checks
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code
@@ -94,6 +96,8 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/sync-demo-template.yml
+++ b/.github/workflows/sync-demo-template.yml
@@ -274,6 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: sync
     if: always() && needs.sync.result == 'success' && needs.sync.outputs.secret_configured == 'true'
+    timeout-minutes: 30
     
     steps:
       - name: Checkout synced demo repository

--- a/cli/dashboard/src/lib/log-utils.ts
+++ b/cli/dashboard/src/lib/log-utils.ts
@@ -168,11 +168,12 @@ function linkifyUrlsWithHtmlAware(
 
 /**
  * Sanitizes HTML to prevent XSS attacks.
- * Removes script tags and javascript: protocols.
+ * Removes dangerous tags, javascript: URLs, and inline event handlers.
  */
 function sanitizeHtml(html: string): string {
   return html
-    .replaceAll(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replaceAll(/<(script|iframe|object|embed|base|link)\b[^<]*(?:(?!<\/\1>)<[^<]*)*<\/\1>/gi, '')
+    .replaceAll(/<(iframe|object|embed|base|link)\b[^>]*\/?>/gi, '')
     .replaceAll(/javascript:/gi, '')
     .replaceAll(/on\w+=/gi, '')
 }

--- a/cli/extension.yaml
+++ b/cli/extension.yaml
@@ -3,6 +3,7 @@ namespace: app
 displayName: App Extension
 description: A collection of developer productivity commands for Azure Developer CLI
 usage: azd app <command> [options]
+# Keep this version aligned with the latest registry.json entry (currently 0.14.0).
 version: 0.14.0
 language: go
 capabilities:

--- a/cli/src/cmd/app/commands/reqs.go
+++ b/cli/src/cmd/app/commands/reqs.go
@@ -210,6 +210,60 @@ var toolAliases = map[string]string{
 	"azure-functions-core-tools": "func",
 }
 
+var allowedCustomPrereqCommands = map[string]struct{}{
+	"air":      {},
+	"aspire":   {},
+	"az":       {},
+	"azd":      {},
+	"cargo":    {},
+	toolDocker: {},
+	"dotnet":   {},
+	"func":     {},
+	"git":      {},
+	"go":       {},
+	"gradle":   {},
+	"java":     {},
+	"mvn":      {},
+	"node":     {},
+	"npm":      {},
+	"pip":      {},
+	"pipenv":   {},
+	"pnpm":     {},
+	"poetry":   {},
+	"python":   {},
+	"uv":       {},
+	"yarn":     {},
+}
+
+func normalizeAllowedCommandName(command string) string {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" || strings.ContainsAny(trimmed, `\\/`) {
+		return ""
+	}
+
+	name := strings.ToLower(filepath.Base(trimmed))
+	return strings.TrimSuffix(name, ".exe")
+}
+
+func isAllowedCustomPrereqCommand(command string) bool {
+	name := normalizeAllowedCommandName(command)
+	if name == "" {
+		return false
+	}
+	_, allowed := allowedCustomPrereqCommands[name]
+	return allowed
+}
+
+func validateCustomPrereqCommand(fieldName, command string) error {
+	if strings.TrimSpace(command) == "" {
+		return nil
+	}
+	if !isAllowedCustomPrereqCommand(command) {
+		return fmt.Errorf("invalid %s %q: only allowlisted tool commands are permitted", fieldName, command)
+	}
+	return nil
+}
+
 // installURLRegistry maps tool names to their installation page URLs.
 var installURLRegistry = map[string]string{
 	"node":     "https://nodejs.org/",
@@ -335,20 +389,31 @@ func NewPrerequisiteChecker() *PrerequisiteChecker {
 
 // Check checks a prerequisite and returns structured result.
 func (pc *PrerequisiteChecker) Check(prereq Prerequisite) ReqResult {
-	installed, version, isPodman := pc.getInstalledVersion(prereq)
-
 	// Resolve install URL (custom overrides built-in)
 	installURL := pc.getInstallURL(prereq)
 
 	result := ReqResult{
 		Name:       prereq.Name,
-		Installed:  installed,
-		Version:    version,
 		Required:   prereq.MinVersion,
 		Satisfied:  false,
-		IsPodman:   isPodman,
 		InstallURL: installURL,
 	}
+
+	if err := validateCustomPrereqCommand("command", prereq.Command); err != nil {
+		result.Message = err.Error()
+		return result
+	}
+	if prereq.CheckRunning {
+		if err := validateCustomPrereqCommand("runningCheckCommand", prereq.RunningCheckCommand); err != nil {
+			result.Message = err.Error()
+			return result
+		}
+	}
+
+	installed, version, isPodman := pc.getInstalledVersion(prereq)
+	result.Installed = installed
+	result.Version = version
+	result.IsPodman = isPodman
 
 	if !installed {
 		result.Message = "Not installed"
@@ -472,7 +537,7 @@ func (pc *PrerequisiteChecker) getToolConfig(prereq Prerequisite) ToolConfig {
 	// Check if custom configuration is provided in prerequisite
 	if prereq.Command != "" {
 		return ToolConfig{
-			Command:       prereq.Command,
+			Command:       normalizeAllowedCommandName(prereq.Command),
 			Args:          prereq.Args,
 			VersionPrefix: prereq.VersionPrefix,
 			VersionField:  prereq.VersionField,
@@ -523,7 +588,11 @@ func (pc *PrerequisiteChecker) checkIsRunning(prereq Prerequisite) bool {
 		}
 	}
 
-	// #nosec G204 -- Command and args come from azure.yaml running check configuration or default Docker check
+	if prereq.RunningCheckCommand != "" {
+		command = normalizeAllowedCommandName(command)
+	}
+
+	// #nosec G204 -- Command and args are validated against an allowlist or come from the built-in Docker check
 	cmd := exec.CommandContext(context.Background(), command, args...)
 	output, err := cmd.CombinedOutput()
 

--- a/cli/src/cmd/app/commands/reqs_test.go
+++ b/cli/src/cmd/app/commands/reqs_test.go
@@ -1083,56 +1083,38 @@ func TestCheckPrerequisiteWithRunningCheck(t *testing.T) {
 	}{
 		{
 			name: "installed and running",
-			prereq: func() Prerequisite {
-				versionCmd, versionArgs := shellCommand("echo 2.0.0")
-				runningCmd, runningArgs := shellCommand("echo running")
-				return Prerequisite{
-					Name:                 "test-tool",
-					MinVersion:           "1.0.0",
-					Command:              versionCmd,
-					Args:                 versionArgs,
-					CheckRunning:         true,
-					RunningCheckCommand:  runningCmd,
-					RunningCheckArgs:     runningArgs,
-					RunningCheckExpected: "running",
-				}
-			}(),
+			prereq: Prerequisite{
+				Name:                 "go",
+				MinVersion:           "1.0.0",
+				CheckRunning:         true,
+				RunningCheckCommand:  "go",
+				RunningCheckArgs:     []string{"version"},
+				RunningCheckExpected: "go version",
+			},
 			expected: true,
 		},
 		{
 			name: "installed but not running",
-			prereq: func() Prerequisite {
-				versionCmd, versionArgs := shellCommand("echo 2.0.0")
-				runningCmd, runningArgs := shellCommand("echo stopped")
-				return Prerequisite{
-					Name:                 "test-tool",
-					MinVersion:           "1.0.0",
-					Command:              versionCmd,
-					Args:                 versionArgs,
-					CheckRunning:         true,
-					RunningCheckCommand:  runningCmd,
-					RunningCheckArgs:     runningArgs,
-					RunningCheckExpected: "running", // Won't match
-				}
-			}(),
+			prereq: Prerequisite{
+				Name:                 "go",
+				MinVersion:           "1.0.0",
+				CheckRunning:         true,
+				RunningCheckCommand:  "go",
+				RunningCheckArgs:     []string{"version"},
+				RunningCheckExpected: "definitely-not-running",
+			},
 			expected: false,
 		},
 		{
 			name: "version too old but running",
-			prereq: func() Prerequisite {
-				versionCmd, versionArgs := shellCommand("echo 2.0.0")
-				runningCmd, runningArgs := shellCommand("echo running")
-				return Prerequisite{
-					Name:                 "test-tool",
-					MinVersion:           "3.0.0",
-					Command:              versionCmd,
-					Args:                 versionArgs,
-					CheckRunning:         true,
-					RunningCheckCommand:  runningCmd,
-					RunningCheckArgs:     runningArgs,
-					RunningCheckExpected: "running",
-				}
-			}(),
+			prereq: Prerequisite{
+				Name:                 "go",
+				MinVersion:           "999.0.0",
+				CheckRunning:         true,
+				RunningCheckCommand:  "go",
+				RunningCheckArgs:     []string{"version"},
+				RunningCheckExpected: "go version",
+			},
 			expected: false, // Version check should fail before running check
 		},
 	}

--- a/cli/src/internal/azure/query_builder_test.go
+++ b/cli/src/internal/azure/query_builder_test.go
@@ -13,6 +13,8 @@ const (
 )
 
 func TestNewQueryBuilder(t *testing.T) {
+	t.Parallel()
+
 	qb := NewQueryBuilder(testServiceName, testTimespan)
 
 	if qb == nil {
@@ -30,6 +32,8 @@ func TestNewQueryBuilder(t *testing.T) {
 }
 
 func TestQueryBuilder_WithTables(t *testing.T) {
+	t.Parallel()
+
 	qb := NewQueryBuilder("test-service", testTimespan)
 	tables := []string{"ContainerAppConsoleLogs_CL", "AppServiceConsoleLogs"}
 
@@ -47,6 +51,8 @@ func TestQueryBuilder_WithTables(t *testing.T) {
 }
 
 func TestQueryBuilder_Build_EmptyTables(t *testing.T) {
+	t.Parallel()
+
 	qb := NewQueryBuilder("test-service", testTimespan)
 
 	query := qb.Build()
@@ -57,6 +63,8 @@ func TestQueryBuilder_Build_EmptyTables(t *testing.T) {
 }
 
 func TestQueryBuilder_Build_SingleTable(t *testing.T) {
+	t.Parallel()
+
 	qb := NewQueryBuilder("test-service", testTimespan).
 		WithTables([]string{"ContainerAppConsoleLogs_CL"})
 
@@ -85,6 +93,8 @@ func TestQueryBuilder_Build_SingleTable(t *testing.T) {
 }
 
 func TestQueryBuilder_Build_SingleTable_NoServiceFilter(t *testing.T) {
+	t.Parallel()
+
 	qb := NewQueryBuilder("", "1h").
 		WithTables([]string{"AppServiceConsoleLogs"})
 
@@ -104,6 +114,8 @@ func TestQueryBuilder_Build_SingleTable_NoServiceFilter(t *testing.T) {
 }
 
 func TestQueryBuilder_Build_MultipleTablesUnion(t *testing.T) {
+	t.Parallel()
+
 	qb := NewQueryBuilder("test-service", testTimespan).
 		WithTables([]string{"ContainerAppConsoleLogs_CL", "ContainerAppSystemLogs_CL"})
 
@@ -132,6 +144,8 @@ func TestQueryBuilder_Build_MultipleTablesUnion(t *testing.T) {
 }
 
 func TestGetServiceFilterColumn(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		tableName string
 		want      string
@@ -149,7 +163,9 @@ func TestGetServiceFilterColumn(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.tableName, func(t *testing.T) {
+			t.Parallel()
 			got := getServiceFilterColumn(tt.tableName)
 			if got != tt.want {
 				t.Errorf("getServiceFilterColumn(%q) = %q, want %q", tt.tableName, got, tt.want)
@@ -159,6 +175,8 @@ func TestGetServiceFilterColumn(t *testing.T) {
 }
 
 func TestGetMessageColumn(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		tableName string
 		want      string
@@ -177,7 +195,9 @@ func TestGetMessageColumn(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.tableName, func(t *testing.T) {
+			t.Parallel()
 			got := getMessageColumn(tt.tableName)
 			if got != tt.want {
 				t.Errorf("getMessageColumn(%q) = %q, want %q", tt.tableName, got, tt.want)
@@ -187,6 +207,8 @@ func TestGetMessageColumn(t *testing.T) {
 }
 
 func TestGetProjectColumns(t *testing.T) {
+	t.Parallel()
+
 	qb := NewQueryBuilder("test-service", testTimespan)
 
 	// Test with known table
@@ -212,6 +234,8 @@ func TestGetProjectColumns(t *testing.T) {
 }
 
 func TestContainsString(t *testing.T) {
+	t.Parallel()
+
 	slice := []string{"apple", "banana", "cherry"}
 
 	if !containsString(slice, "banana") {
@@ -226,6 +250,8 @@ func TestContainsString(t *testing.T) {
 }
 
 func TestBuildQueryFromTables(t *testing.T) {
+	t.Parallel()
+
 	tables := []string{"ContainerAppConsoleLogs_CL"}
 	query := BuildQueryFromTables(tables, "test-service", "1h")
 
@@ -245,6 +271,8 @@ func TestBuildQueryFromTables(t *testing.T) {
 }
 
 func TestBuildQueryFromTables_MultipleServices(t *testing.T) {
+	t.Parallel()
+
 	tables := []string{"AppServiceConsoleLogs", "AppServiceHTTPLogs"}
 	query := BuildQueryFromTables(tables, "my-app", testTimespan)
 
@@ -264,6 +292,8 @@ func TestBuildQueryFromTables_MultipleServices(t *testing.T) {
 }
 
 func TestSubstitutePlaceholders(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		query       string
@@ -302,7 +332,9 @@ func TestSubstitutePlaceholders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := SubstitutePlaceholders(tt.query, tt.serviceName, tt.timespan)
 
 			for _, want := range tt.wantContain {
@@ -323,6 +355,8 @@ func TestSubstitutePlaceholders(t *testing.T) {
 }
 
 func TestSubstitutePlaceholders_SanitizeServiceName(t *testing.T) {
+	t.Parallel()
+
 	// Service names should be sanitized to prevent KQL injection
 	query := "MyTable | where Service == '{serviceName}'"
 	serviceName := "test'; drop table--"
@@ -349,6 +383,8 @@ func TestSubstitutePlaceholders_SanitizeServiceName(t *testing.T) {
 }
 
 func TestQueryBuilder_Build_DifferentResourceTypes(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		table       string
@@ -388,7 +424,9 @@ func TestQueryBuilder_Build_DifferentResourceTypes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			qb := NewQueryBuilder(tt.serviceName, testTimespan).
 				WithTables([]string{tt.table})
 
@@ -402,6 +440,8 @@ func TestQueryBuilder_Build_DifferentResourceTypes(t *testing.T) {
 }
 
 func TestQueryBuilder_Build_ResultLimit(t *testing.T) {
+	t.Parallel()
+
 	qb := NewQueryBuilder("test-service", testTimespan).
 		WithTables([]string{"ContainerAppConsoleLogs_CL"})
 
@@ -414,6 +454,8 @@ func TestQueryBuilder_Build_ResultLimit(t *testing.T) {
 }
 
 func TestQueryBuilder_Build_TimeOrdering(t *testing.T) {
+	t.Parallel()
+
 	qb := NewQueryBuilder("test-service", testTimespan).
 		WithTables([]string{"ContainerAppConsoleLogs_CL"})
 

--- a/cli/src/internal/monitor/state_monitor_test.go
+++ b/cli/src/internal/monitor/state_monitor_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jongio/azd-core/registry"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewStateMonitor(t *testing.T) {
@@ -53,9 +54,6 @@ func TestStateMonitor_StartStop(t *testing.T) {
 
 	monitor := NewStateMonitor(reg, config)
 	monitor.Start()
-
-	// Let it run for a bit
-	time.Sleep(250 * time.Millisecond)
 
 	// Stop should not hang
 	done := make(chan bool)
@@ -124,8 +122,10 @@ func TestStateMonitor_DetectProcessCrash(t *testing.T) {
 	monitor.Start()
 	defer monitor.Stop()
 
-	// Wait for initial state capture
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		_, exists := monitor.GetCurrentState("test-service")
+		return exists
+	}, time.Second, 50*time.Millisecond)
 
 	// Kill the process
 	if err := cmd.Process.Kill(); err != nil {
@@ -137,27 +137,18 @@ func TestStateMonitor_DetectProcessCrash(t *testing.T) {
 		t.Fatalf("Failed to kill test process: %v", err)
 	}
 
-	// Wait for monitor to detect the crash
-	time.Sleep(500 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		transitionMu.Lock()
+		defer transitionMu.Unlock()
 
-	// Check if crash was detected
-	transitionMu.Lock()
-	defer transitionMu.Unlock()
-
-	found := false
-	for _, trans := range transitions {
-		if trans.Severity == SeverityCritical && trans.ServiceName == "test-service" {
-			found = true
-			if trans.Description == "" {
-				t.Error("Transition description is empty")
+		for _, trans := range transitions {
+			if trans.Severity == SeverityCritical && trans.ServiceName == "test-service" {
+				return trans.Description != ""
 			}
-			t.Logf("Detected transition: %s", trans.Description)
 		}
-	}
 
-	if !found {
-		t.Error("Process crash was not detected")
-	}
+		return false
+	}, time.Second, 50*time.Millisecond, "process crash was not detected")
 }
 
 func TestStateMonitor_DetectHealthChange(t *testing.T) {
@@ -194,34 +185,30 @@ func TestStateMonitor_DetectHealthChange(t *testing.T) {
 	monitor.Start()
 	defer monitor.Stop()
 
-	// Wait for initial state
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		_, exists := monitor.GetCurrentState("test-service")
+		return exists
+	}, time.Second, 50*time.Millisecond)
 
 	// Change status to error (health changes are now tracked via health stream, not registry)
 	if err := reg.UpdateStatus("test-service", "error"); err != nil {
 		t.Fatalf("Failed to update status: %v", err)
 	}
 
-	// Wait for detection
-	time.Sleep(300 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		transitionMu.Lock()
+		defer transitionMu.Unlock()
 
-	// Check transitions - now we detect status change instead of health change
-	transitionMu.Lock()
-	defer transitionMu.Unlock()
-
-	found := false
-	for _, trans := range transitions {
-		if trans.Severity == SeverityCritical &&
-			trans.ServiceName == "test-service" &&
-			trans.ToState.Status == "error" {
-			found = true
-			t.Logf("Detected status change: %s", trans.Description)
+		for _, trans := range transitions {
+			if trans.Severity == SeverityCritical &&
+				trans.ServiceName == "test-service" &&
+				trans.ToState.Status == "error" {
+				return true
+			}
 		}
-	}
 
-	if !found {
-		t.Error("Status change was not detected")
-	}
+		return false
+	}, time.Second, 50*time.Millisecond, "status change was not detected")
 }
 
 func TestStateMonitor_DetectStatusChange(t *testing.T) {
@@ -256,30 +243,28 @@ func TestStateMonitor_DetectStatusChange(t *testing.T) {
 	monitor.Start()
 	defer monitor.Stop()
 
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		_, exists := monitor.GetCurrentState("test-service")
+		return exists
+	}, time.Second, 50*time.Millisecond)
 
 	// Change status to error
 	if err := reg.UpdateStatus("test-service", "error"); err != nil {
 		t.Fatalf("Failed to update status: %v", err)
 	}
 
-	time.Sleep(300 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		transitionMu.Lock()
+		defer transitionMu.Unlock()
 
-	transitionMu.Lock()
-	defer transitionMu.Unlock()
-
-	found := false
-	for _, trans := range transitions {
-		if trans.Severity == SeverityCritical &&
-			trans.ToState.Status == "error" {
-			found = true
-			t.Logf("Detected status change: %s", trans.Description)
+		for _, trans := range transitions {
+			if trans.Severity == SeverityCritical && trans.ToState.Status == "error" {
+				return true
+			}
 		}
-	}
 
-	if !found {
-		t.Error("Status change to error was not detected")
-	}
+		return false
+	}, time.Second, 50*time.Millisecond, "status change to error was not detected")
 }
 
 func TestStateMonitor_RateLimiting(t *testing.T) {
@@ -314,7 +299,10 @@ func TestStateMonitor_RateLimiting(t *testing.T) {
 	monitor.Start()
 	defer monitor.Stop()
 
-	time.Sleep(100 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		_, exists := monitor.GetCurrentState("test-service")
+		return exists
+	}, time.Second, 50*time.Millisecond)
 
 	// Trigger multiple warning transitions rapidly
 	// These should be rate limited
@@ -498,24 +486,21 @@ func TestStateMonitor_MultipleListeners(t *testing.T) {
 	monitor.Start()
 	defer monitor.Stop()
 
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		_, exists := monitor.GetCurrentState("test-service")
+		return exists
+	}, time.Second, 50*time.Millisecond)
 
 	// Trigger transition
 	if err := reg.UpdateStatus("test-service", "error"); err != nil {
 		t.Fatalf("Failed to update status: %v", err)
 	}
 
-	time.Sleep(300 * time.Millisecond)
-
-	mu.Lock()
-	defer mu.Unlock()
-
-	if !listener1Called {
-		t.Error("Listener 1 was not called")
-	}
-	if !listener2Called {
-		t.Error("Listener 2 was not called")
-	}
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return listener1Called && listener2Called
+	}, time.Second, 50*time.Millisecond, "expected all listeners to be called")
 }
 
 func TestStateMonitor_HistoryLimit(t *testing.T) {

--- a/cli/src/internal/notifications/pipeline_test.go
+++ b/cli/src/internal/notifications/pipeline_test.go
@@ -45,7 +45,11 @@ func TestPipeline(t *testing.T) {
 		err := pipeline.Publish(event)
 		require.NoError(t, err)
 
-		time.Sleep(100 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return len(handled) == 1
+		}, time.Second, 20*time.Millisecond)
 		mu.Lock()
 		require.Len(t, handled, 1)
 		assert.Equal(t, "api", handled[0].ServiceName)
@@ -83,7 +87,9 @@ func TestPipeline(t *testing.T) {
 		}
 
 		_ = pipeline.Publish(event)
-		time.Sleep(100 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			return count1.Load() == 1 && count2.Load() == 1
+		}, time.Second, 20*time.Millisecond)
 
 		assert.Equal(t, int32(1), count1.Load())
 		assert.Equal(t, int32(1), count2.Load())
@@ -134,9 +140,11 @@ func TestOSNotificationHandler(t *testing.T) {
 		assert.Equal(t, 1, notifier.sendCount)
 
 		// After rate limit period, should go through
-		time.Sleep(1 * time.Second)
-		err = handler.Handle(ctx, event)
-		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			err = handler.Handle(ctx, event)
+			require.NoError(t, err)
+			return notifier.sendCount == 2
+		}, 2*time.Second, 50*time.Millisecond)
 		assert.Equal(t, 2, notifier.sendCount)
 	})
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,13 +15,11 @@ coverage:
         informational: false
 
     # Patch coverage - new code in PRs
-    # Set to informational to prevent blocking PRs on coverage
-    # Many code paths require integration tests with external dependencies (azd CLI)
     patch:
       default:
-        target: 50%  # Target 50% for new code
-        threshold: 10%  # Allow variance
-        informational: true  # Don't fail PRs, just report
+        target: 60%  # Enforce meaningful coverage for new code
+        threshold: 5%  # Allow limited variance
+        informational: false
 
 comment:
   layout: "header, diff, flags, files"


### PR DESCRIPTION
## Wave 5: Security, CI, and Test Health

### Issues Resolved
- **#270**: Full quality audit (unique security/CI findings)
- **#275**: Test health improvements

### Security Fixes (#270)
- **CRITICAL**: Fix \pr-build.yml\ \pull_request_target\ vulnerability (checkout uses base SHA now)
- **CRITICAL**: Add command allowlist in \eqs.go\ for \xec.CommandContext\ calls
- **HIGH**: Harden dashboard \sanitizeHtml()\ to block \<iframe>\, \<object>\, \<embed>\, \<base>\, \<link>\
- **HIGH**: Fix CodeQL workflow: remove \continue-on-error\, enable SARIF upload
- **HIGH**: Add explicit \permissions: contents: read\ to ci.yml and release.yml jobs

### CI/Config Fixes (#270)
- Pin \govulncheck\ to \@v1.1.4\ in scheduled workflow
- Enforce codecov patch coverage at 60% (was informational-only)
- Add \	imeout-minutes: 30\ to sync-demo-template smoke-test
- Note extension.yaml vs registry.json version discrepancy

### Test Health (#275)
- Replace \	ime.Sleep\ with \equire.Eventually\ in state_monitor_test.go and pipeline_test.go
- Add \	.Parallel()\ to table-driven tests in logbuffer_context_test.go and query_builder_test.go

### Deferred (requires manual review)
- Remaining 37 test files with time.Sleep (incremental improvement)
- Adding missing test coverage for service_process.go, detector_commands.go
- Raising codecov coverage threshold (currently 40% floor)

Closes #270, #275