### PR TITLE
fix: remove dead code and exclude node_modules from linter

### DIFF
--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -13,3 +13,6 @@ linters:
     - unused
     - ineffassign
     - misspell
+  exclusions:
+    paths:
+      - dashboard/node_modules

--- a/cli/src/cmd/app/commands/core_helpers.go
+++ b/cli/src/cmd/app/commands/core_helpers.go
@@ -376,16 +376,7 @@ func cleanDirectory(path string) error {
 	return nil
 }
 
-// readFileSecure reads a file with security validation.
-// #nosec G304 -- Called after security validation
-func readFileSecure(path string) ([]byte, error) {
-	return os.ReadFile(path)
-}
 
-// unmarshalYaml unmarshals YAML data into a struct.
-func unmarshalYaml(data []byte, v any) error {
-	return yaml.Unmarshal(data, v)
-}
 
 // detectAllProjects detects all project types in the given directory.
 // This is a convenience wrapper for testing and backward compatibility.


### PR DESCRIPTION
## Changes

- Remove unused readFileSecure and unmarshalYaml functions from core_helpers.go (leftover from wave 4 centralized parsing refactor)
- Add dashboard/node_modules path exclusion to .golangci.yml to prevent false govet warnings from third-party Go files

## Verification

- Go build: clean
- Go tests: all pass
- golangci-lint: 0 issues
- Dashboard build: clean
- Dashboard tests: 1349/1349 pass
- ESLint: clean
- tsc --noEmit: clean
- govulncheck: no vulnerabilities