### PR TITLE
test(runner): fix flaky Windows temp-dir cleanup in TestRunPython_ValidEntrypoints

### DIFF
--- a/cli/src/internal/runner/runner_test.go
+++ b/cli/src/internal/runner/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	types "github.com/jongio/azd-core/projecttype"
 )
@@ -599,6 +600,30 @@ func TestRunPython_LeadingDashEntrypoint(t *testing.T) {
 func TestRunPython_ValidEntrypoints(t *testing.T) {
 	tmpDir := t.TempDir()
 
+	// RunPython starts a fire-and-forget child process whose working
+	// directory is tmpDir. On Windows that process holds a handle on
+	// tmpDir, which races with the RemoveAll that t.TempDir() registered
+	// above ("The process cannot access the file because it is being used
+	// by another process"). Drive every RunPython call off a cancellable
+	// context and, in a cleanup that runs BEFORE t.TempDir()'s (t.Cleanup
+	// is LIFO), cancel the context and poll-remove tmpDir until Windows
+	// releases the handles. Once tmpDir is gone, t.TempDir()'s own
+	// RemoveAll is a no-op and can't fail.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if err := os.RemoveAll(tmpDir); err == nil {
+				return
+			}
+			if time.Now().After(deadline) {
+				return // let t.TempDir()'s cleanup surface any residual error
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	})
+
 	validEntrypoints := []string{
 		"main.py",
 		"src/main.py",
@@ -626,7 +651,7 @@ func TestRunPython_ValidEntrypoints(t *testing.T) {
 
 			// The call may fail because python/venv is absent in CI, but it must NOT fail
 			// with an argv injection error.
-			err := RunPython(context.Background(), project)
+			err := RunPython(ctx, project)
 			if err != nil {
 				// An error is acceptable here (missing python binary, missing venv, etc.)
 				// but it must not be the argv injection guard.


### PR DESCRIPTION
## Description

Fixes a flaky Windows failure in `TestRunPython_ValidEntrypoints` (`cli/src/internal/runner`) that intermittently blocks CI on `main`.

The test called `RunPython` with `context.Background()`, which starts a fire-and-forget Python process whose working directory is the test's `t.TempDir()`. On Windows that process holds a handle on the directory, racing with `t.TempDir()`'s `RemoveAll` cleanup and intermittently failing with:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat ...: The process cannot access the file because it is being used by another process.
--- FAIL: TestRunPython_ValidEntrypoints
    --- PASS: (all subtests)
```

All subtests pass; only the directory cleanup races. The fix drives every `RunPython` call off a cancellable context and, in a cleanup registered after `t.TempDir()` (so it runs first, since `t.Cleanup` is LIFO), cancels the context and poll-removes the temp dir until Windows releases the handles. Once the dir is gone, `t.TempDir()`'s own `RemoveAll` is a no-op.

Test-only change; no production code affected.

## Checklist
- [x] All tests pass
- [x] Documentation updated (N/A — test-only)
- [ ] CHANGELOG.md updated (handled by release automation)
- [x] Follows code style guidelines
