### PR TITLE
fix: auto-resolve port conflicts with --force and in non-interactive mode

### DIFF
--- a/cli/src/cmd/app/commands/run.go
+++ b/cli/src/cmd/app/commands/run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jongio/azd-app/cli/src/internal/detector"
 	"github.com/jongio/azd-app/cli/src/internal/orchestrator"
+	"github.com/jongio/azd-app/cli/src/internal/portmanager"
 	"github.com/jongio/azd-app/cli/src/internal/service"
 	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
 	"github.com/jongio/azd-app/cli/src/internal/trust"
@@ -60,7 +61,7 @@ func NewRunCommand() *cobra.Command {
 	cmd.Flags().StringVar(&runRuntime, "runtime", runtimeModeAzd, "Runtime mode: 'azd' (azd dashboard) or 'aspire' (native Aspire with dotnet run)")
 	cmd.Flags().BoolVarP(&runWeb, "web", "w", false, "Open dashboard in browser")
 	cmd.Flags().BoolVar(&runRestartContainers, "restart-containers", false, "Restart containers even if they are already running")
-	cmd.Flags().BoolVar(&runForce, "force", false, "Force clean dependency reinstall (passes --force to deps)")
+	cmd.Flags().BoolVar(&runForce, "force", false, "Force clean dependency reinstall and auto-resolve port conflicts without prompting")
 	cmd.Flags().BoolVar(&runTrust, "trust", false, "Trust this workspace for code execution and remember the decision")
 
 	return cmd
@@ -264,6 +265,11 @@ func runAzdMode(ctx context.Context, azureYamlPath, azureYamlDir string) error {
 	services := filterServices(azureYaml)
 	if len(services) == 0 {
 		return fmt.Errorf("no services match filter: %s", runServiceFilter)
+	}
+
+	// Propagate --force to port manager so port conflicts auto-resolve without prompting
+	if runForce {
+		portmanager.GetPortManager(azureYamlDir).SetForceMode(true)
 	}
 
 	runtimes, err := detectServiceRuntimes(services, azureYamlDir, runtimeModeAzd)

--- a/cli/src/internal/portmanager/portmanager.go
+++ b/cli/src/internal/portmanager/portmanager.go
@@ -32,6 +32,9 @@ type PortManager struct {
 	// sessionAlwaysKill tracks if user selected "always kill" during this session.
 	// This ensures the preference is honored immediately without waiting for config reload.
 	sessionAlwaysKill bool
+	// forceMode when true auto-kills conflicting processes without prompting.
+	// Set via SetForceMode when --force is passed to azd app run.
+	forceMode bool
 }
 
 // cacheEntry holds a port manager with LRU tracking
@@ -426,7 +429,7 @@ func (pm *PortManager) reassignPort(serviceName string, _ int, isExplicit bool) 
 	if isExplicit {
 		// Release mutex before blocking on user input
 		pm.mu.Unlock()
-		wantsUpdate := promptUpdateAzureYaml(port)
+		wantsUpdate := promptUpdateAzureYaml(pm, port)
 		pm.mu.Lock()
 
 		if wantsUpdate {
@@ -537,6 +540,13 @@ func (pm *PortManager) getConfigClient() (azdconfig.ConfigClient, error) { //nol
 // SetConfigClient sets a custom config client for testing purposes.
 func (pm *PortManager) SetConfigClient(client azdconfig.ConfigClient) {
 	pm.configClient = client
+}
+
+// SetForceMode enables or disables force mode. When enabled, port conflicts are
+// auto-resolved by killing the conflicting process without prompting the user.
+// This is used when --force is passed to azd app run.
+func (pm *PortManager) SetForceMode(force bool) {
+	pm.forceMode = force
 }
 
 // getAlwaysKillPreference returns true if the user has set the preference to always kill

--- a/cli/src/internal/portmanager/portmanager_prompts.go
+++ b/cli/src/internal/portmanager/portmanager_prompts.go
@@ -24,10 +24,12 @@ const (
 )
 
 // handlePortConflict prompts the user to resolve a port conflict and returns the chosen action.
-// It checks the always-kill preference first and returns ActionKill if enabled.
+// It checks force mode and always-kill preference first, returning ActionKill without
+// prompting when either is enabled. In non-interactive environments (piped stdin),
+// it auto-kills with a warning instead of crashing with EOF.
 //
 // Parameters:
-//   - pm: The port manager instance (used for preferences)
+//   - pm: The port manager instance (used for preferences and force mode)
 //   - port: The conflicting port number
 //   - serviceName: The name of the service requiring the port
 //   - processInfo: Human-readable info about the process using the port (e.g., " by nginx (PID 1234)")
@@ -40,10 +42,24 @@ const (
 // IMPORTANT: The caller MUST release the mutex before calling this function
 // and re-acquire it after, as this function blocks on user input.
 func handlePortConflict(pm *PortManager, port int, serviceName string, processInfo string, isExplicit bool) (PortConflictAction, error) {
+	// Check force mode first (--force flag)
+	if pm.forceMode {
+		slog.Info("auto-killing process on port due to --force flag", "port", port, "service", serviceName)
+		printForceKillMessage(serviceName, port, processInfo, isExplicit)
+		return ActionKill, nil
+	}
+
 	// Check if user has set preference to always kill
 	if pm.getAlwaysKillPreference() {
 		slog.Info("auto-killing process on port due to always-kill preference", "port", port, "service", serviceName)
 		printAutoKillMessage(serviceName, port, processInfo, isExplicit)
+		return ActionKill, nil
+	}
+
+	// Non-interactive stdin: auto-kill instead of crashing with EOF
+	if !isStdinInteractive() {
+		slog.Warn("non-interactive stdin detected, auto-killing process on port", "port", port, "service", serviceName)
+		printNonInteractiveKillMessage(serviceName, port, processInfo, isExplicit)
 		return ActionKill, nil
 	}
 
@@ -100,10 +116,16 @@ func printConflictMessage(serviceName string, port int, processInfo string, isEx
 
 // promptUpdateAzureYaml prompts the user to update azure.yaml with a new port.
 // Returns true if user wants to update, false otherwise.
+// In force mode or non-interactive environments, returns false without prompting.
 //
 // IMPORTANT: The caller MUST release the mutex before calling this function
 // and re-acquire it after, as this function blocks on user input.
-func promptUpdateAzureYaml(port int) bool {
+func promptUpdateAzureYaml(pm *PortManager, port int) bool {
+	// Skip prompt in force mode or non-interactive environments
+	if pm.forceMode || !isStdinInteractive() {
+		return false
+	}
+
 	fmt.Fprintf(os.Stderr, "\n⚠️  IMPORTANT: Update your application code to use port %d\n", port)
 	fmt.Fprintf(os.Stderr, "Would you like to update azure.yaml to use port %d for future runs? (y/N): ", port)
 
@@ -169,4 +191,33 @@ func printPortStillInUseMessage(port int) {
 // printAutoAssignedMessage prints a message when a port is auto-assigned.
 func printAutoAssignedMessage(serviceName string, port int) {
 	fmt.Fprintf(os.Stderr, "✓ Auto-assigned port %d to service '%s'\n\n", port, serviceName)
+}
+
+// printForceKillMessage prints the message shown when --force flag triggers auto-kill.
+func printForceKillMessage(serviceName string, port int, processInfo string, isExplicit bool) {
+	if isExplicit {
+		fmt.Fprintf(os.Stderr, "\n⚠️  Service '%s' requires port %d%s - auto-killing (--force)\n", serviceName, port, processInfo)
+	} else {
+		fmt.Fprintf(os.Stderr, "\n⚠️  Service '%s' port %d is in use%s - auto-killing (--force)\n", serviceName, port, processInfo)
+	}
+}
+
+// printNonInteractiveKillMessage prints the message shown when non-interactive stdin triggers auto-kill.
+func printNonInteractiveKillMessage(serviceName string, port int, processInfo string, isExplicit bool) {
+	if isExplicit {
+		fmt.Fprintf(os.Stderr, "\n⚠️  Service '%s' requires port %d%s - auto-killing (non-interactive mode)\n", serviceName, port, processInfo)
+	} else {
+		fmt.Fprintf(os.Stderr, "\n⚠️  Service '%s' port %d is in use%s - auto-killing (non-interactive mode)\n", serviceName, port, processInfo)
+	}
+}
+
+// isStdinInteractive reports whether os.Stdin is connected to a terminal
+// (as opposed to a pipe, file, or /dev/null). Returns false on any error
+// so callers default to non-interactive behavior.
+func isStdinInteractive() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
 }

--- a/cli/src/internal/portmanager/prompts_test.go
+++ b/cli/src/internal/portmanager/prompts_test.go
@@ -27,6 +27,64 @@ func TestPortConflictAction_Constants(t *testing.T) {
 	}
 }
 
+func TestHandlePortConflict_ForceMode(t *testing.T) {
+	pm := &PortManager{forceMode: true}
+
+	action, err := handlePortConflict(pm, 8080, "web", " by node (PID 1234)", false)
+	if err != nil {
+		t.Fatalf("handlePortConflict() error = %v", err)
+	}
+	if action != ActionKill {
+		t.Errorf("handlePortConflict() = %d, want ActionKill (%d)", action, ActionKill)
+	}
+}
+
+func TestHandlePortConflict_ForceMode_Explicit(t *testing.T) {
+	pm := &PortManager{forceMode: true}
+
+	action, err := handlePortConflict(pm, 3000, "api", " by python (PID 5678)", true)
+	if err != nil {
+		t.Fatalf("handlePortConflict() error = %v", err)
+	}
+	if action != ActionKill {
+		t.Errorf("handlePortConflict() = %d, want ActionKill (%d)", action, ActionKill)
+	}
+}
+
+func TestHandlePortConflict_ForceTakesPriorityOverAlwaysKill(t *testing.T) {
+	pm := &PortManager{
+		forceMode:         true,
+		sessionAlwaysKill: true,
+	}
+
+	// Force mode should be checked first
+	action, err := handlePortConflict(pm, 8080, "web", "", false)
+	if err != nil {
+		t.Fatalf("handlePortConflict() error = %v", err)
+	}
+	if action != ActionKill {
+		t.Errorf("handlePortConflict() = %d, want ActionKill (%d)", action, ActionKill)
+	}
+}
+
+func TestSetForceMode(t *testing.T) {
+	pm := &PortManager{}
+
+	if pm.forceMode {
+		t.Error("forceMode should be false by default")
+	}
+
+	pm.SetForceMode(true)
+	if !pm.forceMode {
+		t.Error("forceMode should be true after SetForceMode(true)")
+	}
+
+	pm.SetForceMode(false)
+	if pm.forceMode {
+		t.Error("forceMode should be false after SetForceMode(false)")
+	}
+}
+
 func TestGetProcessInfoString(t *testing.T) {
 	// This function calls getProcessInfoOnPort which is a method, not mockable easily
 	// We'll test with a real PortManager instance
@@ -119,6 +177,30 @@ func TestPrintFunctions(t *testing.T) {
 			name: "printAutoAssignedMessage",
 			fn: func() {
 				printAutoAssignedMessage("test-service", 8080)
+			},
+		},
+		{
+			name: "printForceKillMessage explicit",
+			fn: func() {
+				printForceKillMessage("test-service", 8080, " by node (PID 1234)", true)
+			},
+		},
+		{
+			name: "printForceKillMessage non-explicit",
+			fn: func() {
+				printForceKillMessage("test-service", 8080, " by node (PID 1234)", false)
+			},
+		},
+		{
+			name: "printNonInteractiveKillMessage explicit",
+			fn: func() {
+				printNonInteractiveKillMessage("test-service", 8080, " by node (PID 1234)", true)
+			},
+		},
+		{
+			name: "printNonInteractiveKillMessage non-explicit",
+			fn: func() {
+				printNonInteractiveKillMessage("test-service", 8080, " by node (PID 1234)", false)
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

When `--force` is passed to `azd app run`, port conflicts are now auto-resolved by killing the conflicting process without prompting. Additionally, in non-interactive environments (piped stdin, CI, AI agents), port conflicts are auto-resolved instead of crashing with EOF.

## Changes

- Add `forceMode` field and `SetForceMode()` to `PortManager`
- `handlePortConflict()` priority chain: force -> always-kill -> non-interactive -> prompt
- `isStdinInteractive()` detects piped/non-TTY stdin
- `promptUpdateAzureYaml()` skips in force/non-interactive mode
- Update `--force` flag description to mention port conflict resolution
- Add 5 unit tests for force mode behavior

## Root Cause

`handlePortConflict()` in `portmanager_prompts.go` always prompted via `bufio.NewReader(os.Stdin).ReadString('\n')` unless `alwaysKillPreference` was previously set interactively. No CLI flag or environment variable existed to skip the prompt, causing EOF crashes in non-interactive contexts.

## Testing

- All existing portmanager tests pass (55 tests)
- 5 new unit tests cover force mode, priority ordering, and new print functions
- `go vet` and `go build ./...` clean

Closes #322