### PR TITLE
feat(trust): default trust prompt to Yes and add -y shorthand

### DIFF
--- a/cli/docs/commands/run.md
+++ b/cli/docs/commands/run.md
@@ -32,6 +32,7 @@ azd app run [flags]
 | `--dry-run` | | bool | `false` | Show execution plan without starting services |
 | `--restart-containers` | | bool | `false` | Restart containers even if they are already running |
 | `--force` | | bool | `false` | Force clean dependency reinstall (passes --force to deps) |
+| `--trust` | `-y` | bool | `false` | Trust this workspace for code execution and remember the decision |
 | `--web` | `-w` | bool | `false` | Open dashboard in browser |
 
 ## Dashboard Browser Launch
@@ -1173,9 +1174,35 @@ dotnet workload list
 
 ## Security Considerations
 
+### Workspace Trust Gate
+
+The `run` command enforces a workspace trust gate before executing any commands defined in `azure.yaml`. This prevents untrusted repositories from running arbitrary code on your machine without consent.
+
+**First run in a new workspace:**
+```
+  ⚠️  Security Notice
+  Running 'azd app run' will execute commands defined in:
+    /path/to/azure.yaml
+  Only trust workspaces you own or have reviewed.
+
+  Trust workspace at /path/to/project for code execution? (Y/n):
+```
+
+Press **Enter** or type **y/yes** to trust. Type **n/no** to abort. Once trusted, the decision is remembered in `~/.azd/trusted-workspaces.json` and you won't be asked again unless `azure.yaml` changes.
+
+**Bypassing the prompt:**
+
+```bash
+# CLI flag (also available as -y)
+azd app run --trust
+
+# Environment variable (for CI/scripts)
+AZD_APP_TRUST=1 azd app run
+```
+
 ### Trust Model
 
-The `run` command executes commands defined in `azure.yaml` with your user permissions. When you run `azd app run`, you implicitly trust:
+The `run` command executes commands defined in `azure.yaml` with your user permissions. When you trust a workspace, you authorize execution of:
 
 - **Hook scripts** (prerun/postrun)
 - **Service commands** (command, entrypoint)

--- a/cli/src/cmd/app/commands/run.go
+++ b/cli/src/cmd/app/commands/run.go
@@ -62,7 +62,7 @@ func NewRunCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&runWeb, "web", "w", false, "Open dashboard in browser")
 	cmd.Flags().BoolVar(&runRestartContainers, "restart-containers", false, "Restart containers even if they are already running")
 	cmd.Flags().BoolVar(&runForce, "force", false, "Force clean dependency reinstall and auto-resolve port conflicts without prompting")
-	cmd.Flags().BoolVar(&runTrust, "trust", false, "Trust this workspace for code execution and remember the decision")
+	cmd.Flags().BoolVarP(&runTrust, "trust", "y", false, "Trust this workspace for code execution and remember the decision")
 
 	return cmd
 }
@@ -163,7 +163,7 @@ func ensureWorkspaceTrusted(azureYamlPath string) error {
 		fmt.Fprintf(os.Stderr, "  azure.yaml has changed since this workspace was last trusted.\n\n")
 	}
 
-	fmt.Fprintf(os.Stderr, "  Trust workspace at %s for code execution? (yes/no): ", projectDir)
+	fmt.Fprintf(os.Stderr, "  Trust workspace at %s for code execution? (Y/n): ", projectDir)
 
 	reader := bufio.NewReader(os.Stdin)
 	response, err := reader.ReadString('\n')
@@ -172,7 +172,7 @@ func ensureWorkspaceTrusted(azureYamlPath string) error {
 	}
 
 	response = strings.ToLower(strings.TrimSpace(response))
-	if response != "yes" && response != "y" {
+	if response == "n" || response == "no" {
 		return fmt.Errorf("workspace not trusted — exiting without executing any commands")
 	}
 

--- a/cli/src/internal/dashboard/server_core.go
+++ b/cli/src/internal/dashboard/server_core.go
@@ -151,8 +151,16 @@ func (s *Server) Start() (string, error) {
 		Addr:              fmt.Sprintf("127.0.0.1:%d", port),
 		Handler:           s.buildHandler(),
 		ReadHeaderTimeout: 10 * time.Second,
-		WriteTimeout:      60 * time.Second,
-		IdleTimeout:       120 * time.Second,
+		// WriteTimeout must be 0 (disabled) because Connect-RPC server-streaming
+		// handlers (StreamHealth, StreamLocalLogs, StreamBroadcast) are long-lived.
+		// Go's WriteTimeout is an absolute deadline from request header read — not
+		// a per-write idle timeout — so any non-zero value kills streams after that
+		// duration, causing ERR_INCOMPLETE_CHUNKED_ENCODING on the client.
+		// Security: this server binds to 127.0.0.1 only (not internet-facing).
+		// ReadHeaderTimeout guards against slowloris; IdleTimeout reclaims idle
+		// keep-alive connections.
+		WriteTimeout: 0,
+		IdleTimeout:  120 * time.Second,
 	}
 
 	// Start server in background


### PR DESCRIPTION
## Changes

- Change trust prompt from (yes/no) to (Y/n) so pressing Enter accepts trust
- Add -y short flag for --trust to quickly bypass the check from CLI
- Only explicit n or no rejects trust (previously required typing yes)
- Document --trust/-y flag and workspace trust gate in run.md

## Motivation

Reduce friction for the common case - users who own their workspace should not have to type yes every first run. The Y/n pattern (capital = default) is standard UX for safe-default prompts.

The -y shorthand provides a quick CLI override: azd app run -y