### PR TITLE
fix: use relative timeout threshold in graceful shutdown test

### DIFF
--- a/cli/src/internal/service/graceful_shutdown_test.go
+++ b/cli/src/internal/service/graceful_shutdown_test.go
@@ -57,9 +57,10 @@ func TestStopServiceGraceful_Success(t *testing.T) {
 		t.Errorf("StopServiceGraceful() error = %v, want nil or 'Access is denied'", err)
 	}
 
-	// Should complete quickly (within timeout)
-	if elapsed > 6*time.Second {
-		t.Errorf("StopServiceGraceful() took %v, want < 6s", elapsed)
+	// Should complete within 2x the timeout to account for system load
+	maxExpected := 2 * constants.TestServiceTimeout
+	if elapsed > maxExpected {
+		t.Errorf("StopServiceGraceful() took %v, want < %v", elapsed, maxExpected)
 	}
 
 	// Give system time to fully clean up


### PR DESCRIPTION
Fixes flaky TestStopServiceGraceful_Success that failed on loaded systems (took 7.2s, hardcoded 6s threshold with 5s timeout). Now uses 2x the timeout constant as max expected duration.