### PR TITLE
fix: propagate context through installer and test runner for proper cancellation

### DIFF
--- a/cli/src/internal/installer/installer.go
+++ b/cli/src/internal/installer/installer.go
@@ -23,11 +23,11 @@ import (
 
 // InstallNodeDependencies installs dependencies using the detected package manager.
 func InstallNodeDependencies(project types.NodeProject) error {
-	return installNodeDependenciesWithWriter(project, nil)
+	return installNodeDependenciesWithContext(context.Background(), project, nil)
 }
 
-// installNodeDependenciesWithWriter installs dependencies with optional writer for progress tracking.
-func installNodeDependenciesWithWriter(project types.NodeProject, progressWriter io.Writer) error {
+// installNodeDependenciesWithContext installs dependencies with context for cancellation support.
+func installNodeDependenciesWithContext(ctx context.Context, project types.NodeProject, progressWriter io.Writer) error {
 	// Validate inputs
 	if err := security.ValidatePath(project.Dir); err != nil {
 		return fmt.Errorf("invalid project directory: %w", err)
@@ -87,9 +87,9 @@ func installNodeDependenciesWithWriter(project types.NodeProject, progressWriter
 	if runtime.GOOS == "windows" {
 		// Use cmd.exe /c to properly invoke .cmd files
 		cmdArgs := append([]string{"/c", project.PackageManager}, args...)
-		cmd = exec.CommandContext(context.Background(), "cmd.exe", cmdArgs...)
+		cmd = exec.CommandContext(ctx, "cmd.exe", cmdArgs...)
 	} else {
-		cmd = exec.CommandContext(context.Background(), project.PackageManager, args...)
+		cmd = exec.CommandContext(ctx, project.PackageManager, args...)
 	}
 
 	cmd.Dir = project.Dir
@@ -120,7 +120,7 @@ func installNodeDependenciesWithWriter(project types.NodeProject, progressWriter
 	}
 
 	// Run with retry logic for Windows file locking errors
-	err := runWithRetry(cmd, &stderrBuf, 3)
+	err := runWithRetry(ctx, cmd, &stderrBuf, 3)
 	if err != nil {
 		return formatNodeInstallError(project.PackageManager, project.Dir, cmd, err, stderrBuf.String())
 	}
@@ -133,11 +133,11 @@ func installNodeDependenciesWithWriter(project types.NodeProject, progressWriter
 
 // RestoreDotnetProject runs dotnet restore on a project.
 func RestoreDotnetProject(project types.DotnetProject) error {
-	return restoreDotnetProjectWithWriter(project, nil)
+	return restoreDotnetProjectWithContext(context.Background(), project, nil)
 }
 
-// restoreDotnetProjectWithWriter runs dotnet restore with optional progress writer.
-func restoreDotnetProjectWithWriter(project types.DotnetProject, progressWriter io.Writer) error {
+// restoreDotnetProjectWithContext runs dotnet restore with context for cancellation.
+func restoreDotnetProjectWithContext(ctx context.Context, project types.DotnetProject, progressWriter io.Writer) error {
 	// Validate path
 	if err := security.ValidatePath(project.Path); err != nil {
 		return fmt.Errorf("invalid project path: %w", err)
@@ -149,7 +149,7 @@ func restoreDotnetProjectWithWriter(project types.DotnetProject, progressWriter 
 
 	// Run restore with streaming output
 	dir := filepath.Dir(project.Path)
-	cmd := exec.CommandContext(context.Background(), "dotnet", "restore", project.Path)
+	cmd := exec.CommandContext(ctx, "dotnet", "restore", project.Path)
 	cmd.Dir = dir
 
 	// Capture stderr for error reporting
@@ -181,31 +181,31 @@ func restoreDotnetProjectWithWriter(project types.DotnetProject, progressWriter 
 
 // SetupPythonVirtualEnv creates a virtual environment and installs dependencies.
 func SetupPythonVirtualEnv(project types.PythonProject) error {
-	return setupPythonVirtualEnvWithWriter(project, nil)
+	return setupPythonVirtualEnvWithContext(context.Background(), project, nil)
 }
 
-// setupPythonVirtualEnvWithWriter creates a virtual environment with optional progress writer.
-func setupPythonVirtualEnvWithWriter(project types.PythonProject, progressWriter io.Writer) error {
+// setupPythonVirtualEnvWithContext creates a virtual environment with context for cancellation.
+func setupPythonVirtualEnvWithContext(ctx context.Context, project types.PythonProject, progressWriter io.Writer) error {
 	switch project.PackageManager {
 	case "uv":
-		return setupWithUv(project.Dir, progressWriter)
+		return setupWithUv(ctx, project.Dir, progressWriter)
 	case "poetry":
-		return setupWithPoetry(project.Dir, progressWriter)
+		return setupWithPoetry(ctx, project.Dir, progressWriter)
 	case "pip":
-		return setupWithPip(project.Dir, progressWriter)
+		return setupWithPip(ctx, project.Dir, progressWriter)
 	default:
 		return fmt.Errorf("unknown package manager '%s' for Python project in %s", project.PackageManager, project.Dir)
 	}
 }
 
 // setupWithUv sets up a Python project using uv.
-func setupWithUv(projectDir string, progressWriter io.Writer) error {
+func setupWithUv(ctx context.Context, projectDir string, progressWriter io.Writer) error {
 	// Check if uv is installed
 	if _, err := exec.LookPath("uv"); err != nil {
 		if !cliout.IsJSON() && progressWriter == nil {
 			cliout.ItemWarning("uv not found, falling back to pip")
 		}
-		return setupWithPip(projectDir, progressWriter)
+		return setupWithPip(ctx, projectDir, progressWriter)
 	}
 
 	// uv automatically manages virtual environments
@@ -214,7 +214,7 @@ func setupWithUv(projectDir string, progressWriter io.Writer) error {
 		cliout.Item("Installing dependencies into .venv (uv)...")
 	}
 
-	cmd := exec.CommandContext(context.Background(), "uv", "sync", "--no-progress")
+	cmd := exec.CommandContext(ctx, "uv", "sync", "--no-progress")
 	cmd.Dir = projectDir
 	cmd.Env = os.Environ() // Inherit azd context (AZD_SERVER, AZD_ACCESS_TOKEN, AZURE_*)
 
@@ -237,7 +237,7 @@ func setupWithUv(projectDir string, progressWriter io.Writer) error {
 			if !cliout.IsJSON() && progressWriter == nil {
 				cliout.Item("Creating virtual environment at .venv (uv)...")
 			}
-			venvCmd := exec.CommandContext(context.Background(), "uv", "venv")
+			venvCmd := exec.CommandContext(ctx, "uv", "venv")
 			venvCmd.Dir = projectDir
 			venvCmd.Env = os.Environ() // Inherit azd context (AZD_SERVER, AZD_ACCESS_TOKEN, AZURE_*)
 
@@ -261,7 +261,7 @@ func setupWithUv(projectDir string, progressWriter io.Writer) error {
 			if !cliout.IsJSON() && progressWriter == nil {
 				cliout.Item("Installing dependencies into .venv (uv pip)...")
 			}
-			installCmd := exec.CommandContext(context.Background(), "uv", "pip", "install", "-r", "requirements.txt", "--no-progress")
+			installCmd := exec.CommandContext(ctx, "uv", "pip", "install", "-r", "requirements.txt", "--no-progress")
 			installCmd.Dir = projectDir
 			installCmd.Env = os.Environ() // Inherit azd context (AZD_SERVER, AZD_ACCESS_TOKEN, AZURE_*)
 
@@ -292,17 +292,17 @@ func setupWithUv(projectDir string, progressWriter io.Writer) error {
 }
 
 // setupWithPoetry sets up a Python project using poetry.
-func setupWithPoetry(projectDir string, progressWriter io.Writer) error {
+func setupWithPoetry(ctx context.Context, projectDir string, progressWriter io.Writer) error {
 	// Check if poetry is installed
 	if _, err := exec.LookPath("poetry"); err != nil {
 		if !cliout.IsJSON() && progressWriter == nil {
 			cliout.ItemWarning("poetry not found, falling back to pip")
 		}
-		return setupWithPip(projectDir, progressWriter)
+		return setupWithPip(ctx, projectDir, progressWriter)
 	}
 
 	// Check if virtual environment exists
-	checkCmd := exec.CommandContext(context.Background(), "poetry", "env", "info", "--path")
+	checkCmd := exec.CommandContext(ctx, "poetry", "env", "info", "--path")
 	checkCmd.Dir = projectDir
 	checkCmd.Env = os.Environ() // Inherit azd context (AZD_SERVER, AZD_ACCESS_TOKEN, AZURE_*)
 	cmdOutput, err := checkCmd.CombinedOutput()
@@ -320,7 +320,7 @@ func setupWithPoetry(projectDir string, progressWriter io.Writer) error {
 	}
 
 	// Install dependencies (use --no-root to avoid installing the package itself)
-	cmd := exec.CommandContext(context.Background(), "poetry", "install", "--no-root")
+	cmd := exec.CommandContext(ctx, "poetry", "install", "--no-root")
 	cmd.Dir = projectDir
 	cmd.Env = os.Environ() // Inherit azd context (AZD_SERVER, AZD_ACCESS_TOKEN, AZURE_*)
 
@@ -347,7 +347,7 @@ func setupWithPoetry(projectDir string, progressWriter io.Writer) error {
 }
 
 // setupWithPip sets up a Python project using pip and venv.
-func setupWithPip(projectDir string, progressWriter io.Writer) error {
+func setupWithPip(ctx context.Context, projectDir string, progressWriter io.Writer) error {
 	venvPath := filepath.Join(projectDir, ".venv")
 
 	// Check if venv already exists, create if not
@@ -357,7 +357,7 @@ func setupWithPip(projectDir string, progressWriter io.Writer) error {
 		}
 
 		// Create virtual environment
-		cmd := exec.CommandContext(context.Background(), "python", "-m", "venv", ".venv")
+		cmd := exec.CommandContext(ctx, "python", "-m", "venv", ".venv")
 		cmd.Dir = projectDir
 		cmd.Env = os.Environ() // Inherit azd context (AZD_SERVER, AZD_ACCESS_TOKEN, AZURE_*)
 
@@ -397,7 +397,7 @@ func setupWithPip(projectDir string, progressWriter io.Writer) error {
 		}
 
 		// Run pip install with streaming output and optimizations
-		pipCmd := exec.CommandContext(context.Background(), pipPath, "install", "-r", "requirements.txt", "--disable-pip-version-check", "--prefer-binary")
+		pipCmd := exec.CommandContext(ctx, pipPath, "install", "-r", "requirements.txt", "--disable-pip-version-check", "--prefer-binary")
 		pipCmd.Dir = projectDir
 
 		var stderrBuf bytes.Buffer
@@ -788,7 +788,7 @@ func getPythonSuggestion(tool string, exitCode int, stderr string) string {
 // runWithRetry executes a command with retry logic for Windows file locking errors.
 // This is a safety net for race conditions in npm workspaces on Windows where
 // concurrent npm processes may compete for the same files.
-func runWithRetry(cmd *exec.Cmd, stderrBuf *bytes.Buffer, maxRetries int) error {
+func runWithRetry(ctx context.Context, cmd *exec.Cmd, stderrBuf *bytes.Buffer, maxRetries int) error {
 	var lastErr error
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
@@ -824,7 +824,7 @@ func runWithRetry(cmd *exec.Cmd, stderrBuf *bytes.Buffer, maxRetries int) error 
 			stderrBuf.Reset()
 
 			// Recreate the command for the next attempt (exec.Cmd can only be run once)
-			newCmd := exec.CommandContext(context.Background(), cmd.Path, cmd.Args[1:]...)
+			newCmd := exec.CommandContext(ctx, cmd.Path, cmd.Args[1:]...)
 			newCmd.Dir = cmd.Dir
 			newCmd.Env = cmd.Env
 			newCmd.Stdout = cmd.Stdout

--- a/cli/src/internal/installer/installer_test.go
+++ b/cli/src/internal/installer/installer_test.go
@@ -357,7 +357,7 @@ func TestSetupWithPip_ExistingVenv(t *testing.T) {
 	}
 
 	// Should return nil when venv exists
-	err := setupWithPip(tmpDir, nil)
+	err := setupWithPip(context.Background(), tmpDir, nil)
 	if err != nil {
 		t.Errorf("setupWithPip() with existing venv should not error: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestSetupWithPip_NoRequirementsTxt(t *testing.T) {
 
 	// Try to create venv without requirements.txt
 	// This will succeed if python is available
-	err := setupWithPip(tmpDir, nil)
+	err := setupWithPip(context.Background(), tmpDir, nil)
 
 	// We don't assert success/failure as it depends on python availability
 	// Just verify it doesn't panic
@@ -388,7 +388,7 @@ func TestSetupWithPoetry_EnvExists(t *testing.T) {
 
 	// This tests the path where poetry env info succeeds
 	// In practice, this requires poetry to be installed
-	err := setupWithPoetry(tmpDir, nil)
+	err := setupWithPoetry(context.Background(), tmpDir, nil)
 
 	// We expect this to either succeed or fallback to pip
 	// Just verify it doesn't panic
@@ -409,7 +409,7 @@ func TestSetupWithUv_NoUvInstalled(t *testing.T) {
 	}
 
 	// This will fallback to pip if uv is not installed
-	err := setupWithUv(tmpDir, nil)
+	err := setupWithUv(context.Background(), tmpDir, nil)
 
 	// We don't assert success/failure as it depends on tool availability
 	// Just verify it doesn't panic

--- a/cli/src/internal/installer/parallel.go
+++ b/cli/src/internal/installer/parallel.go
@@ -124,15 +124,15 @@ func (pi *ParallelInstaller) executeTask(task ProjectInstallTask, writer io.Writ
 	switch task.Type {
 	case "node":
 		if project, ok := task.Project.(types.NodeProject); ok {
-			return installNodeDependenciesWithWriter(project, writer)
+			return installNodeDependenciesWithContext(pi.ctx, project, writer)
 		}
 	case "python":
 		if project, ok := task.Project.(types.PythonProject); ok {
-			return setupPythonVirtualEnvWithWriter(project, writer)
+			return setupPythonVirtualEnvWithContext(pi.ctx, project, writer)
 		}
 	case "dotnet":
 		if project, ok := task.Project.(types.DotnetProject); ok {
-			return restoreDotnetProjectWithWriter(project, writer)
+			return restoreDotnetProjectWithContext(pi.ctx, project, writer)
 		}
 	}
 	return fmt.Errorf("unknown task type: %s", task.Type)

--- a/cli/src/internal/testing/dotnet_runner.go
+++ b/cli/src/internal/testing/dotnet_runner.go
@@ -36,7 +36,7 @@ func NewDotnetTestRunner(projectDir string, config *ServiceTestConfig) *DotnetTe
 }
 
 // RunTests executes tests for the .NET project.
-func (r *DotnetTestRunner) RunTests(testType string, coverage bool) (*TestResult, error) {
+func (r *DotnetTestRunner) RunTests(ctx context.Context, testType string, coverage bool) (*TestResult, error) {
 	result := &TestResult{
 		TestType: testType,
 		Success:  false,
@@ -46,7 +46,6 @@ func (r *DotnetTestRunner) RunTests(testType string, coverage bool) (*TestResult
 	command, args := r.buildTestCommand(testType, coverage)
 
 	// Execute the command
-	ctx := context.Background()
 	output, err := executor.RunCommandWithOutput(ctx, command, args, r.projectDir)
 
 	// Parse the output to extract results

--- a/cli/src/internal/testing/dotnet_runner_test.go
+++ b/cli/src/internal/testing/dotnet_runner_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -301,8 +302,7 @@ func TestDotnetRunnerRunTests_Integration(t *testing.T) {
 	}
 
 	runner := NewDotnetTestRunner(tmpDir, config)
-	result, err := runner.RunTests("unit", false)
-	// The command might fail if dotnet isn't installed, that's ok
+	result, err := runner.RunTests(context.Background(), "unit", false)
 	if err != nil {
 		t.Logf("RunTests returned error (expected in test env): %v", err)
 	}

--- a/cli/src/internal/testing/go_runner.go
+++ b/cli/src/internal/testing/go_runner.go
@@ -28,7 +28,7 @@ func NewGoTestRunner(projectDir string, config *ServiceTestConfig) *GoTestRunner
 }
 
 // RunTests executes tests for the Go project.
-func (r *GoTestRunner) RunTests(testType string, coverage bool) (*TestResult, error) {
+func (r *GoTestRunner) RunTests(ctx context.Context, testType string, coverage bool) (*TestResult, error) {
 	result := &TestResult{
 		TestType: testType,
 		Success:  false,
@@ -38,7 +38,6 @@ func (r *GoTestRunner) RunTests(testType string, coverage bool) (*TestResult, er
 	command, args := r.buildTestCommand(testType, coverage)
 
 	// Execute the command
-	ctx := context.Background()
 	output, err := executor.RunCommandWithOutput(ctx, command, args, r.projectDir)
 
 	// Parse the output to extract results

--- a/cli/src/internal/testing/node_runner.go
+++ b/cli/src/internal/testing/node_runner.go
@@ -50,7 +50,7 @@ func NewNodeTestRunner(projectDir string, config *ServiceTestConfig) *NodeTestRu
 }
 
 // RunTests executes tests for the Node.js project.
-func (r *NodeTestRunner) RunTests(testType string, coverage bool) (*TestResult, error) {
+func (r *NodeTestRunner) RunTests(ctx context.Context, testType string, coverage bool) (*TestResult, error) {
 	result := &TestResult{
 		TestType: testType,
 		Success:  false,
@@ -60,7 +60,6 @@ func (r *NodeTestRunner) RunTests(testType string, coverage bool) (*TestResult, 
 	command, args := r.buildTestCommand(testType, coverage)
 
 	// Execute the command
-	ctx := context.Background()
 	output, err := executor.RunCommandWithOutput(ctx, command, args, r.projectDir)
 
 	// Parse the output to extract results

--- a/cli/src/internal/testing/node_runner_test.go
+++ b/cli/src/internal/testing/node_runner_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -266,8 +267,7 @@ func TestNodeRunnerRunTests_Integration(t *testing.T) {
 	}
 
 	runner := NewNodeTestRunner(tmpDir, config)
-	result, err := runner.RunTests("unit", false)
-	// The command should execute (even if it's just echo)
+	result, err := runner.RunTests(context.Background(), "unit", false)
 	if err != nil {
 		// It's ok if it fails due to npm not being available
 		t.Logf("RunTests returned error (expected in test env): %v", err)

--- a/cli/src/internal/testing/orchestrator.go
+++ b/cli/src/internal/testing/orchestrator.go
@@ -626,21 +626,21 @@ func (o *TestOrchestrator) executeWithTimeout(runner TestRunner, testType string
 		err    error
 	}
 
-	// Create a context with timeout
+	// Create a context with timeout - cancellation propagates to the runner
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// Run tests in a goroutine
+	// Run tests in a goroutine with the cancellable context
 	resultChan := make(chan runResult, 1)
 	go func() {
-		result, err := runner.RunTests(testType, coverage)
+		result, err := runner.RunTests(ctx, testType, coverage)
 		resultChan <- runResult{result: result, err: err}
 	}()
 
 	// Wait for either completion or timeout
 	select {
 	case <-ctx.Done():
-		// Timeout exceeded
+		// Timeout exceeded - context cancellation will terminate the subprocess
 		return nil, fmt.Errorf("test execution timed out after %s", timeout)
 	case res := <-resultChan:
 		return res.result, res.err
@@ -649,7 +649,7 @@ func (o *TestOrchestrator) executeWithTimeout(runner TestRunner, testType string
 
 // TestRunner interface for language-specific test runners.
 type TestRunner interface {
-	RunTests(testType string, coverage bool) (*TestResult, error)
+	RunTests(ctx context.Context, testType string, coverage bool) (*TestResult, error)
 }
 
 // GetServicePaths returns the paths of all services for file watching.

--- a/cli/src/internal/testing/orchestrator_test.go
+++ b/cli/src/internal/testing/orchestrator_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1475,14 +1476,15 @@ type mockTestRunner struct {
 	started chan struct{}
 }
 
-func (m *mockTestRunner) RunTests(testType string, coverage bool) (*TestResult, error) {
+func (m *mockTestRunner) RunTests(ctx context.Context, testType string, coverage bool) (*TestResult, error) {
 	if m.started != nil {
 		close(m.started)
 	}
 	if m.delay > 0 {
-		// Use a select with time.After to simulate delay
+		// Use a select with context to respect cancellation during simulated delay
 		select {
-		case <-make(chan struct{}): // never closes
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		case <-func() <-chan struct{} {
 			ch := make(chan struct{})
 			go func() {

--- a/cli/src/internal/testing/python_runner.go
+++ b/cli/src/internal/testing/python_runner.go
@@ -35,7 +35,7 @@ func NewPythonTestRunner(projectDir string, config *ServiceTestConfig) *PythonTe
 }
 
 // RunTests executes tests for the Python project.
-func (r *PythonTestRunner) RunTests(testType string, coverage bool) (*TestResult, error) {
+func (r *PythonTestRunner) RunTests(ctx context.Context, testType string, coverage bool) (*TestResult, error) {
 	result := &TestResult{
 		TestType: testType,
 		Success:  false,
@@ -45,7 +45,6 @@ func (r *PythonTestRunner) RunTests(testType string, coverage bool) (*TestResult
 	command, args := r.buildTestCommand(testType, coverage)
 
 	// Execute the command
-	ctx := context.Background()
 	output, err := executor.RunCommandWithOutput(ctx, command, args, r.projectDir)
 
 	// Parse the output to extract results

--- a/cli/src/internal/testing/python_runner_test.go
+++ b/cli/src/internal/testing/python_runner_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -325,8 +326,7 @@ func TestPythonRunnerRunTests_Integration(t *testing.T) {
 	}
 
 	runner := NewPythonTestRunner(tmpDir, config)
-	result, err := runner.RunTests("unit", false)
-	// The command might fail if pytest isn't installed, that's ok
+	result, err := runner.RunTests(context.Background(), "unit", false)
 	if err != nil {
 		t.Logf("RunTests returned error (expected in test env): %v", err)
 	}


### PR DESCRIPTION
## Summary

Fixes goroutine/process leaks when timeouts fire in the test orchestrator and parallel installer.

### Changes

**TestRunner interface** (testing/orchestrator.go):
- Added ctx context.Context parameter to RunTests interface method
- executeWithTimeout now passes its context to the runner, so subprocess is actually killed on timeout

**Installer context propagation** (installer/):
- Added context-aware internal functions
- ParallelInstaller.executeTask passes pi.ctx through to all install functions
- Fixed runWithRetry to propagate context instead of using context.Background()
- Removed unused WithWriter wrapper functions (dead code)

### Testing
- go build ./... clean
- golangci-lint run ./... — 0 issues
- testing and installer package tests all pass
