### PR TITLE
fix(logging): fix log streaming reliability and latency to dashboard

### DIFF
--- a/cli/dashboard/src/hooks/useLogsStream.test.ts
+++ b/cli/dashboard/src/hooks/useLogsStream.test.ts
@@ -40,8 +40,12 @@ import {
 } from '@/gen/proto/azdapp/v1/azure_pb.js'
 import { create } from '@bufbuild/protobuf'
 
+const { mockBackend } = vi.hoisted(() => ({
+  mockBackend: { connected: true },
+}))
+
 vi.mock('@/hooks/useBackendConnection', () => ({
-  useBackendConnection: () => ({ connected: true }),
+  useBackendConnection: () => ({ connected: mockBackend.connected }),
 }))
 
 type SharedLogStreamArgs = {
@@ -124,6 +128,7 @@ function makeTransport(overrides: TransportOverrides = {}): Transport {
 describe('useLogsStream (orchestration)', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    mockBackend.connected = true
     sharedLogStreamMock.mockClear()
     sharedLogStreamMock.mockImplementation(() => ({
       connectionState: 'disconnected',
@@ -200,6 +205,37 @@ describe('useLogsStream (orchestration)', () => {
         ),
       )
       const arg = lastSharedCall()
+      expect(arg.enabled).toBe(false)
+    })
+
+    it('enables the local stream even when the backend health is not yet connected', () => {
+      // Regression: live local logs were gated on the health stream's
+      // `connected` signal, so a still-starting service delayed all live
+      // logs until the first health probe finished. Local logs run against
+      // the same local server that served the page and must stream
+      // immediately, independent of health.
+      mockBackend.connected = false
+      renderHook(() => useLogsStream(createParams()))
+      const arg = lastSharedCall()
+      expect(arg.mode).toBe('local')
+      expect(arg.enabled).toBe(true)
+    })
+
+    it('does not enable the azure realtime stream until the backend is connected', () => {
+      // Azure realtime stays gated on `connected` because Log Analytics
+      // genuinely needs the backend reachable; only local is decoupled.
+      mockBackend.connected = false
+      renderHook(() =>
+        useLogsStream(
+          createParams({
+            logMode: 'azure',
+            azureRealtime: true,
+            fetchKey: 'azure:15m::realtime',
+          }),
+        ),
+      )
+      const arg = lastSharedCall()
+      expect(arg.mode).toBe('azure')
       expect(arg.enabled).toBe(false)
     })
 

--- a/cli/dashboard/src/hooks/useLogsStream.ts
+++ b/cli/dashboard/src/hooks/useLogsStream.ts
@@ -413,9 +413,16 @@ export function useLogsStream(
     })
   }, [isPausedRef, lastClearTimeRef, setLogs])
 
-  const shouldUseSharedStream = 
-    connected && 
-    (logMode === 'local' || (logMode === 'azure' && azureRealtime))
+  // Local logs stream from the same local server that served this page,
+  // so they don't wait on the health stream's `connected` signal - that
+  // coupling delayed live local logs until the first health probe of all
+  // services finished (a still-starting service blocks it for the full
+  // timeout). Azure realtime stays gated on `connected` because Log
+  // Analytics genuinely needs the backend reachable. Matches LogsView,
+  // which already streams local logs without the health gate.
+  const shouldUseSharedStream =
+    logMode === 'local' ||
+    (connected && logMode === 'azure' && azureRealtime)
 
   const { droppedCount, reconnectGeneration } = useSharedLogStream({
     serviceName,

--- a/cli/dashboard/src/hooks/useLogsStream.ts
+++ b/cli/dashboard/src/hooks/useLogsStream.ts
@@ -417,13 +417,26 @@ export function useLogsStream(
     connected && 
     (logMode === 'local' || (logMode === 'azure' && azureRealtime))
 
-  const { droppedCount } = useSharedLogStream({
+  const { droppedCount, reconnectGeneration } = useSharedLogStream({
     serviceName,
     enabled: shouldUseSharedStream,
     mode: logMode === 'azure' ? 'azure' : 'local',
     onLogEntry: handleSharedLogEntry,
     transport,
   })
+
+  // When the stream reconnects, reset fetch state so the initial unary
+  // fetch re-fires. This closes the gap between the last received entry
+  // before disconnect and the new stream's first live entry.
+  const prevReconnectGenRef = useRef(reconnectGeneration)
+  useEffect(() => {
+    if (reconnectGeneration > prevReconnectGenRef.current) {
+      prevReconnectGenRef.current = reconnectGeneration
+      // Reset fetch counters to trigger a fresh initial fetch
+      fetchCountForKeyRef.current = 0
+      emptyResultCountRef.current = 0
+    }
+  }, [reconnectGeneration])
 
   return { retry, droppedCount }
 }

--- a/cli/dashboard/src/hooks/useSharedLogStream.ts
+++ b/cli/dashboard/src/hooks/useSharedLogStream.ts
@@ -111,6 +111,14 @@ interface LogStreamManager {
   subscribeToStreamStatus(callback: StreamStatusCallback): () => void
   getState(): ConnectionState
   getDroppedCount(): number
+  /**
+   * Monotonically increasing counter that advances each time the stream
+   * successfully reconnects (transitions disconnected/error → connected).
+   * Consumers can incorporate this into a fetch key to trigger re-fetching
+   * initial history after a reconnect, closing the gap between the last
+   * received entry and the new stream.
+   */
+  getReconnectGeneration(): number
   destroy(): void
   resetReconnectionState(): void
 }
@@ -135,6 +143,7 @@ class SubscriberRegistry {
   private readonly streamStatusSubscribers = new Set<StreamStatusCallback>()
   private currentState: ConnectionState = 'disconnected'
   private droppedCount = 0
+  private reconnectGeneration = 0
   private latestStreamStatus: StreamStatus | null = null
   // Keep the last MAX_BUFFER_SIZE entries so a late-mounting subscriber
   // immediately sees recent activity instead of staring at an empty
@@ -238,7 +247,17 @@ class SubscriberRegistry {
 
   setState(newState: ConnectionState): void {
     if (this.currentState === newState) return
+    // Track reconnections: any transition into 'connected' after the
+    // initial connect (generation > 0 means we've been connected before)
+    // constitutes a reconnect that may have missed entries.
+    const wasConnectedBefore = this.reconnectGeneration > 0 || this.currentState !== 'disconnected'
     this.currentState = newState
+    if (newState === 'connected' && wasConnectedBefore) {
+      this.reconnectGeneration++
+    } else if (newState === 'connected') {
+      // First-ever connection: set to 1 so subsequent transitions increment
+      this.reconnectGeneration = 1
+    }
     // Iterate via a snapshot so a subscriber that synchronously
     // unsubscribes from inside its own callback can't mutate the set
     // mid-iteration.
@@ -256,6 +275,10 @@ class SubscriberRegistry {
 
   getState(): ConnectionState {
     return this.currentState
+  }
+
+  getReconnectGeneration(): number {
+    return this.reconnectGeneration
   }
 
   getDroppedCount(): number {
@@ -517,6 +540,10 @@ class ConnectLocalLogStreamManager implements LogStreamManager {
 
   getDroppedCount(): number {
     return this.registry.getDroppedCount()
+  }
+
+  getReconnectGeneration(): number {
+    return this.registry.getReconnectGeneration()
   }
 
   resetReconnectionState(): void {
@@ -846,6 +873,10 @@ class ConnectAzureLogStreamManager implements LogStreamManager {
     return this.registry.getDroppedCount()
   }
 
+  getReconnectGeneration(): number {
+    return this.registry.getReconnectGeneration()
+  }
+
   resetReconnectionState(): void {
     this.streams.forEach((state) => {
       state.reconnectAttempts = 0
@@ -1074,6 +1105,12 @@ export interface UseSharedLogStreamReturn {
    */
   droppedCount: number
   /**
+   * Monotonically increasing counter that advances each time the stream
+   * successfully reconnects. Consumers can incorporate this into a fetch
+   * key to trigger re-fetching initial history after a reconnect.
+   */
+  reconnectGeneration: number
+  /**
    * Latest server-emitted stream status, or `null` if none received
    * yet (or in local mode, which has no equivalent signal). Azure
    * surfaces this so the LogsView can render polling health and
@@ -1125,6 +1162,7 @@ export function useSharedLogStream({
 
   const [connectionState, setConnectionState] = useState<ConnectionState>(() => manager.getState())
   const [droppedCount, setDroppedCount] = useState<number>(() => manager.getDroppedCount())
+  const [reconnectGeneration, setReconnectGeneration] = useState<number>(() => manager.getReconnectGeneration())
   const [streamStatus, setStreamStatus] = useState<StreamStatus | null>(null)
 
   useEffect(() => {
@@ -1149,6 +1187,9 @@ export function useSharedLogStream({
       // Mirror the legacy hook: when disabled, the consumer wants to
       // see "disconnected" regardless of underlying transport activity.
       setConnectionState(enabledRef.current ? state : 'disconnected')
+      // Update reconnect generation when state changes (the registry
+      // increments it on each successful reconnection).
+      setReconnectGeneration(manager.getReconnectGeneration())
     })
   }, [manager])
 
@@ -1195,7 +1236,7 @@ export function useSharedLogStream({
     }
   }, [manager, transport])
 
-  return { connectionState, droppedCount, streamStatus }
+  return { connectionState, droppedCount, reconnectGeneration, streamStatus }
 }
 
 // =============================================================================

--- a/cli/src/internal/dashboard/rpc_logs_adapter.go
+++ b/cli/src/internal/dashboard/rpc_logs_adapter.go
@@ -66,6 +66,23 @@ func newLogsStoreFuncs(s *Server) rpc.LogsStoreFuncs {
 			}
 			buf.Unsubscribe(ch)
 		},
+		OnBufferAddedFn: func() <-chan string {
+			lm := service.GetLogManager(s.projectDir)
+			if lm == nil {
+				// No manager: return nil so the stream's select never
+				// fires on this channel. The stream still serves
+				// already-registered services.
+				return nil
+			}
+			return lm.OnBufferAdded()
+		},
+		RemoveBufferListenerFn: func(ch <-chan string) {
+			lm := service.GetLogManager(s.projectDir)
+			if lm == nil {
+				return
+			}
+			lm.RemoveBufferListener(ch)
+		},
 
 		LoadClassificationsFn: func() ([]service.LogClassification, error) {
 			classificationsMu.RLock()

--- a/cli/src/internal/rpc/logs.go
+++ b/cli/src/internal/rpc/logs.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -64,13 +63,12 @@ func NewLogsHandler(store LogsStore) *LogsHandler {
 	if store == nil {
 		panic("rpc: NewLogsHandler called with nil LogsStore")
 	}
-	// Validate LogsStoreFuncs fields to fail at wiring time, not at request time
+	// Validate LogsStoreFuncs fields to fail at wiring time, not at
+	// request time. The check lives next to the struct (logs_store.go)
+	// so new fields are validated where they're declared.
 	if f, ok := store.(LogsStoreFuncs); ok {
-		if f.GetRecentFn == nil || f.GetAllFn == nil || f.ServiceNamesFn == nil ||
-			f.SubscribeFn == nil || f.UnsubscribeFn == nil ||
-			f.LoadClassificationsFn == nil || f.SaveClassificationsFn == nil ||
-			f.LoadPreferencesFn == nil || f.SavePreferencesFn == nil {
-			panic("rpc: LogsStoreFuncs has nil function field(s) - all fields must be set")
+		if err := f.validate(); err != nil {
+			panic("rpc: " + err.Error())
 		}
 	}
 	return &LogsHandler{store: store}
@@ -112,16 +110,16 @@ func (h *LogsHandler) GetLogs(
 // localLogRing type below.
 //
 // Lifecycle:
-//  1. Resolve subscriptions (one channel per service).
-//  2. Spawn one pump goroutine per source channel; each pump pushes
-//     incoming entries into the per-stream ring (drop-OLDEST if full).
-//  3. Optionally backfill the most-recent N buffered entries before
-//     live tail begins (so reconnects don't blank the dashboard).
-//  4. Main loop selects on ctx.Done and the ring's notify channel;
-//     drains entries per notify, emitting a DroppedNotice ahead of the
-//     next entry whenever the ring's drop counter advanced.
-//  5. On return, deferred Unsubscribe closes each source channel; pump
-//     goroutines see the closed channel and exit.
+//  1. Resolve subscriptions via streamSubscriptions (one pump per service).
+//     Pumps start immediately so subscriber channels drain while backfill
+//     is being sent (prevents channel overflow).
+//  2. Optionally backfill the most-recent N buffered entries.
+//  3. Main loop selects on ctx.Done, the ring's notify channel, and
+//     (for all-services mode) new-buffer notifications; drains entries
+//     per notify, emitting a DroppedNotice ahead of the next entry
+//     whenever the ring's drop counter advanced.
+//  4. On return, deferred cleanup cancels pumps, unsubscribes, and
+//     removes the new-buffer listener.
 func (h *LogsHandler) StreamLocalLogs(
 	ctx context.Context,
 	req *connect.Request[v1.StreamLocalLogsRequest],
@@ -136,50 +134,45 @@ func (h *LogsHandler) StreamLocalLogs(
 		backfill = maxLocalLogBackfill
 	}
 
-	// Resolve subscriptions. Single-service: one channel; all-services:
-	// one channel per registered buffer at the moment of subscribe.
-	// New buffers created mid-stream will not appear (matches the legacy
-	// WebSocket behaviour - reconnect to pick up new services).
-	subs := make(map[string]chan service.LogEntry)
+	// Per-stream ring: bounded, drop-oldest, drop-counter wakes main loop.
+	ring := newLocalLogRing(localLogRingBufferSize)
+
+	// Subscription set: owns the pump goroutines, per-stream context, and
+	// cleanup. close() (deferred below) cancels pumps then unsubscribes.
+	subs := newStreamSubscriptions(ctx, h.store, ring)
+	defer subs.close()
+
+	// Register for new-buffer notifications BEFORE enumerating services so
+	// there's no window where a buffer created between ServiceNames() and
+	// OnBufferAdded() is missed. The dedup guard in subs.add prevents
+	// double-subscription for services that appear in both the initial
+	// list AND the notification channel. All-services mode only. A nil
+	// channel (no manager, or single-service mode) never fires in the
+	// select below, which is the intended "no dynamic subscription" path.
+	var bufferAdded <-chan string
+	if serviceName == "" {
+		bufferAdded = h.store.OnBufferAdded()
+		defer h.store.RemoveBufferListener(bufferAdded)
+	}
+
+	// Resolve initial subscriptions and start pumps immediately so the
+	// subscriber channels drain while we send backfill below.
 	if serviceName != "" {
-		ch, exists := h.store.Subscribe(serviceName)
-		if !exists {
+		if !subs.add(serviceName) {
 			return connect.NewError(
 				connect.CodeNotFound,
 				fmt.Errorf("service %q not found", serviceName),
 			)
 		}
-		subs[serviceName] = ch
 	} else {
 		for _, name := range h.store.ServiceNames() {
-			if ch, exists := h.store.Subscribe(name); exists {
-				subs[name] = ch
-			}
+			subs.add(name)
 		}
 	}
 
-	// Always release every subscription even on early-return paths.
-	defer func() {
-		for name, ch := range subs {
-			h.store.Unsubscribe(name, ch)
-		}
-	}()
-
-	// Per-stream ring: bounded, drop-oldest, drop-counter wakes main loop.
-	ring := newLocalLogRing(localLogRingBufferSize)
-
-	// Per-stream context so pump goroutines exit cleanly when the
-	// outer ctx is cancelled OR when this function returns for any
-	// other reason (e.g. send error). Defer ordering: streamCancel
-	// fires LAST (after Unsubscribe closes the source channels), so a
-	// pump goroutine that's blocked on ring.push gets woken either by
-	// the ring draining or by the cancel.
-	streamCtx, streamCancel := context.WithCancel(ctx)
-	defer streamCancel()
-
 	// Optional backfill: the most-recent N buffered entries before live
-	// tail begins. Resolved once at stream start so we don't race with
-	// concurrent buffer rotation.
+	// tail begins. Pumps are already draining subscriber channels into
+	// the ring so we won't lose entries that arrive during backfill send.
 	if backfill > 0 {
 		var seed []service.LogEntry
 		if serviceName != "" {
@@ -200,41 +193,20 @@ func (h *LogsHandler) StreamLocalLogs(
 		}
 	}
 
-	// Spawn one pump goroutine per subscription. Pumps exit when their
-	// source channel closes (Unsubscribe path) or the stream context is
-	// cancelled. They never block indefinitely on ring.push because
-	// drop-oldest semantics mean ring.push always returns immediately.
-	var pumpWg sync.WaitGroup
-	for _, ch := range subs {
-		pumpWg.Add(1)
-		go func(src chan service.LogEntry) {
-			defer pumpWg.Done()
-			for {
-				select {
-				case <-streamCtx.Done():
-					return
-				case entry, ok := <-src:
-					if !ok {
-						return
-					}
-					ring.push(toProtoLogEntry(entry))
-				}
-			}
-		}(ch)
-	}
-
 	// Main loop: drain ring on notify, emit dropped-notice when the
-	// drop counter advanced since the last drain.
+	// drop counter advanced, and subscribe to new services dynamically.
+	// bufferAdded is nil in single-service mode, so its select case
+	// never fires there.
 	var lastDropped int64
+
 	for {
 		select {
 		case <-ctx.Done():
-			// Wait for pumps to wind down so any in-flight ring.push
-			// completes before the function returns. Bounded by the
-			// per-pump select on streamCtx so this can't hang.
-			streamCancel()
-			pumpWg.Wait()
 			return nil
+
+		case newService := <-bufferAdded:
+			// A new service buffer was created; subscribe (add dedups).
+			subs.add(newService)
 
 		case <-ring.notify:
 			entries, dropped := ring.drain()

--- a/cli/src/internal/rpc/logs_store.go
+++ b/cli/src/internal/rpc/logs_store.go
@@ -1,6 +1,11 @@
 package rpc
 
-import "github.com/jongio/azd-app/cli/src/internal/service"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+)
 
 // LogSource is the narrow read/subscribe slice of service.LogManager that
 // LogsHandler needs. Production wires it to a per-call LogManager
@@ -30,6 +35,13 @@ type LogSource interface {
 	// MUST be safe to call with a channel from a now-removed service
 	// (idempotent / no panic on missing buffer).
 	Unsubscribe(serviceName string, ch chan service.LogEntry)
+	// OnBufferAdded returns a channel that receives the service name
+	// each time a new log buffer is created. Used by StreamLocalLogs
+	// to dynamically subscribe to services that start after the stream
+	// opens. Callers MUST call RemoveBufferListener when done.
+	OnBufferAdded() <-chan string
+	// RemoveBufferListener deregisters a listener returned by OnBufferAdded.
+	RemoveBufferListener(ch <-chan string)
 }
 
 // ClassificationStore is the read/write slice of azure.yaml-stored log
@@ -89,15 +101,44 @@ type LogsStore interface {
 // values cause LogsHandler RPCs to panic at call time, which is the
 // fail-loud signal we want for a misconfigured wiring.
 type LogsStoreFuncs struct {
-	GetRecentFn           func(serviceName string, tail int) ([]service.LogEntry, bool)
-	GetAllFn              func(tail int) []service.LogEntry
-	ServiceNamesFn        func() []string
-	SubscribeFn           func(serviceName string) (chan service.LogEntry, bool)
-	UnsubscribeFn         func(serviceName string, ch chan service.LogEntry)
-	LoadClassificationsFn func() ([]service.LogClassification, error)
-	SaveClassificationsFn func(classifications []service.LogClassification) error
-	LoadPreferencesFn     func() ([]byte, error)
-	SavePreferencesFn     func(data []byte) error
+	GetRecentFn            func(serviceName string, tail int) ([]service.LogEntry, bool)
+	GetAllFn               func(tail int) []service.LogEntry
+	ServiceNamesFn         func() []string
+	SubscribeFn            func(serviceName string) (chan service.LogEntry, bool)
+	UnsubscribeFn          func(serviceName string, ch chan service.LogEntry)
+	OnBufferAddedFn        func() <-chan string
+	RemoveBufferListenerFn func(ch <-chan string)
+	LoadClassificationsFn  func() ([]service.LogClassification, error)
+	SaveClassificationsFn  func(classifications []service.LogClassification) error
+	LoadPreferencesFn      func() ([]byte, error)
+	SavePreferencesFn      func(data []byte) error
+}
+
+// validate reports an error if any function field is nil. Co-located with
+// the struct so a new field added above is validated here in the same edit,
+// avoiding the silent-pass failure mode of a remote nil-check list.
+func (f LogsStoreFuncs) validate() error {
+	missing := []string{}
+	check := func(isNil bool, name string) {
+		if isNil {
+			missing = append(missing, name)
+		}
+	}
+	check(f.GetRecentFn == nil, "GetRecentFn")
+	check(f.GetAllFn == nil, "GetAllFn")
+	check(f.ServiceNamesFn == nil, "ServiceNamesFn")
+	check(f.SubscribeFn == nil, "SubscribeFn")
+	check(f.UnsubscribeFn == nil, "UnsubscribeFn")
+	check(f.OnBufferAddedFn == nil, "OnBufferAddedFn")
+	check(f.RemoveBufferListenerFn == nil, "RemoveBufferListenerFn")
+	check(f.LoadClassificationsFn == nil, "LoadClassificationsFn")
+	check(f.SaveClassificationsFn == nil, "SaveClassificationsFn")
+	check(f.LoadPreferencesFn == nil, "LoadPreferencesFn")
+	check(f.SavePreferencesFn == nil, "SavePreferencesFn")
+	if len(missing) > 0 {
+		return fmt.Errorf("LogsStoreFuncs has nil function field(s): %s", strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // GetRecent implements LogSource.
@@ -120,6 +161,12 @@ func (f LogsStoreFuncs) Subscribe(serviceName string) (chan service.LogEntry, bo
 func (f LogsStoreFuncs) Unsubscribe(serviceName string, ch chan service.LogEntry) {
 	f.UnsubscribeFn(serviceName, ch)
 }
+
+// OnBufferAdded implements LogSource.
+func (f LogsStoreFuncs) OnBufferAdded() <-chan string { return f.OnBufferAddedFn() }
+
+// RemoveBufferListener implements LogSource.
+func (f LogsStoreFuncs) RemoveBufferListener(ch <-chan string) { f.RemoveBufferListenerFn(ch) }
 
 // LoadClassifications implements ClassificationStore.
 func (f LogsStoreFuncs) LoadClassifications() ([]service.LogClassification, error) {

--- a/cli/src/internal/rpc/logs_subscriptions.go
+++ b/cli/src/internal/rpc/logs_subscriptions.go
@@ -1,0 +1,96 @@
+// logs_subscriptions.go manages per-stream subscription lifecycle for
+// StreamLocalLogs, including pump goroutines and dynamic service addition.
+package rpc
+
+import (
+	"context"
+	"sync"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+)
+
+// streamSubscriptions manages the per-stream set of LogBuffer subscriptions
+// and their pump goroutines for StreamLocalLogs. Each subscribed service's
+// channel is drained by a dedicated pump goroutine that pushes entries into
+// the shared ring. Concurrent add (from the dynamic new-service path) and
+// close are safe under mu.
+//
+// Lifecycle: construct with newStreamSubscriptions, add services via add,
+// then call close once on stream exit. close cancels every pump, waits for
+// them to drain in-flight pushes, then unsubscribes each source channel.
+type streamSubscriptions struct {
+	store LogSource
+	ring  *localLogRing
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu    sync.Mutex
+	subs  map[string]chan service.LogEntry
+	pumps sync.WaitGroup
+}
+
+// newStreamSubscriptions creates a subscription set bound to parent's
+// lifetime. The internal context is cancelled by close or when parent is
+// cancelled, whichever comes first.
+func newStreamSubscriptions(parent context.Context, store LogSource, ring *localLogRing) *streamSubscriptions {
+	ctx, cancel := context.WithCancel(parent)
+	return &streamSubscriptions{
+		store:  store,
+		ring:   ring,
+		ctx:    ctx,
+		cancel: cancel,
+		subs:   make(map[string]chan service.LogEntry),
+	}
+}
+
+// add subscribes to serviceName and starts its pump if not already
+// subscribed. Returns true if a new subscription was created, false if the
+// service was already subscribed or does not exist in the store.
+func (s *streamSubscriptions) add(serviceName string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, already := s.subs[serviceName]; already {
+		return false
+	}
+	ch, exists := s.store.Subscribe(serviceName)
+	if !exists {
+		return false
+	}
+	s.subs[serviceName] = ch
+	s.startPump(ch)
+	return true
+}
+
+// startPump launches a pump goroutine that drains src into the ring until
+// the channel closes or the stream context is cancelled. Drop-oldest ring
+// semantics mean push never blocks, so the pump always observes ctx.Done.
+// Caller must hold mu.
+func (s *streamSubscriptions) startPump(src chan service.LogEntry) {
+	s.pumps.Go(func() {
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case entry, ok := <-src:
+				if !ok {
+					return
+				}
+				s.ring.push(toProtoLogEntry(entry))
+			}
+		}
+	})
+}
+
+// close tears down every subscription. Ordering matters: cancel first so
+// pumps stop reading, wait so any in-flight push completes, then unsubscribe
+// to close the source channels (which a now-stopped pump won't read from).
+func (s *streamSubscriptions) close() {
+	s.cancel()
+	s.pumps.Wait()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for name, ch := range s.subs {
+		s.store.Unsubscribe(name, ch)
+	}
+}

--- a/cli/src/internal/rpc/logs_test.go
+++ b/cli/src/internal/rpc/logs_test.go
@@ -41,12 +41,19 @@ type fakeLogsStore struct {
 	prefs    []byte
 	prefsErr error
 	saveErr  error
+
+	// bufferAdded fires the service name when addService is called,
+	// simulating a service buffer created after a stream has opened.
+	// OnBufferAdded returns this channel so StreamLocalLogs can pick up
+	// new services mid-stream. nil until newFakeStore initialises it.
+	bufferAdded chan string
 }
 
 func newFakeStore() *fakeLogsStore {
 	return &fakeLogsStore{
-		buffers: map[string][]service.LogEntry{},
-		subs:    map[string][]chan service.LogEntry{},
+		buffers:     map[string][]service.LogEntry{},
+		subs:        map[string][]chan service.LogEntry{},
+		bufferAdded: make(chan string, 16),
 	}
 }
 
@@ -54,6 +61,17 @@ func (f *fakeLogsStore) addBuffer(name string, entries ...service.LogEntry) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.buffers[name] = append(f.buffers[name], entries...)
+}
+
+// addService registers a new (empty) buffer and fires the buffer-added
+// notification, simulating a service that starts after a stream is already
+// open. Used to exercise StreamLocalLogs' dynamic subscription path.
+func (f *fakeLogsStore) addService(name string) {
+	f.addBuffer(name)
+	select {
+	case f.bufferAdded <- name:
+	default:
+	}
 }
 
 // broadcast pushes entry to every active subscriber for service `name`.
@@ -137,6 +155,14 @@ func (f *fakeLogsStore) Unsubscribe(serviceName string, ch chan service.LogEntry
 			return
 		}
 	}
+}
+
+func (f *fakeLogsStore) OnBufferAdded() <-chan string {
+	return f.bufferAdded
+}
+
+func (f *fakeLogsStore) RemoveBufferListener(_ <-chan string) {
+	// No-op for tests; the channel is GC'd with the store.
 }
 
 func (f *fakeLogsStore) LoadClassifications() ([]service.LogClassification, error) {
@@ -751,6 +777,77 @@ func TestStreamLocalLogsReceivesEntries(t *testing.T) {
 	}
 	if got.GetMessage() != "hello" {
 		t.Errorf("message=%q want hello", got.GetMessage())
+	}
+}
+
+// TestStreamLocalLogsDynamicallySubscribesToNewService validates that a
+// service whose buffer is created AFTER an all-services stream opens is
+// picked up dynamically (via the OnBufferAdded notification) without a
+// reconnect. This is the headline fix for the "logs don't stream" bug.
+func TestStreamLocalLogsDynamicallySubscribesToNewService(t *testing.T) {
+	store := newFakeStore()
+	store.addBuffer("api") // one service exists at stream-open time
+	client, cleanup := newLogsTestServer(t, store)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		// Wait for the all-services stream to subscribe to "api".
+		deadline := time.Now().Add(3 * time.Second)
+		waitForSub := func(name string) bool {
+			for time.Now().Before(deadline) {
+				store.mu.Lock()
+				n := len(store.subs[name])
+				store.mu.Unlock()
+				if n > 0 {
+					return true
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+			return false
+		}
+		if !waitForSub("api") {
+			return
+		}
+		// A new service starts mid-stream: register its buffer and fire
+		// the buffer-added notification.
+		store.addService("worker")
+		// The stream should dynamically subscribe to "worker"; wait for
+		// that before broadcasting so the entry isn't dropped.
+		if !waitForSub("worker") {
+			return
+		}
+		store.broadcast("worker", service.LogEntry{
+			Service:   "worker",
+			Message:   "from-new-service",
+			Level:     service.LogLevelInfo,
+			Timestamp: time.Now(),
+		})
+	}()
+
+	// All-services mode (empty ServiceName) is the path that listens for
+	// new-buffer notifications.
+	stream, err := client.StreamLocalLogs(ctx, connect.NewRequest(&v1.StreamLocalLogsRequest{
+		ServiceName: "",
+	}))
+	if err != nil {
+		t.Fatalf("StreamLocalLogs: %v", err)
+	}
+
+	if !stream.Receive() {
+		t.Fatalf("Receive: %v", stream.Err())
+	}
+	got := stream.Msg().GetEntry()
+	if got == nil {
+		t.Fatalf("expected entry, got %+v", stream.Msg())
+	}
+	if got.GetService() != "worker" {
+		t.Errorf("service=%q want worker", got.GetService())
+	}
+	if got.GetMessage() != "from-new-service" {
+		t.Errorf("message=%q want from-new-service", got.GetMessage())
 	}
 }
 

--- a/cli/src/internal/service/logmanager.go
+++ b/cli/src/internal/service/logmanager.go
@@ -17,10 +17,25 @@ type LogManager struct {
 	buffers    map[string]*LogBuffer // key: serviceName
 	logFilter  *LogFilter            // Optional log filter for all buffers
 	mu         sync.RWMutex
+
+	// bufferAdded is a broadcast mechanism for notifying subscribers when
+	// new service buffers are created. Each listener registered via
+	// OnBufferAdded receives the service name on its channel. Channels
+	// are buffered (bufferAddedListenerCap) so a slow consumer doesn't
+	// block CreateBuffer; if a listener falls behind, the notification is
+	// dropped (the listener can poll ServiceNames to catch up).
+	listenersMu sync.Mutex
+	listeners   []chan string
 }
 
 // Compile-time interface compliance checks.
 var _ LogProvider = (*LogManager)(nil)
+
+// bufferAddedListenerCap bounds each OnBufferAdded listener channel. New
+// buffer notifications are sent non-blocking; if a listener falls behind
+// by more than this many service names, further notifications are
+// dropped (the listener can poll ServiceNames to catch up).
+const bufferAddedListenerCap = 16
 
 var (
 	logManagers   = make(map[string]*LogManager)
@@ -117,20 +132,27 @@ func loadLogFilterForProject(projectDir string) *LogFilter {
 // CreateBuffer creates a log buffer for a service.
 func (lm *LogManager) CreateBuffer(serviceName string, maxSize int, enableFileLogging bool) (*LogBuffer, error) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
 
 	// Return existing buffer if already created
 	if buffer, exists := lm.buffers[serviceName]; exists {
+		lm.mu.Unlock()
 		return buffer, nil
 	}
 
 	// Create new buffer with the log filter
 	buffer, err := NewLogBufferWithFilter(serviceName, maxSize, enableFileLogging, lm.projectDir, lm.logFilter)
 	if err != nil {
+		lm.mu.Unlock()
 		return nil, fmt.Errorf("failed to create log buffer for %s: %w", serviceName, err)
 	}
 
 	lm.buffers[serviceName] = buffer
+	lm.mu.Unlock()
+
+	// Notify listeners outside of the main lock to avoid holding it
+	// while potentially slow consumers process the notification.
+	lm.notifyBufferAdded(serviceName)
+
 	return buffer, nil
 }
 
@@ -293,6 +315,48 @@ func (lm *LogManager) GetServiceNames() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// OnBufferAdded registers a listener that receives the service name each
+// time a new buffer is created. The returned channel is buffered;
+// notifications are dropped (non-blocking send) if the listener doesn't
+// drain promptly. Callers MUST eventually call RemoveBufferListener to
+// prevent resource leaks.
+func (lm *LogManager) OnBufferAdded() <-chan string {
+	ch := make(chan string, bufferAddedListenerCap)
+	lm.listenersMu.Lock()
+	lm.listeners = append(lm.listeners, ch)
+	lm.listenersMu.Unlock()
+	return ch
+}
+
+// RemoveBufferListener removes a previously registered listener and
+// closes its channel. The channel must be one returned by OnBufferAdded.
+// Safe to call with a channel that was already removed.
+func (lm *LogManager) RemoveBufferListener(ch <-chan string) {
+	lm.listenersMu.Lock()
+	defer lm.listenersMu.Unlock()
+	for i, listener := range lm.listeners {
+		if listener == ch {
+			lm.listeners = append(lm.listeners[:i], lm.listeners[i+1:]...)
+			close(listener)
+			return
+		}
+	}
+}
+
+// notifyBufferAdded sends the service name to all registered listeners.
+// Non-blocking: slow listeners miss the notification (they can poll
+// ServiceNames to discover the new buffer).
+func (lm *LogManager) notifyBufferAdded(serviceName string) {
+	lm.listenersMu.Lock()
+	defer lm.listenersMu.Unlock()
+	for _, ch := range lm.listeners {
+		select {
+		case ch <- serviceName:
+		default:
+		}
+	}
 }
 
 // RemoveBuffer removes a log buffer for a service.

--- a/cli/src/internal/service/logmanager_test.go
+++ b/cli/src/internal/service/logmanager_test.go
@@ -352,3 +352,80 @@ func TestLogManagerConcurrency(t *testing.T) {
 		t.Errorf("concurrent CreateBuffer should create only 1 buffer, got %d", len(buffers))
 	}
 }
+
+func TestLogManagerOnBufferAdded(t *testing.T) {
+	lm, err := NewLogManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLogManager() error = %v", err)
+	}
+
+	// Register a listener before creating any buffers.
+	ch := lm.OnBufferAdded()
+	defer lm.RemoveBufferListener(ch)
+
+	// Create a buffer — the listener should receive the service name.
+	_, err = lm.CreateBuffer("svc-alpha", 100, false)
+	if err != nil {
+		t.Fatalf("CreateBuffer() error = %v", err)
+	}
+
+	select {
+	case name := <-ch:
+		if name != "svc-alpha" {
+			t.Errorf("OnBufferAdded got %q, want %q", name, "svc-alpha")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("OnBufferAdded: timed out waiting for notification")
+	}
+
+	// Creating the same buffer again should NOT notify (it's a no-op).
+	_, _ = lm.CreateBuffer("svc-alpha", 100, false)
+	select {
+	case name := <-ch:
+		t.Errorf("OnBufferAdded fired for duplicate CreateBuffer: %q", name)
+	case <-time.After(50 * time.Millisecond):
+		// expected: no notification
+	}
+
+	// Create a second buffer — should notify.
+	_, err = lm.CreateBuffer("svc-beta", 100, false)
+	if err != nil {
+		t.Fatalf("CreateBuffer() error = %v", err)
+	}
+
+	select {
+	case name := <-ch:
+		if name != "svc-beta" {
+			t.Errorf("OnBufferAdded got %q, want %q", name, "svc-beta")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("OnBufferAdded: timed out waiting for second notification")
+	}
+}
+
+func TestLogManagerRemoveBufferListener(t *testing.T) {
+	lm, err := NewLogManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLogManager() error = %v", err)
+	}
+
+	ch := lm.OnBufferAdded()
+
+	// Remove listener, then create a buffer — should NOT receive.
+	lm.RemoveBufferListener(ch)
+
+	_, _ = lm.CreateBuffer("orphan-svc", 100, false)
+
+	// Channel should be closed by RemoveBufferListener.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel to be closed after RemoveBufferListener")
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Error("channel should be closed and readable immediately")
+	}
+
+	// Calling RemoveBufferListener again should not panic.
+	lm.RemoveBufferListener(ch)
+}

--- a/docs/specs/log-stream-races/spec.md
+++ b/docs/specs/log-stream-races/spec.md
@@ -27,6 +27,8 @@ dropped.
   gap between disconnect and new stream
 - Pump goroutines start draining subscriber channels immediately upon subscribe
   (before backfill I/O)
+- Live local logs stream the instant a pane mounts, without waiting on the health
+  stream to connect
 
 ## Non-Goals
 
@@ -62,6 +64,19 @@ triggering a fresh `GetLogs` unary call to fill the gap.
 
 Fix misleading comment about defer LIFO ordering and restructure the cleanup path
 with explicit, correctly-documented defers.
+
+### 5. Decouple local live logs from the health stream (frontend)
+
+The grid view's per-service panes drove live logs through `useLogsStream`, which
+gated `shouldUseSharedStream` on the health stream's `connected` signal. That
+signal only flips true after the server's first health probe of ALL services
+completes, and a still-starting service blocks that probe for the full timeout.
+The result: live local logs were delayed for every service until the slowest
+health probe finished, even though the `StreamLocalLogs` RPC was ready
+immediately. Local logs now stream as soon as the pane mounts, matching the
+unified view (`LogsView`), which never had the health gate. Azure realtime stays
+gated on `connected` because Log Analytics genuinely needs the backend reachable.
+
 
 ## Alternatives Considered
 

--- a/docs/specs/log-stream-races/spec.md
+++ b/docs/specs/log-stream-races/spec.md
@@ -1,0 +1,96 @@
+---
+author: "@jongio"
+status: draft
+---
+
+# Fix Log Streaming Race Conditions
+
+## Problem
+
+When running `azd app run`, the dashboard sometimes fails to display logs for one
+or more services. The user sees an empty log pane that never receives entries
+despite the service clearly producing output. A page refresh fixes it — but only
+if the service's buffer happens to exist by then. This is a regression-prone,
+non-deterministic UX bug that erodes trust in the dashboard's reliability.
+
+Root cause: several race conditions in the CLI→dashboard log streaming pipeline
+mean that services starting after the stream opens, entries produced during the
+backfill window, and entries lost during stream reconnection are all silently
+dropped.
+
+## Goals
+
+- Services that start after the dashboard's log stream opens appear dynamically
+  without requiring a page refresh
+- No entries are lost during the backfill send window (startup burst)
+- After a stream reconnect, the dashboard re-fetches initial history to close the
+  gap between disconnect and new stream
+- Pump goroutines start draining subscriber channels immediately upon subscribe
+  (before backfill I/O)
+
+## Non-Goals
+
+- Guaranteed exactly-once delivery (drop-oldest back-pressure is acceptable)
+- Changing the Connect-RPC wire protocol or adding new proto messages
+- Real-time service removal notifications (existing reconnect-to-discover is fine)
+- Persisting logs across dashboard restarts (out of scope)
+
+## Solution
+
+### 1. Dynamic service subscription (backend)
+
+Add a `OnBufferAdded() chan string` notification mechanism to `LogManager`. When
+`CreateBuffer` registers a new service, all listeners receive the service name.
+`StreamLocalLogs` (in all-services mode) selects on this channel in its main loop
+and dynamically subscribes + starts a pump goroutine for new services mid-stream.
+
+### 2. Reorder pump start before backfill (backend)
+
+Start pump goroutines immediately after subscribing — before sending backfill
+entries to the client. This ensures the 100-capacity subscriber channels drain
+continuously and don't overflow from `broadcast()` drop-on-full during the
+(potentially slow) backfill send phase.
+
+### 3. Reconnect triggers history re-fetch (frontend)
+
+Add a `reconnectGeneration` counter to `SubscriberRegistry` in the shared log
+stream manager. It increments on each successful reconnection. The `useLogsStream`
+hook incorporates this counter to detect reconnects and reset its fetch state,
+triggering a fresh `GetLogs` unary call to fill the gap.
+
+### 4. Correct defer ordering (backend)
+
+Fix misleading comment about defer LIFO ordering and restructure the cleanup path
+with explicit, correctly-documented defers.
+
+## Alternatives Considered
+
+- **Frontend-only reconnect with backfill > 0**: Would require the server to dedup
+  entries the client already has. Adds wire complexity and doesn't solve issue #1
+  (new services invisible).
+- **Periodic poll of ServiceNames from the frontend**: Would work but adds
+  unnecessary latency (polling interval) and network chatter for a rare event.
+  Push notification is cleaner.
+- **LogManager event bus (full pub/sub)**: Over-engineered. A simple channel-based
+  listener list is sufficient for the single consumer (StreamLocalLogs).
+
+## Risks & Rabbit Holes
+
+- The `OnBufferAdded` listener channel (capacity 16) can fill if many services
+  start simultaneously. The non-blocking send means the notification is dropped,
+  but the service still exists in the LogManager — a worst case requires one more
+  reconnect cycle to discover it. Acceptable for the expected service count (<20).
+- Backfill entries and live-stream entries can overlap (duplicate delivery) for
+  entries that arrive between subscribe and backfill-snapshot. The ring buffer's
+  drop-oldest semantics and the dashboard's append-only log list mean duplicates
+  are visually harmless. A future enhancement could add sequence-based dedup.
+
+<!-- Pipeline tracking (auto-managed, not part of product spec) -->
+## Pipeline Status
+Phase: SHIPPING
+Completed: Phase 1-4 (scope, build, verify, certify)
+Worktree: .worktrees/go-log-stream-races
+Branch: fix/log-stream-race-conditions
+Quality gates: golangci-lint 0 issues, gosec/staticcheck no new findings, go test -race clean,
+  vitest 1421 pass, tsc clean, full CLI build clean
+Remaining: Phase 5 (rebase, commit, PR — human-gated)

--- a/docs/specs/log-stream-races/spec.md
+++ b/docs/specs/log-stream-races/spec.md
@@ -1,6 +1,7 @@
 ---
+issue: https://github.com/jongio/azd-app/pull/340
 author: "@jongio"
-status: draft
+status: shipped
 ---
 
 # Fix Log Streaming Race Conditions
@@ -99,13 +100,3 @@ gated on `connected` because Log Analytics genuinely needs the backend reachable
   entries that arrive between subscribe and backfill-snapshot. The ring buffer's
   drop-oldest semantics and the dashboard's append-only log list mean duplicates
   are visually harmless. A future enhancement could add sequence-based dedup.
-
-<!-- Pipeline tracking (auto-managed, not part of product spec) -->
-## Pipeline Status
-Phase: SHIPPING
-Completed: Phase 1-4 (scope, build, verify, certify)
-Worktree: .worktrees/go-log-stream-races
-Branch: fix/log-stream-race-conditions
-Quality gates: golangci-lint 0 issues, gosec/staticcheck no new findings, go test -race clean,
-  vitest 1421 pass, tsc clean, full CLI build clean
-Remaining: Phase 5 (rebase, commit, PR — human-gated)

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,7 @@
     "@astrojs/mdx": "^6.0.2",
     "@jongio/azd-web-core": "^2.4.1",
     "@tailwindcss/vite": "^4.3.0",
-    "astro": "^6.4.4",
+    "astro": "^6.4.8",
     "astro-expressive-code": "^0.42.0",
     "tailwindcss": "^4.3.0"
   },

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -13,19 +13,19 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^6.0.2
-        version: 6.0.2(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.2(astro@6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
       '@jongio/azd-web-core':
         specifier: ^2.4.1
-        version: 2.4.1(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(prettier@3.8.3)(tailwindcss@4.3.0)(typescript@5.9.3)
+        version: 2.4.1(astro@6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(prettier@3.8.3)(tailwindcss@4.3.0)(typescript@5.9.3)
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
       astro:
-        specifier: ^6.4.4
-        version: 6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
+        specifier: ^6.4.8
+        version: 6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
       astro-expressive-code:
         specifier: ^0.42.0
-        version: 0.42.0(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 0.42.0(astro@6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1090,8 +1090,8 @@ packages:
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@6.4.4:
-    resolution: {integrity: sha512-hVe8tq3lqt/Dr0UyB//yUmQSlHMTU8scTiF/vQddQVahLE4TTaSdH5H0nb7OvRcwo0UmlAO8DWYar4jNaS7H+A==}
+  astro@6.4.8:
+    resolution: {integrity: sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -2511,13 +2511,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@6.0.2(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))':
+  '@astrojs/mdx@6.0.2(astro@6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-remark': 7.2.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
+      astro: 6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -2883,10 +2883,10 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@jongio/azd-web-core@2.4.1(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(prettier@3.8.3)(tailwindcss@4.3.0)(typescript@5.9.3)':
+  '@jongio/azd-web-core@2.4.1(astro@6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(prettier@3.8.3)(tailwindcss@4.3.0)(typescript@5.9.3)':
     dependencies:
       '@astrojs/check': 0.9.9(prettier@3.8.3)(typescript@5.9.3)
-      astro: 6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
+      astro: 6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
       tailwindcss: 4.3.0
     transitivePeerDependencies:
       - prettier
@@ -3282,12 +3282,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.42.0(astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)):
+  astro-expressive-code@0.42.0(astro@6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      astro: 6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
+      astro: 6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
       rehype-expressive-code: 0.42.0
 
-  astro@6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0):
+  astro@6.4.8(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0


### PR DESCRIPTION
## Description

Logs sometimes failed to reach the dashboard, or arrived only after a long delay. This PR fixes both the missing-logs race conditions and the streaming latency, restoring instant per-service log streaming.

**Race conditions** (`bc2c7839`):
- New services that started after the stream opened were never subscribed. `LogManager` now broadcasts an `OnBufferAdded` notification and `StreamLocalLogs` subscribes to new buffers mid-stream (listener registered before the service snapshot to close the window).
- Pump goroutines now start before backfill, so bounded subscriber channels don't overflow during the backfill burst.
- On reconnect, the dashboard re-fetches initial history to close the disconnect gap.
- Extracted `streamSubscriptions` to own the subscription and pump lifecycle.

**Latency** (`dc3ec143`):
- Live local logs were gated on the health stream's `connected` signal, which only flips true after the first health probe of all services finishes. A still-starting service blocked that probe for the full timeout, delaying live logs for every service. Local logs now stream the instant a pane mounts, matching the unified view. Azure realtime stays gated.

Validated with the Go race detector and the full dashboard test suite.

## Checklist
- [x] All tests pass
- [x] Documentation updated (spec at `docs/specs/log-stream-races`)
- [ ] CHANGELOG.md updated (handled by release automation)
- [x] Follows code style guidelines

---

## Quality Gates

| Gate | Status | Notes |
|---|---|---|
| preflight | PASS | golangci-lint 0 issues, gofmt/vet clean, gosec no new findings |
| code-review | PASS | multi-model; 1 MEDIUM race window found and fixed |
| secops | PASS | 0 findings (DoS, leaks, races, disclosure, validation) |
| test-health | PASS | Go race detector clean; new code 78-100% covered; rpc 82% |
| tests | PASS | Go (service + rpc + dashboard) plus 1423 dashboard vitest |
