### PR TITLE
fix: detect workspace roots for azure.yaml service deps

### DIFF
--- a/cli/dashboard/e2e/helpers/test-setup.ts
+++ b/cli/dashboard/e2e/helpers/test-setup.ts
@@ -1041,11 +1041,34 @@ export async function mockConnectRoutes(page: Page, options: MockConnectOptions 
   // Everything else falls through to Playwright's normal routing.
   const healthFrameBytes = Array.from(encodeStreamEnvelopeNoEnd(streamReportFrame))
   await page.addInitScript(
-    ({ frameBytes, matchUrl }) => {
+    ({ frameBytes, healthMatchUrl, neverCloseStreams }) => {
       const origFetch = window.fetch.bind(window)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const w = window as any
+      w.__streamHealthIntercepted = false
+      w.__sessionTokenIntercepted = false
+      w.__neverCloseIntercepted = [] as string[]
+      // Track which services request Azure/local logs (set by in-page
+      // fetch intercept to avoid the abort race with React state updates)
+      w.__azureLogsCalledFor = [] as string[]
+      w.__localLogsCalledFor = [] as string[]
       window.fetch = (input, init) => {
         const url = typeof input === 'string' ? input : (input as Request).url
-        if (url.includes(matchUrl)) {
+        // Resolve the session token in-page so that the Connect
+        // interceptor never blocks waiting for a page.route round-trip.
+        if (url.endsWith('/api/session-token') || url.includes('/api/session-token')) {
+          w.__sessionTokenIntercepted = true
+          return Promise.resolve(
+            new Response('test-token', {
+              status: 200,
+              headers: { 'content-type': 'text/plain' },
+            }),
+          )
+        }
+        // StreamHealth: deliver one health report frame, then keep the
+        // stream open forever so `connected` stays true.
+        if (url.includes(healthMatchUrl)) {
+          w.__streamHealthIntercepted = true
           const stream = new ReadableStream<Uint8Array>({
             start(controller) {
               controller.enqueue(new Uint8Array(frameBytes))
@@ -1060,10 +1083,75 @@ export async function mockConnectRoutes(page: Page, options: MockConnectOptions 
             }),
           )
         }
+        // Intercept GetAzureLogs unary RPC in-page to avoid the abort
+        // race: React state updates in useLogsStream (setIsLoading etc.)
+        // trigger re-renders that abort the fetch before the Connect
+        // transport completes its async setup. By resolving here, the
+        // response reaches the hook before any abort can fire.
+        if (url.includes('AzureService/GetAzureLogs')) {
+          try {
+            // Connect serializes bodies as Uint8Array even in JSON mode
+            let bodyStr = ''
+            if (typeof init?.body === 'string') bodyStr = init.body
+            else if (init?.body instanceof Uint8Array) bodyStr = new TextDecoder().decode(init.body)
+            else if (init?.body instanceof ArrayBuffer) bodyStr = new TextDecoder().decode(new Uint8Array(init.body))
+            const parsed = JSON.parse(bodyStr || '{}') as { service?: string }
+            w.__azureLogsCalledFor.push(parsed.service ?? '')
+          } catch { /* ignore parse errors */ }
+          return Promise.resolve(
+            new Response(JSON.stringify({ entries: [] }), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }),
+          )
+        }
+        // Intercept GetLogs (local mode) unary RPC similarly.
+        if (url.includes('LogsService/GetLogs')) {
+          try {
+            // Connect serializes bodies as Uint8Array even in JSON mode
+            let bodyStr = ''
+            if (typeof init?.body === 'string') bodyStr = init.body
+            else if (init?.body instanceof Uint8Array) bodyStr = new TextDecoder().decode(init.body)
+            else if (init?.body instanceof ArrayBuffer) bodyStr = new TextDecoder().decode(new Uint8Array(init.body))
+            const parsed = JSON.parse(bodyStr || '{}') as { serviceName?: string }
+            w.__localLogsCalledFor.push(parsed.serviceName ?? '')
+          } catch { /* ignore parse errors */ }
+          return Promise.resolve(
+            new Response(JSON.stringify({ entries: [], tailClamped: false }), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }),
+          )
+        }
+        // Intercept server-streaming RPCs that would otherwise close
+        // immediately (end-trailer via page.route) and trigger
+        // reconnection floods. Return never-closing empty streams so
+        // hooks stay quiet and don't saturate the page.route IPC channel.
+        for (const pattern of neverCloseStreams) {
+          if (url.includes(pattern)) {
+            w.__neverCloseIntercepted.push(pattern.split('/').pop())
+            const emptyStream = new ReadableStream<Uint8Array>({ start() { /* no data, never closes */ } })
+            return Promise.resolve(
+              new Response(emptyStream, {
+                status: 200,
+                headers: { 'content-type': 'application/connect+json' },
+              }),
+            )
+          }
+        }
         return origFetch(input, init)
       }
     },
-    { frameBytes: healthFrameBytes, matchUrl: 'azdapp.v1.HealthService/StreamHealth' },
+    {
+      frameBytes: healthFrameBytes,
+      healthMatchUrl: 'azdapp.v1.HealthService/StreamHealth',
+      neverCloseStreams: [
+        'azdapp.v1.LifecycleService/StreamBroadcast',
+        'azdapp.v1.HealthService/StreamStateTransitions',
+        'azdapp.v1.LogsService/StreamLocalLogs',
+        'azdapp.v1.AzureService/StreamAzureLogs',
+      ],
+    },
   )
   await mockConnectServerStream(page, 'HealthService', 'StreamStateTransitions', () => [])
 

--- a/cli/dashboard/e2e/logs-ux.spec.ts
+++ b/cli/dashboard/e2e/logs-ux.spec.ts
@@ -92,27 +92,6 @@ test.describe('Console - Logs UX', () => {
   })
 
   test('local-only services do not use Azure logs even when global mode is Azure', async ({ page }) => {
-    let azureRequestedForWeb = false
-    let azureRequestedForApi = false
-
-    // Post-Connect-RPC the legacy `GET /api/azure/logs?service=...` is
-    // gone - the dashboard now POSTs to
-    // `/azdapp.v1.AzureService/GetAzureLogs` with a JSON body carrying
-    // the service name. Sniff the request body instead of the URL
-    // query string so the per-service assertion still works.
-    page.on('request', req => {
-      const url = req.url()
-      if (!url.includes('/azdapp.v1.AzureService/GetAzureLogs')) return
-      try {
-        const body = req.postData() ?? ''
-        const parsed = JSON.parse(body) as { service?: string }
-        if (parsed.service === 'web') azureRequestedForWeb = true
-        if (parsed.service === 'api') azureRequestedForApi = true
-      } catch {
-        // Ignore body parsing issues
-      }
-    })
-
     const scenario = {
       services: [
         createServiceFixture({ name: 'api', status: 'running', health: 'healthy', port: 3001 }),
@@ -134,13 +113,28 @@ test.describe('Console - Logs UX', () => {
     await waitForDashboardReady(page)
 
     // The page starts in local mode and then asynchronously reads /api/mode.
-    // Wait until the UI reflects Azure mode and the Azure-pane request has occurred.
+    // Wait until the UI reflects Azure mode.
     await expect(page.getByText('Viewing Azure Logs')).toBeVisible()
-    await expect.poll(() => azureRequestedForApi, { timeout: 15000 }).toBe(true)
+
+    // The in-page fetch interceptor (addInitScript) tracks which services
+    // triggered GetAzureLogs calls via window.__azureLogsCalledFor. This
+    // avoids the abort race between React state updates and the Connect
+    // transport's async setup that makes page.on('request') unreliable.
+    await expect.poll(async () => {
+      const calls = await page.evaluate(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).__azureLogsCalledFor as string[],
+      )
+      return calls.includes('api')
+    }, { timeout: 15000 }).toBe(true)
 
     // The local-only service should never request Azure logs.
-    await page.waitForTimeout(300)
-    expect(azureRequestedForWeb).toBeFalsy()
+    await page.waitForTimeout(500)
+    const azureCalls = await page.evaluate(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__azureLogsCalledFor as string[],
+    )
+    expect(azureCalls).not.toContain('web')
 
     // UI should reflect mixed log sources.
     await expect(page.getByText('Viewing Local Logs')).toBeVisible()

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -139,8 +139,8 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
-	golang.org/x/net v0.54.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60 // indirect
 	google.golang.org/grpc v1.81.1 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -344,8 +344,8 @@ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -363,8 +363,8 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/cli/src/cmd/app/commands/core_deps.go
+++ b/cli/src/cmd/app/commands/core_deps.go
@@ -445,7 +445,96 @@ func detectProjectsFromAzureYaml(searchRoot string) ([]types.NodeProject, []type
 		}
 	}
 
+	// Link workspace children to their workspace roots.
+	// When services are defined in azure.yaml, the workspace root may not be
+	// listed as a service itself. Detect workspace roots by walking up from each
+	// project directory, and add implicit workspace root projects so that the
+	// workspace handler can correctly deduplicate installs.
+	nodeProjects = linkWorkspaceChildren(nodeProjects, absSearchRoot)
+
 	return nodeProjects, pythonProjects, dotnetProjects, nil
+}
+
+// linkWorkspaceChildren finds workspace roots for Node.js projects and links
+// children to their roots. If a workspace root is not already in the projects
+// list, it is added automatically. This ensures FilterNodeProjects can correctly
+// skip workspace children and install only at the root.
+func linkWorkspaceChildren(projects []types.NodeProject, searchRoot string) []types.NodeProject {
+	if len(projects) == 0 {
+		return projects
+	}
+
+	// Collect existing workspace roots
+	workspaceRoots := make(map[string]bool)
+	for _, p := range projects {
+		if p.IsWorkspaceRoot {
+			absDir, _ := filepath.Abs(p.Dir)
+			workspaceRoots[absDir] = true
+		}
+	}
+
+	// For each non-root project, walk up to find its workspace root
+	discoveredRoots := make(map[string]bool)
+	for i := range projects {
+		if projects[i].IsWorkspaceRoot {
+			continue
+		}
+
+		absDir, err := filepath.Abs(projects[i].Dir)
+		if err != nil {
+			continue
+		}
+
+		// Walk up from project dir looking for a workspace root
+		root := findWorkspaceRootUpward(absDir, searchRoot)
+		if root != "" {
+			projects[i].WorkspaceRoot = root
+			if !workspaceRoots[root] {
+				discoveredRoots[root] = true
+			}
+		}
+	}
+
+	// Add discovered workspace roots that aren't already in the list
+	for root := range discoveredRoots {
+		if workspaceRoots[root] {
+			continue
+		}
+		pm := detector.DetectNodePackageManager(root)
+		projects = append([]types.NodeProject{{
+			Dir:             root,
+			PackageManager:  pm,
+			IsWorkspaceRoot: true,
+		}}, projects...)
+		workspaceRoots[root] = true
+	}
+
+	return projects
+}
+
+// findWorkspaceRootUpward walks up from startDir toward boundaryDir looking for
+// a directory that contains pnpm-workspace.yaml or a package.json with workspaces.
+// Returns the absolute path of the workspace root, or empty string if not found.
+func findWorkspaceRootUpward(startDir, boundaryDir string) string {
+	dir := startDir
+	for {
+		// Don't search above the boundary (project root)
+		rel, err := filepath.Rel(boundaryDir, dir)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return ""
+		}
+
+		if detector.HasNpmWorkspaces(dir) {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached filesystem root
+			return ""
+		}
+		dir = parent
+	}
 }
 
 // isSubdirectory checks if path is a subdirectory of any path in the set.

--- a/cli/src/cmd/app/commands/core_deps.go
+++ b/cli/src/cmd/app/commands/core_deps.go
@@ -464,12 +464,16 @@ func linkWorkspaceChildren(projects []types.NodeProject, searchRoot string) []ty
 		return projects
 	}
 
-	// Collect existing workspace roots
-	workspaceRoots := make(map[string]bool)
+	// Collect existing workspace roots, mapping absolute path to original Dir value.
+	// This ensures children's WorkspaceRoot matches the root's Dir in FilterNodeProjects.
+	workspaceRootDirs := make(map[string]string) // abs path → project.Dir
 	for _, p := range projects {
 		if p.IsWorkspaceRoot {
-			absDir, _ := filepath.Abs(p.Dir)
-			workspaceRoots[absDir] = true
+			absDir, err := filepath.Abs(p.Dir)
+			if err != nil {
+				continue
+			}
+			workspaceRootDirs[absDir] = p.Dir
 		}
 	}
 
@@ -487,26 +491,28 @@ func linkWorkspaceChildren(projects []types.NodeProject, searchRoot string) []ty
 
 		// Walk up from project dir looking for a workspace root
 		root := findWorkspaceRootUpward(absDir, searchRoot)
-		if root != "" {
+		if root == "" {
+			continue
+		}
+
+		if origDir, exists := workspaceRootDirs[root]; exists {
+			// Root already in project list; use its original Dir for path consistency
+			projects[i].WorkspaceRoot = origDir
+		} else {
+			// Root not in project list; use absolute path (will match added root's Dir)
 			projects[i].WorkspaceRoot = root
-			if !workspaceRoots[root] {
-				discoveredRoots[root] = true
-			}
+			discoveredRoots[root] = true
 		}
 	}
 
 	// Add discovered workspace roots that aren't already in the list
 	for root := range discoveredRoots {
-		if workspaceRoots[root] {
-			continue
-		}
 		pm := detector.DetectNodePackageManager(root)
 		projects = append([]types.NodeProject{{
 			Dir:             root,
 			PackageManager:  pm,
 			IsWorkspaceRoot: true,
 		}}, projects...)
-		workspaceRoots[root] = true
 	}
 
 	return projects

--- a/cli/src/cmd/app/commands/workspace_link_test.go
+++ b/cli/src/cmd/app/commands/workspace_link_test.go
@@ -1,0 +1,274 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	types "github.com/jongio/azd-core/projecttype"
+)
+
+func TestLinkWorkspaceChildren_EmptyProjects(t *testing.T) {
+	result := linkWorkspaceChildren(nil, "/tmp")
+	if result != nil {
+		t.Errorf("Expected nil for nil input, got %v", result)
+	}
+
+	result = linkWorkspaceChildren([]types.NodeProject{}, "/tmp")
+	if len(result) != 0 {
+		t.Errorf("Expected empty slice, got %d projects", len(result))
+	}
+}
+
+func TestLinkWorkspaceChildren_NoWorkspaceRoot(t *testing.T) {
+	// Projects without any workspace root above them should remain unchanged
+	tmpDir := t.TempDir()
+
+	childDir := filepath.Join(tmpDir, "child")
+	if err := os.MkdirAll(childDir, 0o750); err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, "package.json"), []byte(`{"name":"child"}`), 0o600); err != nil {
+		t.Fatalf("Failed to write package.json: %v", err)
+	}
+
+	projects := []types.NodeProject{
+		{Dir: childDir, PackageManager: "npm"},
+	}
+
+	result := linkWorkspaceChildren(projects, tmpDir)
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 project, got %d", len(result))
+	}
+	if result[0].WorkspaceRoot != "" {
+		t.Errorf("Expected empty WorkspaceRoot, got %q", result[0].WorkspaceRoot)
+	}
+}
+
+func TestLinkWorkspaceChildren_DiscoversMissingRoot(t *testing.T) {
+	// Simulate: workspace root at tmpDir (has pnpm-workspace.yaml),
+	// two children in subdirs, root NOT in project list.
+	tmpDir := t.TempDir()
+
+	// Create workspace root indicators
+	if err := os.WriteFile(filepath.Join(tmpDir, "pnpm-workspace.yaml"), []byte("packages:\n  - 'src/*'\n"), 0o600); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(`{"name":"root"}`), 0o600); err != nil {
+		t.Fatalf("Failed to write root package.json: %v", err)
+	}
+
+	// Create child directories
+	child1 := filepath.Join(tmpDir, "src", "web")
+	child2 := filepath.Join(tmpDir, "src", "api")
+	for _, d := range []string{child1, child2} {
+		if err := os.MkdirAll(d, 0o750); err != nil {
+			t.Fatalf("Failed to create %s: %v", d, err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "package.json"), []byte(`{"name":"child"}`), 0o600); err != nil {
+			t.Fatalf("Failed to write package.json in %s: %v", d, err)
+		}
+	}
+
+	projects := []types.NodeProject{
+		{Dir: child1, PackageManager: "pnpm"},
+		{Dir: child2, PackageManager: "pnpm"},
+	}
+
+	absRoot, _ := filepath.Abs(tmpDir)
+	result := linkWorkspaceChildren(projects, absRoot)
+
+	// Should have 3 projects: discovered root + 2 children
+	if len(result) != 3 {
+		t.Fatalf("Expected 3 projects (1 root + 2 children), got %d", len(result))
+	}
+
+	// First project should be the discovered workspace root
+	if !result[0].IsWorkspaceRoot {
+		t.Error("First project should be workspace root")
+	}
+	if result[0].Dir != absRoot {
+		t.Errorf("Root Dir = %q, want %q", result[0].Dir, absRoot)
+	}
+
+	// Children should reference the root
+	for i := 1; i < len(result); i++ {
+		if result[i].WorkspaceRoot != absRoot {
+			t.Errorf("Child %d WorkspaceRoot = %q, want %q", i, result[i].WorkspaceRoot, absRoot)
+		}
+		if result[i].IsWorkspaceRoot {
+			t.Errorf("Child %d should not be workspace root", i)
+		}
+	}
+}
+
+func TestLinkWorkspaceChildren_ExistingRootUsesOriginalDir(t *testing.T) {
+	// When workspace root IS in the project list (e.g., as a service),
+	// children's WorkspaceRoot should match the root's original Dir value
+	// for FilterNodeProjects compatibility.
+	tmpDir := t.TempDir()
+
+	// Create workspace root indicators
+	if err := os.WriteFile(filepath.Join(tmpDir, "pnpm-workspace.yaml"), []byte("packages:\n  - 'src/*'\n"), 0o600); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(`{"name":"root"}`), 0o600); err != nil {
+		t.Fatalf("Failed to write root package.json: %v", err)
+	}
+
+	childDir := filepath.Join(tmpDir, "src", "web")
+	if err := os.MkdirAll(childDir, 0o750); err != nil {
+		t.Fatalf("Failed to create child dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, "package.json"), []byte(`{"name":"web"}`), 0o600); err != nil {
+		t.Fatalf("Failed to write package.json: %v", err)
+	}
+
+	// Root IS in the project list with its original Dir
+	projects := []types.NodeProject{
+		{Dir: tmpDir, PackageManager: "pnpm", IsWorkspaceRoot: true},
+		{Dir: childDir, PackageManager: "pnpm"},
+	}
+
+	absRoot, _ := filepath.Abs(tmpDir)
+	result := linkWorkspaceChildren(projects, absRoot)
+
+	// Should still have 2 projects (root already existed, no new addition)
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 projects, got %d", len(result))
+	}
+
+	// Find the child (non-root) project
+	var child *types.NodeProject
+	for i := range result {
+		if !result[i].IsWorkspaceRoot {
+			child = &result[i]
+			break
+		}
+	}
+	if child == nil {
+		t.Fatal("Could not find child project in results")
+	}
+
+	// Child's WorkspaceRoot should match the root's Dir exactly
+	if child.WorkspaceRoot != tmpDir {
+		t.Errorf("Child WorkspaceRoot = %q, want %q (root's original Dir)", child.WorkspaceRoot, tmpDir)
+	}
+}
+
+func TestLinkWorkspaceChildren_AllRoots(t *testing.T) {
+	// If all projects are workspace roots, nothing should change
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "pnpm-workspace.yaml"), []byte("packages:\n  - '*'\n"), 0o600); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+
+	projects := []types.NodeProject{
+		{Dir: tmpDir, PackageManager: "pnpm", IsWorkspaceRoot: true},
+	}
+
+	absRoot, _ := filepath.Abs(tmpDir)
+	result := linkWorkspaceChildren(projects, absRoot)
+
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 project, got %d", len(result))
+	}
+	if result[0].WorkspaceRoot != "" {
+		t.Errorf("Root should not have WorkspaceRoot set, got %q", result[0].WorkspaceRoot)
+	}
+}
+
+func TestFindWorkspaceRootUpward_FindsPnpmWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create workspace root at tmpDir
+	if err := os.WriteFile(filepath.Join(tmpDir, "pnpm-workspace.yaml"), []byte("packages:\n  - 'src/*'\n"), 0o600); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+
+	// Start from a nested child
+	childDir := filepath.Join(tmpDir, "src", "packages", "web")
+	if err := os.MkdirAll(childDir, 0o750); err != nil {
+		t.Fatalf("Failed to create child dir: %v", err)
+	}
+
+	absRoot, _ := filepath.Abs(tmpDir)
+	result := findWorkspaceRootUpward(childDir, absRoot)
+	if result != absRoot {
+		t.Errorf("findWorkspaceRootUpward() = %q, want %q", result, absRoot)
+	}
+}
+
+func TestFindWorkspaceRootUpward_FindsPackageJsonWorkspaces(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create workspace root via package.json workspaces field
+	pkgJSON := `{"name":"root","workspaces":["packages/*"]}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(pkgJSON), 0o600); err != nil {
+		t.Fatalf("Failed to write package.json: %v", err)
+	}
+
+	childDir := filepath.Join(tmpDir, "packages", "lib")
+	if err := os.MkdirAll(childDir, 0o750); err != nil {
+		t.Fatalf("Failed to create child dir: %v", err)
+	}
+
+	absRoot, _ := filepath.Abs(tmpDir)
+	result := findWorkspaceRootUpward(childDir, absRoot)
+	if result != absRoot {
+		t.Errorf("findWorkspaceRootUpward() = %q, want %q", result, absRoot)
+	}
+}
+
+func TestFindWorkspaceRootUpward_StopsAtBoundary(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Place workspace root ABOVE the boundary
+	outerDir := filepath.Join(tmpDir, "outer")
+	innerDir := filepath.Join(outerDir, "inner", "project")
+	if err := os.MkdirAll(innerDir, 0o750); err != nil {
+		t.Fatalf("Failed to create dirs: %v", err)
+	}
+	// Workspace root at outer level (above boundary)
+	if err := os.WriteFile(filepath.Join(outerDir, "pnpm-workspace.yaml"), []byte("packages:\n  - '**'\n"), 0o600); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+
+	// Boundary is inner dir (below workspace root)
+	absInner, _ := filepath.Abs(filepath.Join(outerDir, "inner"))
+	result := findWorkspaceRootUpward(innerDir, absInner)
+	if result != "" {
+		t.Errorf("Expected empty (root above boundary), got %q", result)
+	}
+}
+
+func TestFindWorkspaceRootUpward_NoWorkspaceFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	childDir := filepath.Join(tmpDir, "some", "nested", "dir")
+	if err := os.MkdirAll(childDir, 0o750); err != nil {
+		t.Fatalf("Failed to create dirs: %v", err)
+	}
+
+	absRoot, _ := filepath.Abs(tmpDir)
+	result := findWorkspaceRootUpward(childDir, absRoot)
+	if result != "" {
+		t.Errorf("Expected empty string, got %q", result)
+	}
+}
+
+func TestFindWorkspaceRootUpward_StartDirIsRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// The start dir itself is the workspace root
+	if err := os.WriteFile(filepath.Join(tmpDir, "pnpm-workspace.yaml"), []byte("packages:\n  - '*'\n"), 0o600); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+
+	absRoot, _ := filepath.Abs(tmpDir)
+	result := findWorkspaceRootUpward(absRoot, absRoot)
+	if result != absRoot {
+		t.Errorf("findWorkspaceRootUpward() = %q, want %q", result, absRoot)
+	}
+}


### PR DESCRIPTION
## Problem

When all services in azure.yaml are part of a pnpm/npm/yarn workspace but the workspace root itself is not listed as a service, azd app deps (and azd app run) tried to install dependencies individually in each of the N workspace child directories. This caused 10 redundant pnpm install calls instead of 1, failures in non-verbose mode due to progress bar writer conflicts, and azd app run being completely broken on fresh clones or after node_modules cleanup.

## Root Cause

detectProjectsFromAzureYaml correctly detected IsWorkspaceRoot on projects, but never set WorkspaceRoot on child projects. The existing FilterNodeProjects workspace handler treated all children as independent projects (since WorkspaceRoot was empty), bypassing the deduplication logic entirely.

## Fix

Added linkWorkspaceChildren() that runs after project detection:

1. For each non-root Node.js project, walks up from its directory to find a workspace root (bounded by the project root)
2. Sets WorkspaceRoot on child projects so FilterNodeProjects correctly skips them
3. If the workspace root is not already in the projects list (common, since it's usually not a service in azure.yaml), adds it implicitly

## Result

Before: 10 individual pnpm install calls (all failing in non-verbose mode)
After: 1 pnpm install --prefer-offline --recursive at workspace root (~20s, succeeds)
Subsequent runs: instant skip (0.0s) via isDependenciesUpToDate cache

## Testing

Verified on a pnpm workspace with 10 packages:

- azd app deps from clean state (no node_modules): passes
- azd app deps --no-cache: passes
- azd app deps repeat (cached): instant skip
- azd app run from clean state: deps pass, services start
- azd app deps --dry-run: shows workspace root + children correctly