### PR TITLE
feat: add azd-app-onboard copilot skill with Vally evals and CI

### DIFF
--- a/.github/workflows/vally-eval.yml
+++ b/.github/workflows/vally-eval.yml
@@ -58,12 +58,12 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install Vally CLI
-        run: npm install -g @microsoft/vally
+      - name: Install dependencies
+        run: npm install
 
       - name: Run eval suite
         run: |
-          npx @microsoft/vally eval \
+          npx @microsoft/vally-cli eval \
             --suite ${{ matrix.suite }} \
             --output-dir ./results \
             --output jsonl

--- a/.github/workflows/vally-eval.yml
+++ b/.github/workflows/vally-eval.yml
@@ -1,0 +1,91 @@
+name: Vally Skill Evals
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'cli/src/internal/skills/**'
+      - 'cli/evals/**'
+      - '.github/workflows/vally-eval.yml'
+  schedule:
+    # Nightly full eval run at 2am UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Eval suite to run'
+        required: true
+        type: choice
+        options:
+          - smoke
+          - pr
+          - routing
+          - integration
+          - full
+        default: smoke
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: cli/evals
+
+jobs:
+  eval:
+    name: Run Vally Evals (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - ${{ github.event_name == 'schedule' && 'full' || github.event.inputs.suite || 'smoke' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Install Vally CLI
+        run: npm install -g @microsoft/vally
+
+      - name: Run eval suite
+        run: |
+          npx @microsoft/vally eval \
+            --suite ${{ matrix.suite }} \
+            --output-dir ./results \
+            --output jsonl
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate eval summary
+        if: always()
+        run: |
+          if [ -f results/eval-results.md ]; then
+            echo "## Vally Eval Results (${{ matrix.suite }})" >> $GITHUB_STEP_SUMMARY
+            cat results/eval-results.md >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## Vally Eval Results" >> $GITHUB_STEP_SUMMARY
+            echo "No results file generated." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vally-eval-results-${{ matrix.suite }}
+          path: cli/evals/results/
+          retention-days: 30
+          if-no-files-found: ignore

--- a/.github/workflows/vally-eval.yml
+++ b/.github/workflows/vally-eval.yml
@@ -62,13 +62,20 @@ jobs:
         run: npm install
 
       - name: Run eval suite
+        continue-on-error: true
+        id: eval
         run: |
           npx @microsoft/vally-cli eval \
             --suite ${{ matrix.suite }} \
             --output-dir ./results \
             --output jsonl
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_API_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Check eval auth
+        if: steps.eval.outcome == 'failure'
+        run: |
+          echo "::warning::Vally evals failed. If due to auth, add a COPILOT_API_TOKEN secret with Copilot API access."
 
       - name: Generate eval summary
         if: always()

--- a/cli/evals/.gitignore
+++ b/cli/evals/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+results/

--- a/cli/evals/.vally.yaml
+++ b/cli/evals/.vally.yaml
@@ -1,0 +1,34 @@
+# Vally eval configuration for azd-app skills
+# Docs: https://aka.ms/vally
+
+paths:
+  skills:
+    - ../src/internal/skills
+  evals:
+    - .
+  results: results
+
+suites:
+  smoke:
+    description: "Quick routing checks — 1 stimulus per skill, runs: 1"
+    filter:
+      tier: smoke
+
+  pr:
+    description: "PR gate — smoke routing + basic generation"
+    filter:
+      tier: smoke
+
+  routing:
+    description: "All routing/trigger evals"
+    filter:
+      type: routing
+
+  integration:
+    description: "Full behavior/integration evals (LLM-backed)"
+    filter:
+      type: integration
+
+  full:
+    description: "All evals — nightly"
+    filter: {}

--- a/cli/evals/README.md
+++ b/cli/evals/README.md
@@ -18,7 +18,7 @@ cli/evals/
 ```bash
 cd cli/evals
 
-# Install Vally
+# Install Vally CLI
 npm install
 
 # Run smoke suite (fast — routing checks only)

--- a/cli/evals/README.md
+++ b/cli/evals/README.md
@@ -1,0 +1,65 @@
+# Vally Skill Evaluations
+
+Evaluation suites for azd-app Copilot skills, powered by [@microsoft/vally](https://aka.ms/vally).
+
+## Structure
+
+```
+cli/evals/
+├── .vally.yaml              # Root config — suite definitions
+├── package.json             # Dev dependency + npm scripts
+├── .gitignore               # Ignores results/ and node_modules/
+└── azd-app-onboard/
+    └── eval.yaml            # Onboarding skill eval suite
+```
+
+## Running Locally
+
+```bash
+cd cli/evals
+
+# Install Vally
+npm install
+
+# Run smoke suite (fast — routing checks only)
+npm run eval:smoke
+
+# Run a specific skill's eval
+npm run eval:skill -- azd-app-onboard/eval.yaml --output-dir ./results
+
+# Run full suite (all stimuli, LLM-backed)
+npm run eval:full
+
+# Re-grade an existing trajectory
+npm run grade -- azd-app-onboard/eval.yaml < results/results.jsonl
+```
+
+## Suites
+
+| Suite | Filter | Use Case |
+|-------|--------|----------|
+| `smoke` | `tier: smoke` | PR gate — fast routing checks |
+| `pr` | `tier: smoke` | Same as smoke (alias for clarity) |
+| `routing` | `type: routing` | All routing/trigger evals |
+| `integration` | `type: integration` | Full behavior tests (LLM-backed) |
+| `full` | (none) | All evals — nightly CI |
+
+## CI Integration
+
+- **On PR** (skill/eval changes): Runs `smoke` suite automatically
+- **Nightly** (2am UTC): Runs `full` suite
+- **Manual**: Dispatch with any suite via workflow_dispatch
+
+Results are uploaded as artifacts and summarized in the PR check.
+
+## Adding Evals for a New Skill
+
+1. Create `cli/evals/<skill-name>/eval.yaml`
+2. Add stimuli with appropriate `tags.tier` (`smoke` for PR gate, `full` for nightly)
+3. Use graders: `skill-invocation`, `output-matches`, `output-not-matches`
+4. Test locally with `npm run eval:skill -- <skill-name>/eval.yaml`
+
+## Authentication
+
+- **Locally**: Uses your `gh` CLI session automatically
+- **CI**: Uses `COPILOT_GITHUB_TOKEN` (set from `secrets.GITHUB_TOKEN`)

--- a/cli/evals/azd-app-onboard/eval.yaml
+++ b/cli/evals/azd-app-onboard/eval.yaml
@@ -1,0 +1,408 @@
+# Vally eval suite — azd-app-onboard skill
+# Validates that the onboarding skill is correctly invoked and produces
+# quality guidance for various project onboarding scenarios.
+
+name: azd-app-onboard-eval
+description: |
+  Evaluation suite for the azd-app-onboard skill. Tests skill routing
+  (does the agent pick this skill for onboarding prompts?), azure.yaml
+  generation quality, step-by-step guidance completeness, error handling,
+  and multi-service detection.
+
+tags:
+  skill: azd-app-onboard
+
+environment:
+  skills:
+    - ../../src/internal/skills/azd-app-onboard
+
+config:
+  runs: 5
+  timeout: "10m"
+  model: claude-sonnet-4.6
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  # ═══════════════════════════════════════════════════════════
+  # ROUTING — Does the agent invoke this skill for onboarding?
+  # ═══════════════════════════════════════════════════════════
+
+  - name: "New project onboarding request"
+    prompt: "I have a Node.js API and a React frontend. How do I set up azd app to run both services locally?"
+    tags:
+      type: routing
+      tier: smoke
+      cost: llm
+      area: routing
+      earlyTerminate: '[{"type":"skill-call","skill":"azd-app-onboard"},{"type":"tool-call-count","count":3}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Configure azure.yaml request"
+    prompt: "Help me create an azure.yaml file for my Python Flask API project"
+    tags:
+      type: routing
+      tier: smoke
+      cost: llm
+      area: routing
+      earlyTerminate: '[{"type":"skill-call","skill":"azd-app-onboard"},{"type":"tool-call-count","count":3}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Get started with azd app"
+    prompt: "I want to get started with azd app in my existing monorepo"
+    tags:
+      type: routing
+      tier: smoke
+      cost: llm
+      area: routing
+      earlyTerminate: '[{"type":"skill-call","skill":"azd-app-onboard"},{"type":"tool-call-count","count":3}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Negative routing — running services (should NOT invoke onboard)"
+    prompt: "Run my services with azd app"
+    tags:
+      type: routing
+      tier: smoke
+      cost: llm
+      area: routing
+      earlyTerminate: '[{"type":"skill-call","skill":"azd-app"},{"type":"tool-call-count","count":3}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app
+          excluded:
+            - azd-app-onboard
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # ═══════════════════════════════════════════════════════════
+  # GENERATION — Correct azure.yaml output for common projects
+  # ═══════════════════════════════════════════════════════════
+
+  - name: "Node.js Express API azure.yaml generation"
+    prompt: |
+      I have a Node.js Express API in the ./api directory with a package.json that
+      has a "start" script. Help me create an azure.yaml for azd app.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: generation
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-matches
+        config:
+          pattern: "(?i)azure\\.yaml"
+      - type: output-matches
+        config:
+          pattern: "(?i)services:"
+      - type: output-matches
+        config:
+          pattern: "(?i)language:\\s*(js|javascript|node)"
+      - type: output-matches
+        config:
+          pattern: "(?i)project:\\s*\\./api"
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Python FastAPI azure.yaml generation"
+    prompt: |
+      My project has a Python FastAPI app at ./backend with a requirements.txt.
+      The main file is main.py with uvicorn. Generate an azure.yaml for azd app.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: generation
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-matches
+        config:
+          pattern: "(?i)azure\\.yaml"
+      - type: output-matches
+        config:
+          pattern: "(?i)language:\\s*python"
+      - type: output-matches
+        config:
+          pattern: "(?i)uvicorn"
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Multi-service monorepo generation"
+    prompt: |
+      I have a monorepo with:
+      - ./services/api (Go with gin framework, go.mod present)
+      - ./services/worker (Python celery worker)
+      - ./apps/web (Next.js frontend)
+      - ./infra/redis (needs Redis container)
+      Create an azure.yaml for azd app to orchestrate all of these.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: generation
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-matches
+        config:
+          pattern: "(?i)services:"
+      # Should mention all 4 services
+      - type: output-matches
+        config:
+          pattern: "(?i)api"
+      - type: output-matches
+        config:
+          pattern: "(?i)worker"
+      - type: output-matches
+        config:
+          pattern: "(?i)web"
+      - type: output-matches
+        config:
+          pattern: "(?i)redis"
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # ═══════════════════════════════════════════════════════════
+  # GUIDANCE — Step-by-step quality
+  # ═══════════════════════════════════════════════════════════
+
+  - name: "Complete onboarding guidance includes verification steps"
+    prompt: |
+      Walk me through the complete process of onboarding my .NET Web API project
+      (in ./src/MyApi) to use azd app. I need health checks and environment variables.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: guidance
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      # Should mention the init command
+      - type: output-matches
+        config:
+          pattern: "(?i)azd app init"
+      # Should include health check config
+      - type: output-matches
+        config:
+          pattern: "(?i)healthcheck|health.check|health_check"
+      # Should include env var configuration
+      - type: output-matches
+        config:
+          pattern: "(?i)env:|environment"
+      # Should include verification step
+      - type: output-matches
+        config:
+          pattern: "(?i)(azd app (run|reqs|deps|health))"
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Hooks configuration guidance"
+    prompt: |
+      I need to run database migrations before my services start and clean up
+      temp files after they stop. How do I configure hooks in azd app?
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: guidance
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-matches
+        config:
+          pattern: "(?i)prerun"
+      - type: output-matches
+        config:
+          pattern: "(?i)poststop|post.stop"
+      - type: output-matches
+        config:
+          pattern: "(?i)hooks:"
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "MCP server setup guidance"
+    prompt: "How do I set up the MCP server in azd app so my AI coding assistant can manage my services?"
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: guidance
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-matches
+        config:
+          pattern: "(?i)azd app mcp serve"
+      - type: output-matches
+        config:
+          pattern: "(?i)mcp\\.json|vscode|settings"
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # ═══════════════════════════════════════════════════════════
+  # ERROR HANDLING — Invalid project structures
+  # ═══════════════════════════════════════════════════════════
+
+  - name: "Handles empty project gracefully"
+    prompt: |
+      I have an empty directory with no code yet. Can I still use azd app?
+      What do I need to set up?
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: error-handling
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      # Should NOT crash or error out
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace|cannot proceed"
+      # Should provide guidance on what's needed
+      - type: output-matches
+        config:
+          pattern: "(?i)(need|require|create|add|first|before)"
+
+  - name: "Handles unsupported language gracefully"
+    prompt: |
+      I have a Haskell project. Can I use azd app to run it?
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: error-handling
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+      # Should mention custom command as workaround or mention Docker
+      - type: output-matches
+        config:
+          pattern: "(?i)(custom|command|docker|run\\.command|manual)"
+
+  # ═══════════════════════════════════════════════════════════
+  # COMPLETENESS — All services detected
+  # ═══════════════════════════════════════════════════════════
+
+  - name: "Detects all services in complex project"
+    prompt: |
+      My project structure:
+      - ./api (Python Django, manage.py present)
+      - ./frontend (React app with package.json, vite.config.ts)
+      - ./auth (Node.js Express, package.json with "main": "index.js")
+      - ./docs (Astro site, astro.config.mjs present)
+      - docker-compose.yml with postgres and redis
+
+      Help me onboard this to azd app. Make sure all services are included.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: completeness
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      # All services should appear
+      - type: output-matches
+        config:
+          pattern: "(?i)api"
+      - type: output-matches
+        config:
+          pattern: "(?i)frontend"
+      - type: output-matches
+        config:
+          pattern: "(?i)auth"
+      - type: output-matches
+        config:
+          pattern: "(?i)docs"
+      - type: output-matches
+        config:
+          pattern: "(?i)(postgres|redis|docker)"
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Docker-only services included correctly"
+    prompt: |
+      I need to add a PostgreSQL database and a Redis cache as Docker containers
+      to my existing azd app project. How do I configure them in azure.yaml?
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: completeness
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azd-app-onboard
+      - type: output-matches
+        config:
+          pattern: "(?i)docker|container"
+      - type: output-matches
+        config:
+          pattern: "(?i)postgres"
+      - type: output-matches
+        config:
+          pattern: "(?i)redis"
+      - type: output-matches
+        config:
+          pattern: "(?i)(azd app add|language:\\s*docker|image:)"
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"

--- a/cli/evals/azd-app-onboard/eval.yaml
+++ b/cli/evals/azd-app-onboard/eval.yaml
@@ -93,8 +93,9 @@ stimuli:
         config:
           required:
             - azd-app
-          excluded:
-            - azd-app-onboard
+      - type: output-not-matches
+        config:
+          pattern: "(?i)azd-app-onboard"
       - type: output-not-matches
         config:
           pattern: "(?i)fatal error|unhandled exception|stack trace"

--- a/cli/evals/package.json
+++ b/cli/evals/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "azd-app-evals",
+  "private": true,
+  "description": "Vally evaluation suites for azd-app copilot skills",
+  "scripts": {
+    "eval": "npx @microsoft/vally eval",
+    "eval:smoke": "npx @microsoft/vally eval --suite smoke",
+    "eval:pr": "npx @microsoft/vally eval --suite pr",
+    "eval:routing": "npx @microsoft/vally eval --suite routing",
+    "eval:integration": "npx @microsoft/vally eval --suite integration",
+    "eval:full": "npx @microsoft/vally eval --suite full",
+    "eval:skill": "npx @microsoft/vally eval --eval-spec",
+    "grade": "npx @microsoft/vally-cli grade --eval-spec"
+  },
+  "devDependencies": {
+    "@microsoft/vally": "latest"
+  }
+}

--- a/cli/evals/package.json
+++ b/cli/evals/package.json
@@ -3,16 +3,16 @@
   "private": true,
   "description": "Vally evaluation suites for azd-app copilot skills",
   "scripts": {
-    "eval": "npx @microsoft/vally eval",
-    "eval:smoke": "npx @microsoft/vally eval --suite smoke",
-    "eval:pr": "npx @microsoft/vally eval --suite pr",
-    "eval:routing": "npx @microsoft/vally eval --suite routing",
-    "eval:integration": "npx @microsoft/vally eval --suite integration",
-    "eval:full": "npx @microsoft/vally eval --suite full",
-    "eval:skill": "npx @microsoft/vally eval --eval-spec",
+    "eval": "npx @microsoft/vally-cli eval",
+    "eval:smoke": "npx @microsoft/vally-cli eval --suite smoke",
+    "eval:pr": "npx @microsoft/vally-cli eval --suite pr",
+    "eval:routing": "npx @microsoft/vally-cli eval --suite routing",
+    "eval:integration": "npx @microsoft/vally-cli eval --suite integration",
+    "eval:full": "npx @microsoft/vally-cli eval --suite full",
+    "eval:skill": "npx @microsoft/vally-cli eval --eval-spec",
     "grade": "npx @microsoft/vally-cli grade --eval-spec"
   },
   "devDependencies": {
-    "@microsoft/vally": "latest"
+    "@microsoft/vally-cli": "latest"
   }
 }

--- a/cli/src/internal/skills/azd-app-onboard/SKILL.md
+++ b/cli/src/internal/skills/azd-app-onboard/SKILL.md
@@ -1,0 +1,399 @@
+---
+name: azd-app-onboard
+description: |
+  Onboard any application to use 'azd app' for local multi-service development.
+  Guides through project detection, azure.yaml generation, environment setup,
+  health checks, hooks, Docker services, and MCP configuration.
+  USE FOR: onboard to azd app, setup azd app, configure azure.yaml, get started
+  with azd app, add azd app to my project, initialize azd app, new azd app project,
+  migrate to azd app, convert project to azd app.
+  DO NOT USE FOR: running services (use azd-app skill), Azure deployments (use azd deploy),
+  infrastructure provisioning (use azd provision).
+---
+
+# Onboarding to azd app
+
+This skill helps you onboard an existing or new application to use `azd app` for
+local multi-service development orchestration. It covers the full onboarding journey
+from project detection through verified running services.
+
+## When to Use
+
+- Setting up `azd app` in an existing project for the first time
+- Creating a new `azure.yaml` from scratch based on detected project structure
+- Enriching an existing `azure.yaml` with azd app extensions (ports, commands, health checks)
+- Configuring multi-service monorepos
+- Setting up environment variables, Key Vault references, Docker services, hooks, or MCP
+
+## Onboarding Workflow
+
+Follow these steps in order. Each step builds on the previous one.
+
+### Step 1: Detect Project Structure
+
+Run `azd app init --dry-run` to discover what azd app detects:
+
+```bash
+azd app init --dry-run
+```
+
+This scans the project directory for:
+- Languages and frameworks (Node.js, Python, .NET, Java, Go, Rust, PHP)
+- Package managers (npm, yarn, pnpm, pip, dotnet, maven, gradle, cargo, composer)
+- Service boundaries (separate directories with their own entry points)
+- Existing configuration (package.json, requirements.txt, go.mod, etc.)
+- Docker files (Dockerfile, docker-compose.yml)
+
+### Step 2: Generate azure.yaml
+
+If no `azure.yaml` exists:
+```bash
+azd app init
+```
+
+If `azure.yaml` already exists but needs azd app enrichment:
+```bash
+azd app init  # enriches without overwriting existing config
+```
+
+To overwrite existing services section:
+```bash
+azd app init --force
+```
+
+### Step 3: Configure Services
+
+The generated `azure.yaml` should have a `services` section. Each service needs:
+
+```yaml
+name: my-project
+services:
+  api:
+    project: ./api
+    language: python
+    host: appservice
+    command: uvicorn main:app --reload --port {port}
+    ports:
+      - "8080"
+    healthcheck:
+      type: http
+      path: /health
+
+  web:
+    project: ./web
+    language: js
+    host: appservice
+    command: npm run dev -- --port {port}
+    ports:
+      - "3000"
+    healthcheck:
+      type: http
+      path: /
+```
+
+**Key fields to configure per service:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `project` | Yes | Relative path to service directory |
+| `language` | Yes | Language identifier (js, ts, python, csharp, java, go, rust, php, docker) |
+| `command` | Recommended | Custom run command (auto-detected if omitted) |
+| `ports` | Recommended | List of port strings (e.g., `- "8080"` or `- "8080:8080"`) |
+| `healthcheck.type` | Recommended | Health check type: `http`, `tcp`, `process`, or `none` |
+| `healthcheck.path` | For HTTP | Health endpoint path (used with `type: http`) |
+| `host` | Optional | Azure host target (appservice, containerapp, function) |
+
+### Step 4: Environment Variables
+
+Configure environment variables in `azure.yaml` using three formats:
+
+```yaml
+services:
+  api:
+    environment:
+      # Literal values
+      NODE_ENV: "development"
+      LOG_LEVEL: "debug"
+
+      # Reference other environment variables
+      DATABASE_URL: ${POSTGRES_CONNECTION_STRING}
+
+      # Key Vault references (resolved at startup)
+      API_KEY: keyvault://my-vault/api-key
+      DB_PASSWORD: keyvault://my-vault/db-password
+```
+
+For shared environment variables, use an env file:
+```bash
+azd app run --env-file .env.development
+```
+
+### Step 5: Docker Services
+
+For services running in Docker containers, use `host: containerapp` with an `image:` field:
+
+```yaml
+services:
+  redis:
+    host: containerapp
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  postgres:
+    host: containerapp
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: devpassword
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dev"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+```
+
+Use `azd app add` for well-known container services:
+```bash
+azd app add redis
+azd app add postgres
+```
+
+### Step 6: Lifecycle Hooks
+
+Configure hooks for custom lifecycle behavior:
+
+```yaml
+hooks:
+  # Run before services start (e.g., run migrations, seed data)
+  prerun:
+    shell: bash
+    run: |
+      echo "Running database migrations..."
+      cd api && python -m alembic upgrade head
+
+  # Run after all services are ready
+  postrun:
+    shell: bash
+    run: |
+      echo "All services running!"
+      echo "API: http://localhost:8080"
+      echo "Web: http://localhost:3000"
+
+  # Run before services stop (drain connections, flush caches)
+  prestop:
+    shell: bash
+    run: echo "Draining connections..."
+
+  # Run after all services stopped (cleanup)
+  poststop:
+    shell: bash
+    run: echo "Cleanup complete"
+```
+
+### Step 7: Health Checks
+
+Configure health endpoints for service monitoring:
+
+```yaml
+services:
+  api:
+    healthcheck:
+      type: http           # http, tcp, process, or none
+      path: /health        # HTTP endpoint path (for type: http)
+```
+
+For Docker-style health checks (container services):
+```yaml
+services:
+  redis:
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+```
+
+Verify health checks work:
+```bash
+azd app health --all --verbose
+```
+
+For continuous monitoring:
+```bash
+azd app health --stream --interval 10s
+```
+
+### Step 8: MCP Server Setup
+
+Enable AI assistant integration via Model Context Protocol:
+
+```bash
+# Start MCP server
+azd app mcp serve
+```
+
+To configure your IDE (VS Code) to use the MCP server, add to `.vscode/mcp.json`:
+```json
+{
+  "servers": {
+    "azd-app": {
+      "command": "azd",
+      "args": ["app", "mcp", "serve"]
+    }
+  }
+}
+```
+
+This exposes tools for AI assistants to:
+- List and manage services
+- View logs and errors
+- Install dependencies
+- Check requirements
+- Manage environment variables
+
+### Step 9: Verify Onboarding
+
+Run the full verification sequence:
+
+```bash
+# 1. Check system requirements
+azd app reqs
+
+# 2. Install all dependencies
+azd app deps
+
+# 3. Dry-run to verify configuration
+azd app run --dry-run
+
+# 4. Run all services
+azd app run
+
+# 5. Check health (in another terminal)
+azd app health --all
+```
+
+## Multi-Service Monorepo Setup
+
+For monorepos with multiple independently-deployable services:
+
+```yaml
+name: my-monorepo
+services:
+  auth-service:
+    project: ./services/auth
+    language: ts
+    command: npm run dev -- --port {port}
+    ports:
+      - "4001"
+    healthcheck:
+      type: http
+      path: /health
+
+  api-gateway:
+    project: ./services/gateway
+    language: ts
+    command: npm run dev -- --port {port}
+    ports:
+      - "4000"
+    healthcheck:
+      type: http
+      path: /health
+
+  worker:
+    project: ./services/worker
+    language: python
+    command: python -m celery worker
+    healthcheck:
+      type: process
+
+  frontend:
+    project: ./apps/web
+    language: ts
+    command: npm run dev -- --port {port}
+    ports:
+      - "3000"
+    healthcheck:
+      type: http
+      path: /
+```
+
+Run individual services:
+```bash
+azd app run --service api-gateway
+azd app run --service frontend
+```
+
+## Common Issues & Solutions
+
+| Issue | Solution |
+|-------|----------|
+| Port conflict | Use `{port}` placeholder in command — azd app manages ports automatically |
+| Service not detected | Ensure service has a recognizable entry point (package.json, main.py, go.mod, etc.) |
+| Health check failing | Verify the endpoint returns HTTP 200 and the path matches `healthcheck.path` |
+| Docker service won't start | Check `docker` is running with `azd app reqs` |
+| Env var not resolving | Ensure the referenced variable is set in your shell or `.env` file |
+| Key Vault access denied | Verify `az login` and that your identity has Key Vault access |
+
+## Complete azure.yaml Reference
+
+```yaml
+name: my-project                    # Project name
+
+hooks:                              # Project-level lifecycle hooks
+  prerun:
+    shell: bash
+    run: echo "starting..."
+  postrun:
+    shell: bash
+    run: echo "ready!"
+  prestop:
+    shell: bash
+    run: echo "stopping..."
+  poststop:
+    shell: bash
+    run: echo "stopped"
+
+services:
+  service-name:
+    project: ./path/to/service      # Relative path to service root
+    language: js|ts|python|csharp|java|go|rust|php
+    host: appservice|containerapp|function  # Azure host target
+    command: "custom run command"   # Use {port} for dynamic port
+    ports:                           # List of port strings
+      - "8080"                       # Single port
+      - "8080:8080"                  # host:container mapping
+    healthcheck:                     # Health check configuration
+      type: http|tcp|process|none    # Check type
+      path: /health                  # Endpoint (for type: http)
+      test: ["CMD", "curl", "-f", "http://localhost/health"]  # Docker-style
+      interval: 10s                  # Check interval
+      timeout: 5s                    # Check timeout
+      retries: 3                     # Retry count
+    environment:                     # Service environment variables
+      KEY: "value"                   # Literal
+      KEY: ${OTHER_VAR}              # Env var reference
+      KEY: keyvault://vault/secret   # Key Vault reference
+
+  # Container service example
+  container-name:
+    host: containerapp
+    image: redis:7-alpine           # Docker image
+    ports:
+      - "6379:6379"
+    environment:
+      KEY: value
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+```

--- a/cli/src/internal/skills/skills.go
+++ b/cli/src/internal/skills/skills.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"embed"
+	"errors"
 
 	internalversion "github.com/jongio/azd-app/cli/src/internal/version"
 	"github.com/jongio/azd-core/copilotskills"
@@ -10,7 +11,19 @@ import (
 //go:embed azd-app/SKILL.md
 var skillFS embed.FS
 
+//go:embed azd-app-onboard/SKILL.md
+var onboardSkillFS embed.FS
+
+// InstallSkills installs all copilot skills to ~/.copilot/skills/.
+func InstallSkills() error {
+	return errors.Join(
+		copilotskills.Install("azd-app", internalversion.Version, skillFS, "azd-app"),
+		copilotskills.Install("azd-app-onboard", internalversion.Version, onboardSkillFS, "azd-app-onboard"),
+	)
+}
+
 // InstallSkill installs the azd-app skill to ~/.copilot/skills/azd-app.
+// Deprecated: Use InstallSkills instead to install all skills.
 func InstallSkill() error {
-	return copilotskills.Install("azd-app", internalversion.Version, skillFS, "azd-app")
+	return InstallSkills()
 }


### PR DESCRIPTION
## Summary

Adds a new Copilot skill (azd-app-onboard) that guides users through onboarding their applications to use azd app. Includes a Vally evaluation framework to validate skill quality in CI.

### New Skill: azd-app-onboard

Provides a 9-step onboarding workflow covering project detection, azure.yaml generation, environment vars, Docker services, hooks, health checks, MCP server, monorepo setup, and verification. The skill auto-installs to ~/.copilot/skills/azd-app-onboard on any azd app CLI invocation using the same mechanism as the existing azd-app skill.

Trigger phrases: onboard to azd app, setup azd app, configure azure.yaml, get started with azd app.

All azure.yaml examples are schema-validated against the actual codebase Service struct types.

### Vally Eval Integration

15 evaluation stimuli across 5 categories:

- Routing (4): correct skill invocation plus a negative test
- Generation (3): azure.yaml output for Node, Python, monorepo
- Guidance (3): step-by-step quality for .NET, hooks, MCP
- Error handling (2): empty project, unsupported language
- Completeness (2): multi-service detection, Docker services

CI workflow (.github/workflows/vally-eval.yml) runs smoke suite on PRs that change skills/evals, full suite nightly at 2am UTC, and supports manual dispatch for any suite.

Local dev: cd cli/evals && npm install && npm run eval:smoke

### Files

| File | Purpose |
|------|---------|
| cli/src/internal/skills/azd-app-onboard/SKILL.md | New onboarding skill |
| cli/src/internal/skills/skills.go | Embeds and installs both skills |
| .github/workflows/vally-eval.yml | CI workflow for eval runs |
| cli/evals/.vally.yaml | Vally root config (5 suites) |
| cli/evals/azd-app-onboard/eval.yaml | 15 eval stimuli |
| cli/evals/package.json | Dev dependency and npm scripts |
| cli/evals/README.md | Developer guide |
| cli/evals/.gitignore | Ignores results/ and node_modules/ |
