### PR TITLE
Add a CLI dependency graph command

### DIFF
--- a/cli/src/cmd/app/commands/graph.go
+++ b/cli/src/cmd/app/commands/graph.go
@@ -1,0 +1,194 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/spf13/cobra"
+)
+
+const (
+	graphOutputText = "text"
+	graphOutputJSON = "json"
+)
+
+type graphOptions struct {
+	output string
+	writer io.Writer
+}
+
+type graphResult struct {
+	Project string      `json:"project"`
+	Nodes   []graphNode `json:"nodes"`
+	Edges   []graphEdge `json:"edges"`
+	Levels  [][]string  `json:"levels"`
+}
+
+type graphNode struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Level    int    `json:"level"`
+	Host     string `json:"host,omitempty"`
+	Language string `json:"language,omitempty"`
+	Project  string `json:"project,omitempty"`
+}
+
+type graphEdge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// NewGraphCommand creates the graph command.
+func NewGraphCommand() *cobra.Command {
+	opts := &graphOptions{writer: os.Stdout}
+	cmd := &cobra.Command{
+		Use:          "graph",
+		Short:        "Show the service dependency graph",
+		Long:         "Show services, resources, dependency edges, and startup levels from azure.yaml.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGraph(opts)
+		},
+	}
+	cmd.Flags().StringVarP(&opts.output, "output", "o", graphOutputText, "Output format: text or json")
+	return cmd
+}
+
+func runGraph(opts *graphOptions) error {
+	if opts == nil {
+		opts = &graphOptions{writer: os.Stdout}
+	}
+	if opts.writer == nil {
+		opts.writer = os.Stdout
+	}
+	if opts.output == "" {
+		opts.output = graphOutputText
+	}
+	if opts.output != graphOutputText && opts.output != graphOutputJSON {
+		return fmt.Errorf("invalid output format: %s (must be text or json)", opts.output)
+	}
+
+	azureYamlPath, err := findAzureYaml()
+	if err != nil {
+		return err
+	}
+	projectDir := filepath.Dir(azureYamlPath)
+	azureYaml, err := service.ParseAzureYaml(projectDir)
+	if err != nil {
+		return fmt.Errorf("failed to parse azure.yaml: %w", err)
+	}
+	if len(azureYaml.Services) == 0 && len(azureYaml.Resources) == 0 {
+		return fmt.Errorf("azure.yaml has no services or resources to graph")
+	}
+
+	graph, err := service.BuildDependencyGraph(azureYaml.Services, azureYaml.Resources)
+	if err != nil {
+		return err
+	}
+	result := buildGraphResult(projectDir, graph)
+
+	if opts.output == graphOutputJSON {
+		enc := json.NewEncoder(opts.writer)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	printGraphText(opts.writer, result)
+	return nil
+}
+
+func buildGraphResult(projectDir string, graph *service.DependencyGraph) graphResult {
+	nodeNames := make([]string, 0, len(graph.Nodes))
+	for name := range graph.Nodes {
+		nodeNames = append(nodeNames, name)
+	}
+	sort.Strings(nodeNames)
+
+	nodes := make([]graphNode, 0, len(nodeNames))
+	for _, name := range nodeNames {
+		node := graph.Nodes[name]
+		out := graphNode{
+			Name:  name,
+			Type:  "service",
+			Level: node.Level,
+		}
+		if node.IsResource {
+			out.Type = "resource"
+		}
+		if node.Service != nil {
+			out.Host = node.Service.Host
+			out.Language = node.Service.Language
+			out.Project = node.Service.Project
+		}
+		nodes = append(nodes, out)
+	}
+
+	edges := make([]graphEdge, 0)
+	for from, deps := range graph.Edges {
+		for _, dep := range deps {
+			edges = append(edges, graphEdge{From: from, To: dep})
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].From == edges[j].From {
+			return edges[i].To < edges[j].To
+		}
+		return edges[i].From < edges[j].From
+	})
+
+	return graphResult{
+		Project: projectDir,
+		Nodes:   nodes,
+		Edges:   edges,
+		Levels:  service.TopologicalSort(graph),
+	}
+}
+
+func printGraphText(w io.Writer, result graphResult) {
+	_, _ = fmt.Fprintf(w, "Dependency graph for %s\n\n", result.Project)
+
+	if len(result.Levels) == 0 {
+		_, _ = fmt.Fprintln(w, "No service startup levels found.")
+	} else {
+		_, _ = fmt.Fprintln(w, "Startup levels:")
+		for i, level := range result.Levels {
+			_, _ = fmt.Fprintf(w, "  Level %d: %s\n", i, joinGraphNames(level))
+		}
+	}
+
+	_, _ = fmt.Fprintln(w, "\nNodes:")
+	for _, node := range result.Nodes {
+		detail := node.Type
+		if node.Language != "" {
+			detail += ", " + node.Language
+		}
+		if node.Host != "" {
+			detail += ", " + node.Host
+		}
+		_, _ = fmt.Fprintf(w, "  - %s (%s, level %d)\n", node.Name, detail, node.Level)
+	}
+
+	_, _ = fmt.Fprintln(w, "\nEdges:")
+	if len(result.Edges) == 0 {
+		_, _ = fmt.Fprintln(w, "  No dependency edges.")
+		return
+	}
+	for _, edge := range result.Edges {
+		_, _ = fmt.Fprintf(w, "  %s -> %s\n", edge.From, edge.To)
+	}
+}
+
+func joinGraphNames(names []string) string {
+	if len(names) == 0 {
+		return "(none)"
+	}
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ", ")
+}

--- a/cli/src/cmd/app/commands/graph_test.go
+++ b/cli/src/cmd/app/commands/graph_test.go
@@ -1,0 +1,110 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+)
+
+func TestNewGraphCommand(t *testing.T) {
+	cmd := NewGraphCommand()
+	if cmd == nil {
+		t.Fatal("NewGraphCommand returned nil")
+	}
+	if cmd.Use != "graph" {
+		t.Fatalf("Use = %q, want graph", cmd.Use)
+	}
+	if cmd.Flags().Lookup("output") == nil {
+		t.Fatal("output flag not found")
+	}
+}
+
+func TestBuildGraphResult(t *testing.T) {
+	graph, err := service.BuildDependencyGraph(
+		map[string]service.Service{
+			"api": {Host: "local", Language: "go", Project: "./api", Uses: []string{"db"}},
+			"web": {Host: "local", Language: "node", Project: "./web", Uses: []string{"api"}},
+		},
+		map[string]service.Resource{"db": {Type: "postgres"}},
+	)
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+
+	result := buildGraphResult("project", graph)
+	if len(result.Nodes) != 3 {
+		t.Fatalf("nodes = %d, want 3", len(result.Nodes))
+	}
+	if len(result.Edges) != 2 {
+		t.Fatalf("edges = %d, want 2", len(result.Edges))
+	}
+	if result.Edges[0] != (graphEdge{From: "api", To: "db"}) {
+		t.Fatalf("first edge = %#v, want api -> db", result.Edges[0])
+	}
+	if len(result.Levels) != 2 || result.Levels[0][0] != "api" || result.Levels[1][0] != "web" {
+		t.Fatalf("levels = %#v, want [[api] [web]]", result.Levels)
+	}
+}
+
+func TestPrintGraphText(t *testing.T) {
+	result := graphResult{
+		Project: "project",
+		Nodes: []graphNode{
+			{Name: "api", Type: "service", Level: 1, Language: "go", Host: "local"},
+			{Name: "db", Type: "resource", Level: 0},
+		},
+		Edges:  []graphEdge{{From: "api", To: "db"}},
+		Levels: [][]string{{"api"}},
+	}
+
+	var buf bytes.Buffer
+	printGraphText(&buf, result)
+	out := buf.String()
+	for _, want := range []string{"Dependency graph", "Level 0: api", "api -> db", "db (resource"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunGraphJSON(t *testing.T) {
+	dir := t.TempDir()
+	azureYaml := []byte(`
+name: graph-test
+services:
+  api:
+    host: local
+    language: go
+    project: ./api
+    uses:
+      - db
+resources:
+  db:
+    type: postgres
+`)
+	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), azureYaml, 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "api"), 0o750); err != nil {
+		t.Fatalf("mkdir api: %v", err)
+	}
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+	err := runGraph(&graphOptions{output: graphOutputJSON, writer: &buf})
+	if err != nil {
+		t.Fatalf("runGraph failed: %v", err)
+	}
+	var got graphResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if len(got.Nodes) != 2 || len(got.Edges) != 1 {
+		t.Fatalf("unexpected graph result: %#v", got)
+	}
+}

--- a/cli/src/cmd/app/main.go
+++ b/cli/src/cmd/app/main.go
@@ -100,6 +100,7 @@ func main() {
 		commands.NewRestartCommand(),
 		commands.NewAddCommand(),
 		commands.NewSupportBundleCommand(),
+		commands.NewGraphCommand(),
 		commands.NewMetadataCommand(func() *cobra.Command { return rootCmd }),
 	)
 


### PR DESCRIPTION
Closes #355

Adds `azd app graph` with text and JSON output for service/resource nodes, `uses` edges, and startup levels.

Verification:
- `go build ./...` passed
- `go test ./...` passed