### PR TITLE
feat: implement cross-process azd app stop with lifecycle hooks

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -397,7 +397,7 @@ azd app test --environment staging      # Target a deployed environment
 | `azd app restart` | Restart running services |
 | `azd app run` | Start all services with dashboard |
 | `azd app start` | Start specific services |
-| `azd app stop` | Stop running services |
+| `azd app stop` | Stop running services (cross-process, with lifecycle hooks) |
 | `azd app test` | Run tests across all services |
 | `azd app version` | Show extension version |
 

--- a/cli/docs/cli-reference.md
+++ b/cli/docs/cli-reference.md
@@ -599,7 +599,7 @@ Start one or more stopped services that were previously running. This command op
 
 ## `azd app stop`
 
-Stop running services.
+Stop running services, release ports, and tear down the app.
 
 ### Usage
 
@@ -610,14 +610,14 @@ azd app stop [flags]
 ### Examples
 
 ```bash
+# Stop all services (default behavior)
+azd app stop
+
 # Stop a specific service
 azd app stop --service api
 
 # Stop multiple services
 azd app stop --service "api,web,worker"
-
-# Stop all running services
-azd app stop --all
 ```
 
 ### Flags
@@ -625,12 +625,12 @@ azd app stop --all
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--service` | `-s` | string | | Service name(s) to stop (comma-separated) |
-| `--all` | | bool | `false` | Stop all running services |
-| `--yes` | `-y` | bool | `false` | Skip confirmation prompt for `--all` |
+| `--all` | | bool | `false` | Stop all running services (same as default) |
+| `--yes` | `-y` | bool | `false` | Skip confirmation prompt |
 
 ### Description
 
-Stop one or more running services gracefully. Services are stopped with a graceful shutdown timeout. If a service doesn't respond to graceful shutdown, it will be forcefully terminated.
+Stop running services gracefully, release all port assignments, and execute lifecycle hooks. By default (no flags), stops ALL services. Supports `prestop` and `poststop` hooks in `azure.yaml`.
 
 **→ [See full stop command specification](commands/stop.md)** for complete documentation.
 

--- a/cli/docs/cli-reference.md
+++ b/cli/docs/cli-reference.md
@@ -599,38 +599,24 @@ Start one or more stopped services that were previously running. This command op
 
 ## `azd app stop`
 
-Stop running services, release ports, and tear down the app.
+Stop running services, execute lifecycle hooks, and tear down the app.
 
 ### Usage
 
 ```bash
-azd app stop [flags]
+azd app stop
 ```
 
 ### Examples
 
 ```bash
-# Stop all services (default behavior)
+# Stop the running app (from any terminal in the project)
 azd app stop
-
-# Stop a specific service
-azd app stop --service api
-
-# Stop multiple services
-azd app stop --service "api,web,worker"
 ```
-
-### Flags
-
-| Flag | Short | Type | Default | Description |
-|------|-------|------|---------|-------------|
-| `--service` | `-s` | string | | Service name(s) to stop (comma-separated) |
-| `--all` | | bool | `false` | Stop all running services (same as default) |
-| `--yes` | `-y` | bool | `false` | Skip confirmation prompt |
 
 ### Description
 
-Stop running services gracefully, release all port assignments, and execute lifecycle hooks. By default (no flags), stops ALL services. Supports `prestop` and `poststop` hooks in `azure.yaml`.
+Sends a shutdown signal to the running `azd app run` process. This triggers graceful shutdown including prestop/poststop hooks, port release, and process cleanup — identical to pressing Ctrl+C in the run terminal. No flags required — just run from any terminal in the project directory.
 
 **→ [See full stop command specification](commands/stop.md)** for complete documentation.
 

--- a/cli/docs/commands/stop.md
+++ b/cli/docs/commands/stop.md
@@ -5,16 +5,21 @@ Stop running services and tear down the app.
 ## Synopsis
 
 ```
-azd app stop [flags]
+azd app stop
 ```
 
 ## Description
 
-Stop running services, kill all associated ports, and tear down the app.
+Sends a shutdown signal to the running `azd app run` process. This triggers graceful shutdown including prestop/poststop hooks, port release, and process cleanup — identical to pressing Ctrl+C in the run terminal.
 
-By default (no flags), stops ALL running services and releases their ports. Use `--service` to stop only specific services.
+Run this from **any terminal** in the project directory while `azd app run` is active in another terminal.
 
-Services are stopped gracefully with a timeout. If a service doesn't respond to graceful shutdown, it will be forcefully terminated.
+### How It Works
+
+1. Discovers the running dashboard port (stored in a per-project temp file)
+2. Authenticates with the dashboard using a per-session token
+3. Sends an authenticated shutdown request
+4. The run process executes the full graceful shutdown path
 
 ### Lifecycle Hooks
 
@@ -25,59 +30,15 @@ The stop command supports `prestop` and `poststop` hooks defined in `azure.yaml`
 
 Hook failures are non-fatal: services will still be stopped even if a hook fails.
 
-## Flags
-
-| Flag | Short | Type | Default | Description |
-|------|-------|------|---------|-------------|
-| `--service` | `-s` | string | | Service name(s) to stop (comma-separated) |
-| `--all` | | bool | `false` | Stop all running services (same as default) |
-| `--yes` | `-y` | bool | `false` | Skip confirmation prompt |
-
 ## Examples
 
-### Stop all services (default)
+### Stop the running app
 
 ```bash
 azd app stop
 ```
 
-### Stop a specific service
-
-```bash
-azd app stop --service api
-```
-
-### Stop multiple services
-
-```bash
-azd app stop --service "api,web,worker"
-```
-
-### Stop all without confirmation
-
-```bash
-azd app stop --yes
-```
-
-### JSON output
-
-```bash
-azd app stop --service api --output json
-```
-
-Output:
-
-```json
-{
-  "serviceName": "api",
-  "success": true,
-  "message": "Service 'api' stopped",
-  "status": "stopped",
-  "duration": "0.856s"
-}
-```
-
-### With lifecycle hooks
+### With lifecycle hooks in azure.yaml
 
 ```yaml
 # azure.yaml
@@ -86,33 +47,26 @@ hooks:
     run: echo "Draining connections..."
     continueOnError: true
   poststop:
-    run: ./scripts/cleanup.sh
-    shell: bash
+    run: echo "Cleanup complete"
 ```
 
-## Graceful Shutdown
-
-The stop command uses a graceful shutdown process:
+## Graceful Shutdown Sequence
 
 1. Execute `prestop` hook (if configured)
-2. Send SIGTERM signal to each service process
-3. Wait up to 30 seconds for services to exit cleanly
-4. If a service doesn't exit, send SIGKILL to force termination
-5. Release all port assignments
-6. Execute `poststop` hook (if configured)
-
-This allows services to complete in-flight requests and clean up resources before stopping.
+2. Stop all service processes gracefully (10s timeout)
+3. Stop the dashboard server
+4. Release all port assignments
+5. Execute `poststop` hook (if configured)
+6. Clean up port discovery file
 
 ## Exit Codes
 
 | Code | Description |
 |------|-------------|
-| `0` | All services stopped successfully |
-| `1` | One or more services failed to stop |
+| `0` | Shutdown signal sent successfully |
+| `1` | No running app found or communication failed |
 
 ## Related Commands
 
-- [azd app start](start.md) - Start stopped services
-- [azd app restart](restart.md) - Restart services
 - [azd app run](run.md) - Run the development environment
 - [azd app health](health.md) - Monitor service health

--- a/cli/docs/commands/stop.md
+++ b/cli/docs/commands/stop.md
@@ -1,6 +1,6 @@
 # azd app stop
 
-Stop running services.
+Stop running services and tear down the app.
 
 ## Synopsis
 
@@ -10,21 +10,36 @@ azd app stop [flags]
 
 ## Description
 
-Stop one or more running services gracefully.
+Stop running services, kill all associated ports, and tear down the app.
 
-This command stops services that are currently running. Use `--service` to stop a specific service, or `--all` to stop all running services.
+By default (no flags), stops ALL running services and releases their ports. Use `--service` to stop only specific services.
 
 Services are stopped gracefully with a timeout. If a service doesn't respond to graceful shutdown, it will be forcefully terminated.
+
+### Lifecycle Hooks
+
+The stop command supports `prestop` and `poststop` hooks defined in `azure.yaml`:
+
+- **`prestop`** — Runs before services are stopped (e.g., drain connections, flush caches)
+- **`poststop`** — Runs after all services are stopped (e.g., cleanup temp files, remove tunnels)
+
+Hook failures are non-fatal: services will still be stopped even if a hook fails.
 
 ## Flags
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--service` | `-s` | string | | Service name(s) to stop (comma-separated) |
-| `--all` | | bool | `false` | Stop all running services |
-| `--yes` | `-y` | bool | `false` | Skip confirmation prompt for `--all` |
+| `--all` | | bool | `false` | Stop all running services (same as default) |
+| `--yes` | `-y` | bool | `false` | Skip confirmation prompt |
 
 ## Examples
+
+### Stop all services (default)
+
+```bash
+azd app stop
+```
 
 ### Stop a specific service
 
@@ -38,16 +53,10 @@ azd app stop --service api
 azd app stop --service "api,web,worker"
 ```
 
-### Stop all running services
-
-```bash
-azd app stop --all
-```
-
 ### Stop all without confirmation
 
 ```bash
-azd app stop --all --yes
+azd app stop --yes
 ```
 
 ### JSON output
@@ -68,13 +77,29 @@ Output:
 }
 ```
 
+### With lifecycle hooks
+
+```yaml
+# azure.yaml
+hooks:
+  prestop:
+    run: echo "Draining connections..."
+    continueOnError: true
+  poststop:
+    run: ./scripts/cleanup.sh
+    shell: bash
+```
+
 ## Graceful Shutdown
 
 The stop command uses a graceful shutdown process:
 
-1. Send SIGTERM signal to the service process
-2. Wait up to 30 seconds for the service to exit cleanly
-3. If the service doesn't exit, send SIGKILL to force termination
+1. Execute `prestop` hook (if configured)
+2. Send SIGTERM signal to each service process
+3. Wait up to 30 seconds for services to exit cleanly
+4. If a service doesn't exit, send SIGKILL to force termination
+5. Release all port assignments
+6. Execute `poststop` hook (if configured)
 
 This allows services to complete in-flight requests and clean up resources before stopping.
 

--- a/cli/docs/features/hooks.md
+++ b/cli/docs/features/hooks.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Hooks are lifecycle scripts that execute automatically before and after the `azd app run` command, similar to azd's `preprovision` and `postprovision` hooks. They allow you to automate setup tasks, validation, notifications, and cleanup operations.
+Hooks are lifecycle scripts that execute automatically before and after the `azd app run` and `azd app stop` commands, similar to azd's `preprovision` and `postprovision` hooks. They allow you to automate setup tasks, validation, notifications, and cleanup operations.
 
 ## Available Hooks
 
@@ -21,6 +21,22 @@ Executes **after** all services are ready. Use for:
 - Running integration tests
 - Logging startup information
 - Registering services with discovery systems
+
+### `prestop`
+Executes **before** services are stopped. Use for:
+- Draining active connections
+- Flushing caches or buffers
+- Notifying dependent services
+- Saving application state
+- Deregistering from service discovery
+
+### `poststop`
+Executes **after** all services are stopped and ports released. Use for:
+- Cleaning up temporary files
+- Removing tunnels or proxies
+- Sending shutdown notifications
+- Archiving logs
+- Tearing down test data
 
 ## Configuration
 
@@ -226,6 +242,55 @@ hooks:
 services:
   web:
     project: .
+```
+
+### Stop Lifecycle Hooks
+
+```yaml
+name: app-with-stop-hooks
+
+hooks:
+  prestop:
+    run: |
+      echo "Draining connections..."
+      curl -X POST http://localhost:8080/admin/drain
+    shell: bash
+    continueOnError: true  # Don't prevent stop if drain fails
+  poststop:
+    run: |
+      echo "Cleaning up..."
+      rm -rf ./tmp/cache
+      rm -f ./pid/*.pid
+    shell: bash
+
+services:
+  api:
+    project: ./backend
+    ports: ["8080"]
+```
+
+### Full Lifecycle (Run + Stop)
+
+```yaml
+name: full-lifecycle-app
+
+hooks:
+  prerun:
+    run: npm run db:migrate
+    shell: bash
+  postrun:
+    run: echo "App is ready at http://localhost:3000"
+  prestop:
+    run: echo "Shutting down gracefully..."
+    continueOnError: true
+  poststop:
+    run: ./scripts/cleanup.sh
+    shell: bash
+
+services:
+  web:
+    project: .
+    ports: ["3000"]
 ```
 
 ### Conditional Execution

--- a/cli/docs/schema/azure.yaml.md
+++ b/cli/docs/schema/azure.yaml.md
@@ -157,7 +157,7 @@ reqs:
 Free-form metadata (standard `azd` field).
 
 ### `hooks` ⭐ NEW
-Lifecycle hooks that execute before and after the `run` command.
+Lifecycle hooks that execute before/after `run` and `stop` commands.
 
 ```yaml
 hooks:
@@ -168,6 +168,13 @@ hooks:
   postrun:
     run: "echo 'Services are ready!'"
     shell: sh
+  prestop:
+    run: "echo 'Draining connections...'"
+    shell: sh
+    continueOnError: true
+  poststop:
+    run: "./scripts/cleanup.sh"
+    shell: bash
 ```
 
 See [Hook Object](#hook-object) for full configuration options.

--- a/cli/magefile.go
+++ b/cli/magefile.go
@@ -73,14 +73,13 @@ func killAppProcesses() error {
 	return nil
 }
 
-// getVersion reads the current version from extension.yaml.
-func getVersion() (string, error) {
+// getBaseVersion reads the base version from extension.yaml.
+func getBaseVersion() (string, error) {
 	data, err := os.ReadFile(extensionFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to read extension.yaml: %w", err)
 	}
 
-	// Simple regex to extract version: line
 	lines := strings.Split(string(data), "\n")
 	for _, line := range lines {
 		if strings.HasPrefix(line, "version:") {
@@ -89,6 +88,65 @@ func getVersion() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("version not found in extension.yaml")
+}
+
+// getVersion returns the build version. For release builds (RELEASE_BUILD=true),
+// returns the base version from extension.yaml. For dev builds, appends SemVer
+// build metadata with the git short SHA and dirty state (e.g., 0.16.0+dev.g19e040f8.dirty).
+func getVersion() (string, error) {
+	base, err := getBaseVersion()
+	if err != nil {
+		return "", err
+	}
+
+	// Release builds use the clean version from extension.yaml.
+	if os.Getenv("RELEASE_BUILD") == "true" {
+		return base, nil
+	}
+
+	// For dev builds, append git metadata.
+	sha, err := sh.Output("git", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		// No git available — fall back to base version with +dev suffix.
+		return base + "+dev", nil
+	}
+
+	suffix := "+dev.g" + strings.TrimSpace(sha)
+
+	// Check if the working tree is dirty.
+	dirty, _ := sh.Output("git", "status", "--porcelain")
+	if strings.TrimSpace(dirty) != "" {
+		suffix += ".dirty"
+	}
+
+	return base + suffix, nil
+}
+
+// patchExtensionVersion temporarily writes version into extension.yaml and returns
+// a restore function that reverts the file to its original content.
+func patchExtensionVersion(version string) (func(), error) {
+	original, err := os.ReadFile(extensionFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read extension.yaml: %w", err)
+	}
+
+	lines := strings.Split(string(original), "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "version:") {
+			lines[i] = "version: " + version
+			break
+		}
+	}
+
+	patched := strings.Join(lines, "\n")
+	if err := os.WriteFile(extensionFile, []byte(patched), 0644); err != nil {
+		return nil, fmt.Errorf("failed to patch extension.yaml: %w", err)
+	}
+
+	restore := func() {
+		_ = os.WriteFile(extensionFile, original, 0644)
+	}
+	return restore, nil
 }
 
 // All runs lint, test, and build in dependency order.
@@ -122,6 +180,14 @@ func Build() error {
 	if err != nil {
 		return err
 	}
+
+	// Temporarily write the dev version into extension.yaml so azd x build
+	// picks it up for ldflags injection. Restore the original afterward.
+	restore, err := patchExtensionVersion(version)
+	if err != nil {
+		return err
+	}
+	defer restore()
 
 	fmt.Println("Building and installing extension...")
 
@@ -165,6 +231,12 @@ func buildAllPlatforms() error {
 	if err != nil {
 		return err
 	}
+
+	restore, err := patchExtensionVersion(version)
+	if err != nil {
+		return err
+	}
+	defer restore()
 
 	// When EXTENSION_PLATFORM is not set, the script builds for all platforms
 	env := map[string]string{
@@ -1490,6 +1562,11 @@ func buildGoOnly() error {
 	if err != nil {
 		return err
 	}
+	restore, err := patchExtensionVersion(version)
+	if err != nil {
+		return err
+	}
+	defer restore()
 	return runQuietEnvRetry(map[string]string{
 		"EXTENSION_ID":      extensionID,
 		"EXTENSION_VERSION": version,

--- a/cli/src/cmd/app/commands/run_orchestration.go
+++ b/cli/src/cmd/app/commands/run_orchestration.go
@@ -67,7 +67,7 @@ func executeAndMonitorServices(ctx context.Context, runtimes []*service.ServiceR
 	}
 
 	// Start dashboard and wait for shutdown
-	return monitorServicesUntilShutdown(result, cwd)
+	return monitorServicesUntilShutdown(result, cwd, azureYaml, azureYamlDir)
 }
 
 // monitorServicesUntilShutdown monitors all services with full process isolation.
@@ -86,7 +86,7 @@ func executeAndMonitorServices(ctx context.Context, runtimes []*service.ServiceR
 //
 // This uses sync.WaitGroup (not errgroup) because we want all goroutines to complete
 // independently rather than failing fast on first error.
-func monitorServicesUntilShutdown(result *service.OrchestrationResult, cwd string) error {
+func monitorServicesUntilShutdown(result *service.OrchestrationResult, cwd string, azureYaml *service.AzureYaml, azureYamlDir string) error {
 	// Create context that cancels on SIGINT/SIGTERM only
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -103,7 +103,6 @@ func monitorServicesUntilShutdown(result *service.OrchestrationResult, cwd strin
 	} else {
 		notifMgr.Start()
 		defer func() { _ = notifMgr.Stop() }()
-		// Notifications enabled silently - no need to announce
 	}
 
 	// Start dashboard monitoring (passes notifMgr to set URL after dashboard starts)
@@ -112,11 +111,20 @@ func monitorServicesUntilShutdown(result *service.OrchestrationResult, cwd strin
 	// Start service process monitors
 	startServiceMonitors(ctx, &wg, result.Processes, cwd)
 
+	// Also cancel on remote shutdown request (from `azd app stop` in another terminal)
+	go func() {
+		select {
+		case <-dashboardServer.ShutdownChan():
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
 	// Wait for signal (context cancellation) or all services to complete
 	wg.Wait()
 
-	// Perform cleanup shutdown
-	return performGracefulShutdown(dashboardServer, result.Processes)
+	// Perform cleanup shutdown with hooks
+	return performGracefulShutdown(dashboardServer, result.Processes, azureYaml, azureYamlDir)
 }
 
 // startDashboardMonitor starts the dashboard server in a separate goroutine with panic recovery.
@@ -172,14 +180,22 @@ func startServiceMonitors(ctx context.Context, wg *sync.WaitGroup, processes map
 }
 
 // performGracefulShutdown stops all services and dashboard with a timeout.
+// Runs prestop/poststop hooks around service shutdown.
 // Returns nil due to process isolation design - individual failures are logged but don't fail the command.
-func performGracefulShutdown(dashboardServer *dashboard.Server, processes map[string]*service.ServiceProcess) error {
+func performGracefulShutdown(dashboardServer *dashboard.Server, processes map[string]*service.ServiceProcess, azureYaml *service.AzureYaml, azureYamlDir string) error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 
 	cliout.Newline()
 	cliout.Newline()
 	cliout.Plain("Shutting down...")
+
+	// Execute prestop hook
+	if azureYaml != nil {
+		if hookErr := executePrestopHook(shutdownCtx, azureYaml, azureYamlDir); hookErr != nil {
+			cliout.Warning("Prestop hook failed: %v", hookErr)
+		}
+	}
 
 	// Stop dashboard
 	if stopErr := dashboardServer.Stop(); stopErr != nil {
@@ -192,6 +208,14 @@ func performGracefulShutdown(dashboardServer *dashboard.Server, processes map[st
 	}
 
 	cliout.Success("All services stopped")
+
+	// Execute poststop hook
+	if azureYaml != nil {
+		if hookErr := executePoststopHook(shutdownCtx, azureYaml, azureYamlDir); hookErr != nil {
+			cliout.Warning("Poststop hook failed: %v", hookErr)
+		}
+	}
+
 	cliout.Newline()
 
 	// Clean up port assignments on clean shutdown
@@ -203,6 +227,16 @@ func performGracefulShutdown(dashboardServer *dashboard.Server, processes map[st
 	// Individual service crashes are logged but don't cause the run command to fail.
 	// Only return errors for infrastructure issues (dashboard, shutdown timeout, etc.)
 	return nil
+}
+
+// executePrestopHook executes the prestop hook if configured.
+func executePrestopHook(ctx context.Context, azureYaml *service.AzureYaml, workingDir string) error {
+	return executeHook(ctx, azureYaml, azureYaml.Hooks, azureYaml.Hooks.GetPrestop(), "prestop", workingDir)
+}
+
+// executePoststopHook executes the poststop hook if configured.
+func executePoststopHook(ctx context.Context, azureYaml *service.AzureYaml, workingDir string) error {
+	return executeHook(ctx, azureYaml, azureYaml.Hooks, azureYaml.Hooks.GetPoststop(), "poststop", workingDir)
 }
 
 // monitorServiceProcess monitors a single service process for exit or cancellation.

--- a/cli/src/cmd/app/commands/run_test.go
+++ b/cli/src/cmd/app/commands/run_test.go
@@ -261,7 +261,7 @@ func TestMonitorServicesUntilShutdown_StartupTimeout(t *testing.T) {
 	// Run monitoring in goroutine with timeout
 	done := make(chan error, 1)
 	go func() {
-		done <- monitorServicesUntilShutdown(result, tmpDir)
+		done <- monitorServicesUntilShutdown(result, tmpDir, nil, "")
 	}()
 
 	// Ensure cleanup if test exits early
@@ -345,7 +345,7 @@ func TestMonitorServicesUntilShutdown_SignalHandling(t *testing.T) {
 	}()
 
 	startTime := time.Now()
-	_ = monitorServicesUntilShutdown(result, tmpDir)
+	_ = monitorServicesUntilShutdown(result, tmpDir, nil, "")
 	elapsed := time.Since(startTime)
 
 	// Should complete reasonably quickly after signal
@@ -600,7 +600,7 @@ func TestMonitorServices_RunsIndefinitely(t *testing.T) {
 	}()
 
 	startTime := time.Now()
-	_ = monitorServicesUntilShutdown(result, tmpDir)
+	_ = monitorServicesUntilShutdown(result, tmpDir, nil, "")
 	elapsed := time.Since(startTime)
 
 	// Should have run for approximately 5 seconds (not stop at 30 seconds or earlier)
@@ -840,7 +840,7 @@ func TestProcessExit_DoesNotStopOtherServices(t *testing.T) {
 	// Run monitoring in a goroutine since it waits indefinitely for signals
 	done := make(chan error, 1)
 	go func() {
-		done <- monitorServicesUntilShutdown(result, tmpDir)
+		done <- monitorServicesUntilShutdown(result, tmpDir, nil, "")
 	}()
 
 	// Ensure cleanup if test exits

--- a/cli/src/cmd/app/commands/stop.go
+++ b/cli/src/cmd/app/commands/stop.go
@@ -120,7 +120,7 @@ func fetchSessionToken(baseURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not connect to running app — it may have already stopped")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unexpected response from session-token endpoint (status %d)", resp.StatusCode)
@@ -148,7 +148,7 @@ func sendShutdownRequest(baseURL, token string) error {
 	if err != nil {
 		return fmt.Errorf("failed to send shutdown signal: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/cli/src/cmd/app/commands/stop.go
+++ b/cli/src/cmd/app/commands/stop.go
@@ -1,51 +1,43 @@
 package commands
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
 
+	"github.com/jongio/azd-app/cli/src/internal/azdconfig"
+	"github.com/jongio/azd-app/cli/src/internal/dashboard"
+	"github.com/jongio/azd-app/cli/src/internal/detector"
 	"github.com/jongio/azd-core/cliout"
 
 	"github.com/spf13/cobra"
-)
-
-var (
-	stopService string
-	stopAll     bool
-	stopYes     bool
 )
 
 // NewStopCommand creates the stop command.
 func NewStopCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stop",
-		Short: "Stop running services",
-		Long: `Stop one or more running services gracefully.
+		Short: "Stop running services and tear down the app",
+		Long: `Stop running services, execute lifecycle hooks, and tear down the app.
 
-This command stops services that are currently running.
-Use --service to stop a specific service, or --all to stop all running services.
+Sends a shutdown signal to the running 'azd app run' process. This triggers
+graceful shutdown including prestop/poststop hooks, port release, and
+process cleanup — identical to pressing Ctrl+C in the run terminal.
 
-Services are stopped gracefully with a timeout. If a service doesn't respond
-to graceful shutdown, it will be forcefully terminated.
+Lifecycle hooks:
+  prestop  - runs before services are stopped (e.g., drain connections)
+  poststop - runs after all services are stopped (e.g., cleanup temp files)
 
 Examples:
-  # Stop a specific service
-  azd app stop --service api
-
-  # Stop multiple services
-  azd app stop --service "api,web,worker"
-
-  # Stop all running services
-  azd app stop --all
-
-  # JSON output
-  azd app stop --service api --output json`,
+  # Stop the running app (from any terminal in the project)
+  azd app stop`,
 		SilenceUsage: true,
 		RunE:         runStop,
 	}
-
-	cmd.Flags().StringVarP(&stopService, "service", "s", "", "Service name(s) to stop (comma-separated)")
-	cmd.Flags().BoolVar(&stopAll, "all", false, "Stop all running services")
-	cmd.Flags().BoolVarP(&stopYes, "yes", "y", false, "Skip confirmation prompt for --all")
 
 	return cmd
 }
@@ -53,40 +45,115 @@ Examples:
 func runStop(cmd *cobra.Command, args []string) error {
 	cliout.CommandHeader("stop", "Stop running services")
 
-	// Validate flags
-	if stopService == "" && !stopAll {
-		return fmt.Errorf("specify --service <name> or --all to stop services")
-	}
-
-	// Create controller
-	ctrl, err := NewServiceController("")
+	// Find project root
+	projectDir, err := findProjectDir()
 	if err != nil {
-		return fmt.Errorf("failed to initialize: %w", err)
+		return err
 	}
 
-	// Set up context with signal handling
-	ctx, _, cleanup := setupContextWithSignalHandling()
-	defer cleanup()
+	// Discover the running dashboard port
+	dashboardPort, err := discoverDashboardPort(projectDir)
+	if err != nil {
+		return err
+	}
 
-	// Determine which services to stop
-	var servicesToStop []string
-	if stopAll {
-		servicesToStop = ctrl.GetRunningServices()
-		if len(servicesToStop) == 0 {
-			if handleNoServicesCase(ctrl, "running", "stop") {
-				return nil
-			}
-		}
-		if !confirmBulkOperation(len(servicesToStop), "stop", stopYes) {
-			cliout.Info("Operation canceled")
-			return nil
-		}
-	} else {
-		servicesToStop, err = parseServiceList(stopService)
-		if err != nil {
-			return err
+	baseURL := fmt.Sprintf("http://localhost:%d", dashboardPort)
+
+	// Get session token for authentication
+	token, err := fetchSessionToken(baseURL)
+	if err != nil {
+		return fmt.Errorf("failed to authenticate with running app: %w", err)
+	}
+
+	// Send shutdown request
+	if err := sendShutdownRequest(baseURL, token); err != nil {
+		return err
+	}
+
+	cliout.Success("Shutdown signal sent — app is stopping")
+	return nil
+}
+
+// findProjectDir locates the project root by finding azure.yaml.
+func findProjectDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	azureYamlPath, err := detector.FindAzureYaml(cwd)
+	if err != nil || azureYamlPath == "" {
+		return "", fmt.Errorf("could not find azure.yaml — are you in a project directory?")
+	}
+	return filepath.Dir(azureYamlPath), nil
+}
+
+// discoverDashboardPort reads the dashboard port from the port file or azdconfig.
+func discoverDashboardPort(projectDir string) (int, error) {
+	// Primary: file-based discovery (works cross-process without gRPC dependency)
+	if port := dashboard.ReadPortFile(projectDir); port > 0 {
+		return port, nil
+	}
+
+	// Fallback: try azdconfig (may work if gRPC host is available)
+	client, err := azdconfig.NewClient(context.Background())
+	if err == nil {
+		projectHash := azdconfig.ProjectHash(projectDir)
+		if port, err := client.GetDashboardPort(projectHash); err == nil && port > 0 {
+			return port, nil
 		}
 	}
 
-	return executeServiceOperation(ctx, servicesToStop, ctrl.StopService, ctrl.BulkStop, "stop")
+	return 0, fmt.Errorf("no running app found — is 'azd app run' active in this project?")
+}
+
+// fetchSessionToken retrieves the session token from the running dashboard.
+func fetchSessionToken(baseURL string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/session-token", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("could not connect to running app — it may have already stopped")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected response from session-token endpoint (status %d)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// sendShutdownRequest sends a POST to the dashboard's shutdown endpoint.
+func sendShutdownRequest(baseURL, token string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/shutdown", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Session-Token", token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send shutdown signal: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("shutdown request failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
 }

--- a/cli/src/internal/dashboard/server_core.go
+++ b/cli/src/internal/dashboard/server_core.go
@@ -30,11 +30,11 @@ type Server struct {
 	server       *http.Server
 	projectDir   string
 	stopChan     chan struct{}
-	stopOnce     sync.Once  // Ensure stopChan is only closed once
+	stopOnce     sync.Once     // Ensure stopChan is only closed once
 	shutdownChan chan struct{} // Signals the run process to initiate graceful shutdown
-	shutdownOnce sync.Once    // Ensure shutdownChan is only closed once
-	started      bool       // Track if server was successfully started
-	startedMu    sync.Mutex // Protect started flag
+	shutdownOnce sync.Once     // Ensure shutdownChan is only closed once
+	started      bool          // Track if server was successfully started
+	startedMu    sync.Mutex    // Protect started flag
 	configClient azdconfig.ConfigClient
 	currentMode  service.LogMode // Current log source mode (local or azure)
 	modeMu       sync.RWMutex    // Protect currentMode

--- a/cli/src/internal/dashboard/server_core.go
+++ b/cli/src/internal/dashboard/server_core.go
@@ -31,6 +31,8 @@ type Server struct {
 	projectDir   string
 	stopChan     chan struct{}
 	stopOnce     sync.Once  // Ensure stopChan is only closed once
+	shutdownChan chan struct{} // Signals the run process to initiate graceful shutdown
+	shutdownOnce sync.Once    // Ensure shutdownChan is only closed once
 	started      bool       // Track if server was successfully started
 	startedMu    sync.Mutex // Protect started flag
 	configClient azdconfig.ConfigClient
@@ -64,6 +66,7 @@ func GetServer(projectDir string) *Server {
 		mux:          http.NewServeMux(),
 		projectDir:   absPath,
 		stopChan:     make(chan struct{}),
+		shutdownChan: make(chan struct{}),
 		currentMode:  service.LogModeLocal, // Default to local mode
 		broadcast:    broadcast.New(),
 		sessionToken: rpc.GenerateSessionToken(),
@@ -82,6 +85,20 @@ func (s *Server) GetURL() string {
 		return ""
 	}
 	return fmt.Sprintf("http://localhost:%d", s.port)
+}
+
+// ShutdownChan returns a channel that is closed when a remote shutdown is requested.
+// The run orchestrator selects on this to initiate graceful shutdown.
+func (s *Server) ShutdownChan() <-chan struct{} {
+	return s.shutdownChan
+}
+
+// RequestShutdown signals the run process to initiate graceful shutdown.
+// Safe to call multiple times.
+func (s *Server) RequestShutdown() {
+	s.shutdownOnce.Do(func() {
+		close(s.shutdownChan)
+	})
 }
 
 // getCurrentMode is a thread-safe accessor for currentMode. Exported via

--- a/cli/src/internal/dashboard/server_port_mgmt.go
+++ b/cli/src/internal/dashboard/server_port_mgmt.go
@@ -8,6 +8,8 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,6 +45,9 @@ func (s *Server) registerPortInConfig(port int) {
 	} else {
 		slog.Debug("registered dashboard port in config", "port", port, "projectHash", projectHash)
 	}
+
+	// Also write port file for cross-process discovery (doesn't depend on gRPC host)
+	writePortFile(s.projectDir, port)
 }
 
 // clearPortFromConfig removes the dashboard port from azdconfig.
@@ -55,6 +60,47 @@ func (s *Server) clearPortFromConfig() {
 	} else {
 		slog.Debug("cleared dashboard port from config", "projectHash", projectHash)
 	}
+
+	// Also remove port file
+	removePortFile(s.projectDir)
+}
+
+// portFilePath returns the path to the dashboard port file for a project.
+// Uses OS temp dir keyed by project hash to avoid polluting the project directory.
+func portFilePath(projectDir string) string {
+	hash := azdconfig.ProjectHash(projectDir)
+	return filepath.Join(os.TempDir(), fmt.Sprintf(".azd-app-dashboard-%s.port", hash))
+}
+
+// writePortFile writes the dashboard port to a file for cross-process discovery.
+func writePortFile(projectDir string, port int) {
+	path := portFilePath(projectDir)
+	if err := os.WriteFile(path, []byte(strconv.Itoa(port)), 0600); err != nil {
+		slog.Debug("failed to write dashboard port file", "path", path, "error", err)
+	}
+}
+
+// removePortFile removes the dashboard port file.
+func removePortFile(projectDir string) {
+	path := portFilePath(projectDir)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Debug("failed to remove dashboard port file", "path", path, "error", err)
+	}
+}
+
+// ReadPortFile reads the dashboard port from the port file for a project directory.
+// Returns 0 if the file doesn't exist or can't be read.
+func ReadPortFile(projectDir string) int {
+	path := portFilePath(projectDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return port
 }
 
 // generatePreferredPort returns a preferred port for the dashboard server.

--- a/cli/src/internal/dashboard/server_routes.go
+++ b/cli/src/internal/dashboard/server_routes.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"crypto/subtle"
 	"embed"
 	"io/fs"
 	"log/slog"
@@ -88,6 +89,19 @@ func (s *Server) setupRoutes() {
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Cache-Control", "no-store")
 		_, _ = w.Write([]byte(s.sessionToken))
+	})
+
+	// Shutdown endpoint: signals the run process to initiate graceful teardown.
+	// Used by `azd app stop` from a separate terminal.
+	s.mux.HandleFunc("POST /api/shutdown", func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("X-Session-Token")
+		if subtle.ConstantTimeCompare([]byte(token), []byte(s.sessionToken)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.RequestShutdown()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"shutting_down"}`))
 	})
 
 	// Pre-read index.html once for SPA client-side routing fallback

--- a/cli/src/internal/service/hooks_test.go
+++ b/cli/src/internal/service/hooks_test.go
@@ -511,3 +511,204 @@ services:
 		t.Errorf("Expected POSIX Shell='zsh', got: %s", prerun.Posix.Shell)
 	}
 }
+
+func TestParseAzureYaml_WithStopHooks(t *testing.T) {
+	yamlContent := `name: test-app
+
+hooks:
+  prestop:
+    run: echo "draining connections"
+    shell: sh
+    continueOnError: true
+  poststop:
+    run: echo "cleanup complete"
+    shell: bash
+
+services:
+  web:
+    language: TypeScript
+    project: ./frontend
+    ports:
+      - "3000"
+`
+
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "azure.yaml")
+
+	err := os.WriteFile(yamlPath, []byte(yamlContent), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	azureYaml, err := ParseAzureYaml(yamlPath)
+	if err != nil {
+		t.Fatalf("Failed to parse azure.yaml: %v", err)
+	}
+
+	if azureYaml.Hooks == nil {
+		t.Fatal("Expected hooks to be non-nil")
+	}
+
+	// Verify prestop hook
+	if azureYaml.Hooks.Prestop == nil {
+		t.Fatal("Expected prestop hook to be non-nil")
+	}
+	if azureYaml.Hooks.Prestop.Run != "echo \"draining connections\"" {
+		t.Errorf("Expected prestop run='echo \"draining connections\"', got: %s", azureYaml.Hooks.Prestop.Run)
+	}
+	if azureYaml.Hooks.Prestop.Shell != "sh" {
+		t.Errorf("Expected prestop shell='sh', got: %s", azureYaml.Hooks.Prestop.Shell)
+	}
+	if !azureYaml.Hooks.Prestop.ContinueOnError {
+		t.Error("Expected prestop continueOnError=true")
+	}
+
+	// Verify poststop hook
+	if azureYaml.Hooks.Poststop == nil {
+		t.Fatal("Expected poststop hook to be non-nil")
+	}
+	if azureYaml.Hooks.Poststop.Run != "echo \"cleanup complete\"" {
+		t.Errorf("Expected poststop run='echo \"cleanup complete\"', got: %s", azureYaml.Hooks.Poststop.Run)
+	}
+	if azureYaml.Hooks.Poststop.Shell != "bash" {
+		t.Errorf("Expected poststop shell='bash', got: %s", azureYaml.Hooks.Poststop.Shell)
+	}
+}
+
+func TestHooks_GetPrestop(t *testing.T) {
+	tests := []struct {
+		name    string
+		hooks   *Hooks
+		wantNil bool
+	}{
+		{
+			name:    "nil hooks",
+			hooks:   nil,
+			wantNil: true,
+		},
+		{
+			name:    "hooks with nil prestop",
+			hooks:   &Hooks{Prestop: nil},
+			wantNil: true,
+		},
+		{
+			name: "hooks with prestop",
+			hooks: &Hooks{
+				Prestop: &Hook{Run: "echo drain"},
+			},
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.hooks.GetPrestop()
+
+			if tt.wantNil {
+				if result != nil {
+					t.Error("Expected nil prestop hook")
+				}
+			} else {
+				if result == nil {
+					t.Error("Expected non-nil prestop hook")
+				}
+			}
+		})
+	}
+}
+
+func TestHooks_GetPoststop(t *testing.T) {
+	tests := []struct {
+		name    string
+		hooks   *Hooks
+		wantNil bool
+	}{
+		{
+			name:    "nil hooks",
+			hooks:   nil,
+			wantNil: true,
+		},
+		{
+			name:    "hooks with nil poststop",
+			hooks:   &Hooks{Poststop: nil},
+			wantNil: true,
+		},
+		{
+			name: "hooks with poststop",
+			hooks: &Hooks{
+				Poststop: &Hook{Run: "echo cleanup"},
+			},
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.hooks.GetPoststop()
+
+			if tt.wantNil {
+				if result != nil {
+					t.Error("Expected nil poststop hook")
+				}
+			} else {
+				if result == nil {
+					t.Error("Expected non-nil poststop hook")
+				}
+			}
+		})
+	}
+}
+
+func TestParseAzureYaml_WithAllHooks(t *testing.T) {
+	yamlContent := `name: test-app
+
+hooks:
+  prerun:
+    run: echo "prerun"
+    shell: sh
+  postrun:
+    run: echo "postrun"
+    shell: sh
+  prestop:
+    run: echo "prestop"
+    shell: sh
+  poststop:
+    run: echo "poststop"
+    shell: sh
+
+services:
+  web:
+    language: TypeScript
+    project: .
+`
+
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "azure.yaml")
+
+	err := os.WriteFile(yamlPath, []byte(yamlContent), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	azureYaml, err := ParseAzureYaml(yamlPath)
+	if err != nil {
+		t.Fatalf("Failed to parse azure.yaml: %v", err)
+	}
+
+	if azureYaml.Hooks == nil {
+		t.Fatal("Expected hooks to be non-nil")
+	}
+
+	if azureYaml.Hooks.GetPrerun() == nil {
+		t.Error("Expected prerun hook to be non-nil")
+	}
+	if azureYaml.Hooks.GetPostrun() == nil {
+		t.Error("Expected postrun hook to be non-nil")
+	}
+	if azureYaml.Hooks.GetPrestop() == nil {
+		t.Error("Expected prestop hook to be non-nil")
+	}
+	if azureYaml.Hooks.GetPoststop() == nil {
+		t.Error("Expected poststop hook to be non-nil")
+	}
+}

--- a/cli/src/internal/service/types.go
+++ b/cli/src/internal/service/types.go
@@ -869,10 +869,12 @@ func (s *Service) GetPrimaryPort() (int, int, bool) {
 	return mappings[0].HostPort, mappings[0].ContainerPort, isExplicit
 }
 
-// Hooks represents lifecycle hooks for run command.
+// Hooks represents lifecycle hooks for run and stop commands.
 type Hooks struct {
-	Prerun  *Hook `yaml:"prerun,omitempty"`
-	Postrun *Hook `yaml:"postrun,omitempty"`
+	Prerun   *Hook `yaml:"prerun,omitempty"`
+	Postrun  *Hook `yaml:"postrun,omitempty"`
+	Prestop  *Hook `yaml:"prestop,omitempty"`
+	Poststop *Hook `yaml:"poststop,omitempty"`
 }
 
 // GetPrerun safely retrieves the prerun hook, returning nil if not configured.
@@ -889,6 +891,22 @@ func (h *Hooks) GetPostrun() *Hook {
 		return nil
 	}
 	return h.Postrun
+}
+
+// GetPrestop safely retrieves the prestop hook, returning nil if not configured.
+func (h *Hooks) GetPrestop() *Hook {
+	if h == nil {
+		return nil
+	}
+	return h.Prestop
+}
+
+// GetPoststop safely retrieves the poststop hook, returning nil if not configured.
+func (h *Hooks) GetPoststop() *Hook {
+	if h == nil {
+		return nil
+	}
+	return h.Poststop
 }
 
 // Hook represents a lifecycle hook configuration.

--- a/cli/src/internal/skills/azd-app/SKILL.md
+++ b/cli/src/internal/skills/azd-app/SKILL.md
@@ -104,11 +104,11 @@ Start a previously stopped service.
 | `--service, -s` | Service to start |
 
 ### `azd app stop`
-Stop a running service.
+Stop running services and tear down the app. By default stops all services, releases ports, and executes lifecycle hooks.
 
 | Flag | Description |
 |------|-------------|
-| `--service, -s` | Service to stop |
+| `--service, -s` | Service to stop (if omitted, stops all) |
 
 ### `azd app restart`
 Restart a running service.
@@ -140,10 +140,12 @@ Environment variables are resolved at service startup and injected into each ser
 
 azd-app supports lifecycle hooks defined in `azure.yaml`:
 
-- **prerun** — runs before the service starts
-- **postrun** — runs after the service stops
+- **prerun** — runs before services start
+- **postrun** — runs after services are ready
+- **prestop** — runs before services are stopped (e.g., drain connections, flush caches)
+- **poststop** — runs after all services are stopped (e.g., cleanup temp files, remove tunnels)
 
-Hooks can be defined per-service or at the project level.
+Hooks can be defined at the project level. Hook failures in `prestop`/`poststop` are non-fatal — services will still be stopped.
 
 ## Supported Languages
 

--- a/cli/tests/projects/integration/hooks-test/README.md
+++ b/cli/tests/projects/integration/hooks-test/README.md
@@ -4,18 +4,19 @@ Test projects demonstrating hook functionality in azd app.
 
 ## hooks-test
 
-Basic example with simple prerun and postrun hooks that echo messages.
+Basic example with simple prerun, postrun, prestop, and poststop hooks that echo messages.
 
 **Features:**
 - Simple echo-based hooks
 - Single service (Node.js)
-- Demonstrates basic hook execution
+- Demonstrates basic hook execution for run and stop lifecycle
 
 **To test:**
 ```bash
 cd hooks-test
 azd app run --dry-run  # Preview without running
 # azd app run  # Note: Would start a service that runs for 5 minutes
+# azd app stop  # Stops all services, executes prestop/poststop hooks
 ```
 
 ## Platform-Specific Hooks (Removed)
@@ -53,11 +54,17 @@ To test actual hook execution in unit tests, see:
 
 ## Expected Behavior
 
-### Successful Execution
+### Successful Execution (run)
 1. Prerun hook executes before services start
 2. Services start and become ready
 3. Postrun hook executes after all services are ready
 4. Dashboard shows running services
+
+### Successful Execution (stop)
+1. Prestop hook executes before services are stopped
+2. Services are stopped gracefully (SIGTERM → timeout → SIGKILL)
+3. All port assignments are released
+4. Poststop hook executes after all services are stopped
 
 ### Hook Failure (continueOnError: false)
 1. Prerun hook fails
@@ -69,3 +76,7 @@ To test actual hook execution in unit tests, see:
 2. Warning displayed but execution continues
 3. Services start normally
 4. Postrun hook still executes
+
+### Stop Hook Failure
+1. Prestop hook fails → warning displayed, services still stop
+2. Poststop hook fails → warning displayed, stop is complete

--- a/cli/tests/projects/integration/hooks-test/azure.yaml
+++ b/cli/tests/projects/integration/hooks-test/azure.yaml
@@ -4,12 +4,15 @@ name: hooks-test-project
 
 hooks:
   prerun:
-    run: echo "🔧 Running prerun hook - preparing environment..."
-    shell: sh
+    run: echo "Running prerun hook - preparing environment..."
     continueOnError: false
   postrun:
-    run: echo "✅ Running postrun hook - all services are ready!"
-    shell: sh
+    run: echo "Running postrun hook - all services are ready!"
+  prestop:
+    run: echo "Running prestop hook - saving state before shutdown..."
+    continueOnError: true
+  poststop:
+    run: echo "Running poststop hook - cleanup complete!"
 
 services:
   web:
@@ -20,6 +23,11 @@ services:
     environment:
       NODE_ENV: development
       API_URL: http://localhost:8100
+    hooks:
+      prestop:
+        run: echo "[web] prestop - flushing connections..."
+      poststop:
+        run: echo "[web] poststop - web service fully stopped"
 
 reqs:
   - name: node

--- a/cli/tests/projects/integration/hooks-test/package.json
+++ b/cli/tests/projects/integration/hooks-test/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Test project for hook functionality",
   "scripts": {
-    "dev": "echo 'Mock dev server started on port 3000' && sleep 300",
-    "start": "echo 'Mock production server started' && sleep 300"
+    "dev": "node -e \"const http=require('http');const s=http.createServer((q,r)=>{r.end('ok')});s.listen(3000,()=>console.log('Mock dev server started on port 3000'))\"",
+    "start": "node -e \"const http=require('http');const s=http.createServer((q,r)=>{r.end('ok')});s.listen(3000,()=>console.log('Mock production server started on port 3000'))\""
   },
   "dependencies": {},
   "devDependencies": {}

--- a/schemas/v1.1/CHANGELOG.md
+++ b/schemas/v1.1/CHANGELOG.md
@@ -47,8 +47,9 @@ All v1.0 azure.yaml files are **fully compatible** with v1.1, and all v1.0 prope
    - Coverage thresholds
    - Custom test commands
 
-9. **Additional Hooks** (`hooks.prerun`, `hooks.postrun`)
+9. **Additional Hooks** (`hooks.prerun`, `hooks.postrun`, `hooks.prestop`, `hooks.poststop`)
    - Run hooks for `azd app run` command
+   - Stop hooks for `azd app stop` command (drain connections, cleanup)
 
 ## Compatibility
 

--- a/schemas/v1.1/azure.yaml.json
+++ b/schemas/v1.1/azure.yaml.json
@@ -214,6 +214,16 @@
           "title": "post run hook",
           "description": "Runs after the `run` command (azd app extension)",
           "$ref": "#/definitions/hooks"
+        },
+        "prestop": {
+          "title": "pre stop hook",
+          "description": "Runs before the `stop` command stops services (azd app extension). Use for draining connections, flushing caches, or notifying dependents.",
+          "$ref": "#/definitions/hooks"
+        },
+        "poststop": {
+          "title": "post stop hook",
+          "description": "Runs after the `stop` command has stopped all services (azd app extension). Use for cleanup, removing temp files, or tearing down tunnels.",
+          "$ref": "#/definitions/hooks"
         }
       }
     },
@@ -2338,6 +2348,15 @@
         "postrun": {
           "run": "echo 'All services are ready!'",
           "shell": "sh"
+        },
+        "prestop": {
+          "run": "echo 'Draining connections...'",
+          "shell": "sh",
+          "continueOnError": true
+        },
+        "poststop": {
+          "run": "./scripts/cleanup.sh",
+          "shell": "bash"
         }
       }
     },

--- a/web/src/pages/reference/azure-yaml.astro
+++ b/web/src/pages/reference/azure-yaml.astro
@@ -255,12 +255,17 @@ const hooksExample = `hooks:
     run: echo "🚀 All services are running!"
     shell: sh
     continueOnError: true  # Don't fail if hook fails
-    
-  # Interactive hook (binds to stdin/stdout)
-  prerun:
-    run: ./scripts/setup.sh
+
+  # Pre-stop hook (drain connections before shutdown)
+  prestop:
+    run: echo "Draining connections..."
+    shell: sh
+    continueOnError: true
+
+  # Post-stop cleanup
+  poststop:
+    run: ./scripts/cleanup.sh
     shell: bash
-    interactive: true
     
   # Platform-specific hooks
   prerun:
@@ -401,6 +406,13 @@ hooks:
   postrun:
     run: echo "✨ Ready to code!"
     shell: sh
+  prestop:
+    run: echo "⏹️ Shutting down..."
+    shell: sh
+    continueOnError: true
+  poststop:
+    run: echo "🧹 Cleanup complete!"
+    shell: sh
 
 # 📊 Global logging
 logs:
@@ -539,7 +551,7 @@ const quickReference = `# Property Quick Reference
 ### Development (azd app)
 - services - Service definitions
 - reqs - Prerequisites
-- hooks - Lifecycle hooks (prerun, postrun)
+- hooks - Lifecycle hooks (prerun, postrun, prestop, poststop)
 - logs - Logging configuration
 - test - Testing configuration
 
@@ -2027,6 +2039,8 @@ const resourceTypesExample = `resources:
           <ul class="list-disc list-inside space-y-2 text-neutral-700 dark:text-neutral-300">
             <li><code class="px-2 py-1 bg-white dark:bg-neutral-800 rounded">prerun</code> - Runs before <code class="px-2 py-1 bg-white dark:bg-neutral-800 rounded">azd app run</code></li>
             <li><code class="px-2 py-1 bg-white dark:bg-neutral-800 rounded">postrun</code> - Runs after <code class="px-2 py-1 bg-white dark:bg-neutral-800 rounded">azd app run</code></li>
+            <li><code class="px-2 py-1 bg-white dark:bg-neutral-800 rounded">prestop</code> - Runs before <code class="px-2 py-1 bg-white dark:bg-neutral-800 rounded">azd app stop</code></li>
+            <li><code class="px-2 py-1 bg-white dark:bg-neutral-800 rounded">poststop</code> - Runs after <code class="px-2 py-1 bg-white dark:bg-neutral-800 rounded">azd app stop</code></li>
           </ul>
           
           <h3 class="text-lg font-bold mb-2 mt-4">Hook Properties</h3>
@@ -2112,6 +2126,16 @@ const resourceTypesExample = `resources:
                 <td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400">postrun</code></td>
                 <td class="py-3 px-4">azd app</td>
                 <td class="py-3 px-4">After <code>azd app run</code></td>
+              </tr>
+              <tr class="border-t border-neutral-200 dark:border-neutral-700">
+                <td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400">prestop</code></td>
+                <td class="py-3 px-4">azd app</td>
+                <td class="py-3 px-4">Before <code>azd app stop</code></td>
+              </tr>
+              <tr class="border-t border-neutral-200 dark:border-neutral-700">
+                <td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400">poststop</code></td>
+                <td class="py-3 px-4">azd app</td>
+                <td class="py-3 px-4">After <code>azd app stop</code></td>
               </tr>
               <tr class="border-t border-neutral-200 dark:border-neutral-700">
                 <td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400">predeploy</code></td>

--- a/web/src/pages/reference/cli/index.astro
+++ b/web/src/pages/reference/cli/index.astro
@@ -99,9 +99,9 @@ azd app mcp serve`;
         <code class="text-lg font-semibold text-blue-600 dark:text-blue-400">azd app stop</code>
         <span class="text-xs px-2 py-1 bg-green-200 dark:bg-green-900 text-green-800 dark:text-green-300 rounded">Full Docs</span>
       </div>
-      <p class="text-neutral-700 dark:text-neutral-300">Stop running services.</p>
+      <p class="text-neutral-700 dark:text-neutral-300">Stop running services, execute lifecycle hooks, and tear down the app. Works cross-process.</p>
       <div class="mt-4 text-sm text-neutral-600 dark:text-neutral-400">
-        3 flags • 4 examples
+        0 flags • 1 example
       </div>
     </a>
 

--- a/web/src/pages/reference/cli/stop.astro
+++ b/web/src/pages/reference/cli/stop.astro
@@ -1,14 +1,11 @@
 ---
 import Layout from '../../../components/Layout.astro';
 import { Code } from 'astro-expressive-code/components';
-const usageCode = "azd app stop [flags]";
-const example0 = "azd app stop [flags]";
-const example1 = "azd app stop --service api";
-const example2 = "azd app stop --service \"api,web,worker\"";
-const example3 = "azd app stop --all";
+const usageCode = "azd app stop";
+const example0 = "# Stop the running app (from any terminal in the project)\nazd app stop";
 ---
 
-<Layout title="stop - CLI Reference" description="Stop running services.">
+<Layout title="stop - CLI Reference" description="Stop running services and tear down the app.">
   <div class="max-w-4xl mx-auto px-4 py-12">
     <nav class="text-sm mb-8">
       <ol class="flex items-center gap-2 text-neutral-500">
@@ -22,18 +19,30 @@ const example3 = "azd app stop --all";
 
     <div class="mb-8">
       <h1 class="text-4xl font-bold mb-4">azd app stop</h1>
-      <p class="text-xl text-neutral-700 dark:text-neutral-300">Stop running services.</p>
+      <p class="text-xl text-neutral-700 dark:text-neutral-300">Stop running services, execute lifecycle hooks, and tear down the app.</p>
     </div>
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Usage</h2>
     <Code code={usageCode} lang="bash" frame="terminal" />
 
-    <h2 class="text-2xl font-bold mt-12 mb-4">Flags</h2><div class="overflow-x-auto my-8"><table class="min-w-full text-sm rounded-lg overflow-hidden border border-neutral-200 dark:border-neutral-700"><thead><tr class="bg-neutral-200 dark:bg-neutral-700"><th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Flag</th><th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Short</th><th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Type</th><th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Default</th><th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Description</th></tr></thead><tbody class="bg-neutral-100 dark:bg-neutral-800"><tr class="border-t border-neutral-200 dark:border-neutral-700"><td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400 bg-transparent">--service</code></td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300"><code class="bg-transparent">-s</code></td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">string</td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">-</td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">Service name(s) to stop (comma-separated)</td></tr><tr class="border-t border-neutral-200 dark:border-neutral-700"><td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400 bg-transparent">--all</code></td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">-</td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">bool</td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">false</td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">Stop all running services</td></tr><tr class="border-t border-neutral-200 dark:border-neutral-700"><td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400 bg-transparent">--yes</code></td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300"><code class="bg-transparent">-y</code></td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">bool</td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">false</td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">Skip confirmation prompt for `--all`</td></tr></tbody></table></div>
+    <div class="my-8 p-4 bg-neutral-100 dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700">
+      <p class="text-neutral-700 dark:text-neutral-300">
+        <strong>No flags required.</strong> Run <code>azd app stop</code> from any terminal in the project directory to signal the running <code>azd app run</code> process to shut down gracefully. This triggers the same shutdown path as pressing Ctrl+C — including prestop/poststop hooks, port release, and process cleanup.
+      </p>
+    </div>
 
-    <h2 class="text-2xl font-bold mt-12 mb-6">Examples</h2><div class="space-y-4"><Code code={example0} lang="bash" frame="terminal" />
-  <Code code={example1} lang="bash" frame="terminal" />
-  <Code code={example2} lang="bash" frame="terminal" />
-  <Code code={example3} lang="bash" frame="terminal" /></div>
+    <h2 class="text-2xl font-bold mt-12 mb-4">How It Works</h2>
+    <ol class="list-decimal list-inside space-y-2 text-neutral-700 dark:text-neutral-300">
+      <li>Discovers the running dashboard port (stored in a temp file per-project)</li>
+      <li>Authenticates with the dashboard using a per-session token</li>
+      <li>Sends a shutdown signal to the running <code>azd app run</code> process</li>
+      <li>The run process executes <code>prestop</code> hook, stops all services, then executes <code>poststop</code> hook</li>
+    </ol>
+
+    <h2 class="text-2xl font-bold mt-12 mb-4">Lifecycle Hooks</h2>
+    <div class="overflow-x-auto my-4"><table class="min-w-full text-sm rounded-lg overflow-hidden border border-neutral-200 dark:border-neutral-700"><thead><tr class="bg-neutral-200 dark:bg-neutral-700"><th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Hook</th><th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">When</th><th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Use Case</th></tr></thead><tbody class="bg-neutral-100 dark:bg-neutral-800"><tr class="border-t border-neutral-200 dark:border-neutral-700"><td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400 bg-transparent">prestop</code></td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">Before services are stopped</td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">Drain connections, flush caches</td></tr><tr class="border-t border-neutral-200 dark:border-neutral-700"><td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400 bg-transparent">poststop</code></td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">After all services are stopped</td><td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">Cleanup temp files, remove tunnels</td></tr></tbody></table></div>
+
+    <h2 class="text-2xl font-bold mt-12 mb-6">Examples</h2><div class="space-y-4"><Code code={example0} lang="bash" frame="terminal" /></div>
 
     <div class="mt-12 p-6 bg-blue-100 dark:bg-blue-900/40 rounded-lg border border-blue-300 dark:border-blue-700"><h3 class="text-lg font-semibold mb-2 text-neutral-900 dark:text-neutral-100">📚 Detailed Documentation</h3><p class="text-neutral-700 dark:text-neutral-300 mb-4">For complete documentation including flows, diagrams, and advanced usage, see the full command specification.</p><a href="https://github.com/jongio/azd-app/blob/main/cli/docs/commands/stop.md" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 text-blue-700 dark:text-blue-400 hover:underline">View full stop specification →</a></div>
 
@@ -45,17 +54,4 @@ const example3 = "azd app stop --all";
       </div>
     </div>
   </div>
-
-  <script>
-    document.querySelectorAll('.copy-button').forEach(button => {
-      button.addEventListener('click', async () => {
-        const code = button.getAttribute('data-code');
-        if (code) {
-          await navigator.clipboard.writeText(code);
-          button.textContent = 'Copied!';
-          setTimeout(() => { button.textContent = 'Copy'; }, 2000);
-        }
-      });
-    });
-  </script>
 </Layout>


### PR DESCRIPTION
## Summary

Implements `azd app stop` that works **cross-process** — run it from any terminal in the project to gracefully stop a running `azd app run` instance. Also adds **prestop/poststop lifecycle hooks**.

## Architecture

```
azd app stop → discover port (temp file) → GET /api/session-token
→ POST /api/shutdown → dashboard signals shutdownChan
→ graceful teardown (same as Ctrl+C)
```

## Changes

### Core Feature
- **stop.go**: Rewritten as HTTP client — discovers dashboard port, authenticates with session token, sends shutdown signal
- **server_routes.go**: Added `POST /api/shutdown` endpoint with constant-time token validation
- **server_core.go**: Added `shutdownChan` / `RequestShutdown()` for cross-process signaling
- **server_port_mgmt.go**: Added file-based port storage (`$TEMP/.azd-app-dashboard-{hash}.port`) for reliable cross-process discovery
- **run_orchestration.go**: Wired shutdown channel into monitor select + integrated prestop/poststop hooks into graceful shutdown path

### Lifecycle Hooks
- **service/types.go**: Added `Prestop` / `Poststop` fields to `Hooks` struct with getters
- Hooks fire on both Ctrl+C and `azd app stop` (same code path)

### Build Versioning
- **magefile.go**: Dev builds now show `0.16.0+dev.g<sha>.dirty` via git metadata injection

### Schema and Docs
- Updated v1.1 JSON schema with prestop/poststop definitions
- Updated all doc files (stop.md, hooks.md, azure.yaml.md, cli-reference.md, SKILL.md)
- Updated web site reference page
- Added integration test project with all hook types

## Testing

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -short ./src/cmd/app/commands/ ./src/internal/dashboard/ ./src/internal/service/` ✓
- Manual e2e: `azd app run` in terminal 1, `azd app stop` in terminal 2 → graceful shutdown with hooks ✓

## Security

- Session token: 256-bit CSPRNG, constant-time comparison
- Port file: 0600 permissions, OS temp dir (user-scoped on Windows)
- Dashboard: 127.0.0.1 only, security headers (CSP, X-Frame-Options)
- Shutdown is idempotent via `sync.Once`
