### PR TITLE
refactor: MQ Wave 2 - lock contention, dedup, dead exports

### DIFF
--- a/cli/src/internal/installer/parallel.go
+++ b/cli/src/internal/installer/parallel.go
@@ -71,44 +71,35 @@ func (pi *ParallelInstaller) AddTask(task ProjectInstallTask) {
 
 // AddNodeProject adds a Node.js project installation task.
 func (pi *ParallelInstaller) AddNodeProject(project types.NodeProject) {
-	projectName := getProjectName(project.Dir)
-	task := ProjectInstallTask{
-		ID:          project.Dir,
-		Description: projectName + " (" + project.PackageManager + ")",
-		Type:        "node",
-		Dir:         project.Dir,
-		Manager:     project.PackageManager,
-		Project:     project,
-	}
-	pi.AddTask(task)
+	pi.AddTask(newProjectTask(project.Dir, project.PackageManager, "node", project))
 }
 
 // AddPythonProject adds a Python project installation task.
 func (pi *ParallelInstaller) AddPythonProject(project types.PythonProject) {
-	projectName := getProjectName(project.Dir)
-	task := ProjectInstallTask{
-		ID:          project.Dir,
-		Description: projectName + " (" + project.PackageManager + ")",
-		Type:        "python",
-		Dir:         project.Dir,
-		Manager:     project.PackageManager,
-		Project:     project,
-	}
-	pi.AddTask(task)
+	pi.AddTask(newProjectTask(project.Dir, project.PackageManager, "python", project))
 }
 
 // AddDotnetProject adds a .NET project installation task.
 func (pi *ParallelInstaller) AddDotnetProject(project types.DotnetProject) {
-	projectName := getProjectName(project.Path)
+	pi.AddTask(newProjectTask(project.Path, "dotnet", "dotnet", project))
+}
+
+// newProjectTask constructs a ProjectInstallTask with consistent description formatting.
+func newProjectTask(pathOrDir string, manager string, taskType string, project interface{}) ProjectInstallTask {
+	projectName := getProjectName(pathOrDir)
 	task := ProjectInstallTask{
-		ID:          project.Path,
-		Description: projectName + " (dotnet)",
-		Type:        "dotnet",
-		Path:        project.Path,
-		Manager:     "dotnet",
+		ID:          pathOrDir,
+		Description: projectName + " (" + manager + ")",
+		Type:        taskType,
+		Manager:     manager,
 		Project:     project,
 	}
-	pi.AddTask(task)
+	if taskType == "dotnet" {
+		task.Path = pathOrDir
+	} else {
+		task.Dir = pathOrDir
+	}
+	return task
 }
 
 // executeTask is the unified task execution logic.

--- a/cli/src/internal/service/logbuffer.go
+++ b/cli/src/internal/service/logbuffer.go
@@ -94,28 +94,26 @@ func (lb *LogBuffer) Add(entry LogEntry) {
 		return // Skip noisy log entry
 	}
 
+	// Hold the main lock only for the ring buffer update (fast, O(1))
 	lb.mu.Lock()
-	defer lb.mu.Unlock()
-
-	// Write into the ring buffer at the next position (O(1))
 	idx := (lb.head + lb.count) % lb.maxSize
 	if lb.count >= lb.maxSize {
-		// Buffer full: overwrite oldest, advance head
 		lb.entries[lb.head] = entry
 		lb.head = (lb.head + 1) % lb.maxSize
 	} else {
 		lb.entries[idx] = entry
 		lb.count++
 	}
+	lb.mu.Unlock()
 
-	// Write to file if enabled
+	// File I/O and broadcast happen outside the main lock to avoid
+	// blocking producers on disk latency or slow subscribers.
 	if lb.fileWriter != nil {
 		lb.fileMu.Lock()
 		lb.writeToFile(entry)
 		lb.fileMu.Unlock()
 	}
 
-	// Broadcast to subscribers
 	lb.broadcast(entry)
 }
 

--- a/cli/src/internal/service/service_process.go
+++ b/cli/src/internal/service/service_process.go
@@ -184,13 +184,16 @@ func StopServiceGraceful(process *ServiceProcess, timeout time.Duration) error {
 		done <- err
 	}()
 
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
 	select {
 	case err := <-done:
 		// Process exited within timeout
 		slog.Info("service stopped gracefully",
 			slog.String("service", process.Name))
 		return err
-	case <-time.After(timeout):
+	case <-timer.C:
 		// Timeout expired, force kill
 		slog.Warn("graceful shutdown timeout, forcing kill",
 			slog.String("service", process.Name),

--- a/cli/src/internal/testing/config_writer.go
+++ b/cli/src/internal/testing/config_writer.go
@@ -13,10 +13,10 @@ import (
 
 const configTest = "test"
 
-// GenerateTestConfigYAML generates a YAML snippet for discovered test configurations.
+// generateTestConfigYAML generates a YAML snippet for discovered test configurations.
 // Only includes services that were auto-detected (had no config in azure.yaml).
 // Returns an empty string if no auto-detected services are found.
-func GenerateTestConfigYAML(validations []ServiceValidation, services []ServiceInfo) string {
+func generateTestConfigYAML(validations []ServiceValidation, services []ServiceInfo) string {
 	// Find services that were auto-detected (no Config in azure.yaml)
 	autoDetected := make(map[string]ServiceValidation)
 	for i, v := range validations {

--- a/cli/src/internal/testing/config_writer_test.go
+++ b/cli/src/internal/testing/config_writer_test.go
@@ -99,9 +99,9 @@ func TestGenerateTestConfigYAML(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GenerateTestConfigYAML(tt.validations, tt.services)
+			got := generateTestConfigYAML(tt.validations, tt.services)
 			if got != tt.want {
-				t.Errorf("GenerateTestConfigYAML() =\n%q\nwant:\n%q", got, tt.want)
+				t.Errorf("generateTestConfigYAML() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}

--- a/cli/src/internal/testing/discovery_test.go
+++ b/cli/src/internal/testing/discovery_test.go
@@ -281,7 +281,7 @@ func TestDiscovery_GenerateYAML(t *testing.T) {
 	services := orchestrator.GetServices()
 	autoDetected := GetAutoDetectedServices(validations, services)
 
-	yaml := GenerateTestConfigYAML(autoDetected, services)
+	yaml := generateTestConfigYAML(autoDetected, services)
 
 	// Verify YAML contains expected services
 	expectedServices := []string{"web", "api", "backend", "gateway", "nested"}


### PR DESCRIPTION
## MQ Wave 2 Fixes

Addresses 4 AUTO-FIX findings from Wave 2 (architecture + smells + performance):

- **SM-1 HIGH** logbuffer: move file I/O and broadcast outside main mutex - reduces lock contention by holding mu only for the O(1) ring buffer update
- **SM-3 HIGH** parallel.go: extract newProjectTask helper - deduplicates task construction across AddNode/Python/DotnetProject
- **SM-5 MEDIUM** testing: unexport GenerateTestConfigYAML - only used within package, reduces public API surface
- **SM-6 LOW** service_process: use time.NewTimer instead of time.After - timer can be GC'd if process exits early

All tests pass, lint clean, build clean.
