### PR TITLE
Add redaction for shareable log output

### DIFF
--- a/cli/src/cmd/app/commands/logs.go
+++ b/cli/src/cmd/app/commands/logs.go
@@ -153,6 +153,7 @@ type logsOptions struct {
 	noBuiltins   bool
 	contextLines int    // Number of context lines before/after matching entries (0-10)
 	source       string // Log source: "local", "azure", or "all"
+	redact       bool
 }
 
 // logsExecutor encapsulates the logs command execution with injectable dependencies.
@@ -292,6 +293,7 @@ Examples:
 	cmd.Flags().BoolVar(&opts.noBuiltins, "no-builtins", false, "Disable built-in filter patterns")
 	cmd.Flags().IntVar(&opts.contextLines, "context", 0, "Number of context lines before/after matching entries (0-10, requires --level)")
 	cmd.Flags().StringVar(&opts.source, "source", "local", "Log source: 'local' (default), 'azure', or 'all'")
+	cmd.Flags().BoolVar(&opts.redact, "redact", false, "Redact secret-shaped values before printing logs")
 
 	return cmd
 }
@@ -335,6 +337,9 @@ func (e *logsExecutor) execute(ctx context.Context, args []string) error {
 	// Emit any warnings collected during log retrieval
 	for _, w := range collected.Warnings {
 		cliout.Warning("%s", w)
+	}
+	if e.opts.redact {
+		redactCollectedLogs(collected)
 	}
 
 	if e.opts.source == string(LogSourceAzure) && !e.opts.follow {
@@ -805,6 +810,27 @@ func (e *logsExecutor) getOrCreateSignalChan() (chan os.Signal, func()) {
 	}
 
 	return sigChan, cleanup
+}
+
+func redactCollectedLogs(collected *CollectedLogs) {
+	if collected == nil {
+		return
+	}
+	for i := range collected.Entries {
+		collected.Entries[i].Message = service.MaskSecretsInLogLine(collected.Entries[i].Message)
+	}
+	for i := range collected.EntriesWithContext {
+		collected.EntriesWithContext[i].Message = service.MaskSecretsInLogLine(collected.EntriesWithContext[i].Message)
+		if collected.EntriesWithContext[i].Context == nil {
+			continue
+		}
+		for j := range collected.EntriesWithContext[i].Context.Before {
+			collected.EntriesWithContext[i].Context.Before[j] = service.MaskSecretsInLogLine(collected.EntriesWithContext[i].Context.Before[j])
+		}
+		for j := range collected.EntriesWithContext[i].Context.After {
+			collected.EntriesWithContext[i].Context.After[j] = service.MaskSecretsInLogLine(collected.EntriesWithContext[i].Context.After[j])
+		}
+	}
 }
 
 // shouldDisplayEntry checks if a log entry should be displayed based on filters.

--- a/cli/src/cmd/app/commands/logs_redaction_test.go
+++ b/cli/src/cmd/app/commands/logs_redaction_test.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+)
+
+func TestLogsCommandHasRedactFlag(t *testing.T) {
+	cmd := NewLogsCommand()
+	flag := cmd.Flags().Lookup("redact")
+	if flag == nil {
+		t.Fatal("redact flag not found")
+	}
+	if flag.Value.Type() != "bool" {
+		t.Fatalf("redact flag type = %s, want bool", flag.Value.Type())
+	}
+}
+
+func TestRedactCollectedLogs(t *testing.T) {
+	collected := &CollectedLogs{
+		Entries: []service.LogEntry{
+			{
+				Service:   "api",
+				Message:   "token=abc123456789 password: hunter222",
+				Level:     service.LogLevelInfo,
+				Timestamp: time.Now(),
+			},
+		},
+		EntriesWithContext: []LogEntryWithContext{
+			{
+				Service: "worker",
+				Message: "Authorization token=eyJaaaaaaaaaa.bbbbbbbbbb.cccccccccc",
+				Context: &LogContext{
+					Before: []string{"apiKey=1234567890"},
+					After:  []string{"normal line"},
+				},
+			},
+		},
+	}
+
+	redactCollectedLogs(collected)
+
+	if strings.Contains(collected.Entries[0].Message, "abc123456789") || strings.Contains(collected.Entries[0].Message, "hunter222") {
+		t.Fatalf("entry message was not redacted: %s", collected.Entries[0].Message)
+	}
+	if strings.Contains(collected.EntriesWithContext[0].Message, "eyJaaaaaaaaaa") {
+		t.Fatalf("context entry message was not redacted: %s", collected.EntriesWithContext[0].Message)
+	}
+	if strings.Contains(collected.EntriesWithContext[0].Context.Before[0], "1234567890") {
+		t.Fatalf("before context was not redacted: %s", collected.EntriesWithContext[0].Context.Before[0])
+	}
+	if collected.EntriesWithContext[0].Context.After[0] != "normal line" {
+		t.Fatalf("non-sensitive context changed: %s", collected.EntriesWithContext[0].Context.After[0])
+	}
+}
+
+func TestMaskSecretsInLogLineIsAvailableForShareableLogs(t *testing.T) {
+	got := service.MaskSecretsInLogLine("connection token=abcdefghi")
+	if strings.Contains(got, "abcdefghi") {
+		t.Fatalf("secret value was not masked: %s", got)
+	}
+}

--- a/cli/src/internal/service/logbuffer.go
+++ b/cli/src/internal/service/logbuffer.go
@@ -129,8 +129,8 @@ var sensitivePatterns = regexp.MustCompile(
 		`(eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})`,
 )
 
-// maskSecretsInLogLine redacts sensitive values from a log message before writing to file.
-func maskSecretsInLogLine(message string) string {
+// MaskSecretsInLogLine redacts sensitive values from a log message.
+func MaskSecretsInLogLine(message string) string {
 	return sensitivePatterns.ReplaceAllStringFunc(message, func(match string) string {
 		// For key=value patterns, keep the key and mask the value
 		if idx := strings.IndexAny(match, "=:"); idx >= 0 {
@@ -155,7 +155,7 @@ func (lb *LogBuffer) writeToFile(entry LogEntry) {
 		stream = "ERR"
 	}
 
-	line := fmt.Sprintf("[%s] [%s] [%s] %s\n", timestamp, level, stream, maskSecretsInLogLine(entry.Message))
+	line := fmt.Sprintf("[%s] [%s] [%s] %s\n", timestamp, level, stream, MaskSecretsInLogLine(entry.Message))
 	n, err := lb.fileWriter.WriteString(line)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to write log entry: %v\n", err)


### PR DESCRIPTION
Closes #356

Adds `azd app logs --redact` so copied log output masks secret-shaped values in text, JSON, and context output.

Verification:
- `go build ./...` passed
- `go test ./src/cmd/app/commands -run 'TestLogsCommandHasRedactFlag|TestRedactCollectedLogs|TestMaskSecretsInLogLineIsAvailableForShareableLogs'` passed
- `go test ./src/internal/service -run 'Test'` passed
- `go test ./...` had one existing Windows cleanup failure in `src/internal/runner`: temp directory still in use by spawned function host processes