### PR TITLE
fix(dashboard): disable WriteTimeout to fix streaming RPC disconnects

### DIFF
--- a/cli/src/internal/dashboard/server_core.go
+++ b/cli/src/internal/dashboard/server_core.go
@@ -151,8 +151,16 @@ func (s *Server) Start() (string, error) {
 		Addr:              fmt.Sprintf("127.0.0.1:%d", port),
 		Handler:           s.buildHandler(),
 		ReadHeaderTimeout: 10 * time.Second,
-		WriteTimeout:      60 * time.Second,
-		IdleTimeout:       120 * time.Second,
+		// WriteTimeout must be 0 (disabled) because Connect-RPC server-streaming
+		// handlers (StreamHealth, StreamLocalLogs, StreamBroadcast) are long-lived.
+		// Go's WriteTimeout is an absolute deadline from request header read — not
+		// a per-write idle timeout — so any non-zero value kills streams after that
+		// duration, causing ERR_INCOMPLETE_CHUNKED_ENCODING on the client.
+		// Security: this server binds to 127.0.0.1 only (not internet-facing).
+		// ReadHeaderTimeout guards against slowloris; IdleTimeout reclaims idle
+		// keep-alive connections.
+		WriteTimeout: 0,
+		IdleTimeout:  120 * time.Second,
 	}
 
 	// Start server in background


### PR DESCRIPTION
## Problem

The dashboard's Connect-RPC server-streaming endpoints (StreamHealth, StreamLocalLogs, StreamBroadcast) are forcefully killed after 60 seconds, causing:

- \ERR_INCOMPLETE_CHUNKED_ENCODING\ errors in the browser
- Log panes stuck on 'Loading logs for [service]...' forever
- Health status not updating after the first minute

## Root Cause

Go's \http.Server.WriteTimeout\ is an **absolute deadline** measured from when request headers are read, not a per-write idle timeout. With \WriteTimeout: 60s\, any streaming handler that lives longer than 60 seconds has its connection killed by the runtime.

## Fix

Set \WriteTimeout: 0\ (disabled). This is safe because:

- The server binds to \127.0.0.1\ only (not internet-facing)
- \ReadHeaderTimeout: 10s\ guards against slowloris attacks
- \IdleTimeout: 120s\ reclaims idle keep-alive connections
- The alternate port path in \server_port_mgmt.go\ already omits WriteTimeout

## Testing

After this fix, open \http://localhost:<port>/console\ and verify:
1. Logs stream continuously beyond 60 seconds
2. Health status updates persist
3. No \ERR_INCOMPLETE_CHUNKED_ENCODING\ in DevTools
