### PR TITLE
Add a support bundle command for local run state

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,6 +4,7 @@ If you need help with azd-app:
 
 - Check the documentation in the `docs/` folder and README.md.
 - Search existing issues and discussions.
+- Run `azd app support-bundle` from your project and attach the created folder when reporting local run, health, or log issues. The bundle redacts common secret-shaped values before writing files.
 - File an issue in this repository for bugs, feature requests, or questions.
 
 We aim to respond to issues within a few days. For security concerns, file a private issue and mark it as security-related.

--- a/cli/src/cmd/app/commands/support_bundle.go
+++ b/cli/src/cmd/app/commands/support_bundle.go
@@ -1,0 +1,311 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/jongio/azd-app/cli/src/internal/healthcheck"
+	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
+	"github.com/jongio/azd-app/cli/src/internal/version"
+	"github.com/jongio/azd-core/cliout"
+	"github.com/jongio/azd-core/security"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const defaultSupportBundleTail = 200
+
+var secretValuePattern = regexp.MustCompile(
+	`(?i)((?:secret|password|token|key|credential|connection[_-]?string|auth)[_\-]?\w*\s*[=:]\s*)"?([^\s"]{6,})"?` +
+		`|` +
+		`(eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})`,
+)
+
+type supportBundleOptions struct {
+	output  string
+	tail    int
+	service string
+}
+
+type supportBundleManifest struct {
+	CreatedAt  string   `json:"createdAt"`
+	ProjectDir string   `json:"projectDir"`
+	Version    string   `json:"version"`
+	BuildTime  string   `json:"buildTime"`
+	Commit     string   `json:"commit"`
+	OS         string   `json:"os"`
+	Arch       string   `json:"arch"`
+	Files      []string `json:"files"`
+	Warnings   []string `json:"warnings,omitempty"`
+}
+
+// NewSupportBundleCommand creates the support-bundle command.
+func NewSupportBundleCommand() *cobra.Command {
+	opts := &supportBundleOptions{tail: defaultSupportBundleTail}
+	cmd := &cobra.Command{
+		Use:          "support-bundle",
+		Short:        "Collect local diagnostics for support",
+		Long:         "Collect sanitized project, service, health, and log diagnostics into a local folder for issue reports.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSupportBundle(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "Output folder path")
+	cmd.Flags().IntVar(&opts.tail, "tail", defaultSupportBundleTail, "Recent log lines per service to include")
+	cmd.Flags().StringVarP(&opts.service, "service", "s", "", "Include logs and health for specific service(s), comma-separated")
+	return cmd
+}
+
+func runSupportBundle(ctx context.Context, opts *supportBundleOptions) error {
+	if opts == nil {
+		opts = &supportBundleOptions{tail: defaultSupportBundleTail}
+	}
+	if opts.tail < 0 {
+		return fmt.Errorf("--tail must be zero or greater")
+	}
+
+	azureYamlPath, err := findAzureYaml()
+	if err != nil {
+		return err
+	}
+	projectDir := filepath.Dir(azureYamlPath)
+	outputDir, err := resolveSupportBundleOutput(projectDir, opts.output)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
+		return fmt.Errorf("failed to create support bundle folder: %w", err)
+	}
+
+	manifest := supportBundleManifest{
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		ProjectDir: projectDir,
+		Version:    version.Version,
+		BuildTime:  BuildTime,
+		Commit:     Commit,
+		OS:         runtime.GOOS,
+		Arch:       runtime.GOARCH,
+	}
+
+	addFile := func(name string, write func(string) error) {
+		if err := write(filepath.Join(outputDir, name)); err != nil {
+			manifest.Warnings = append(manifest.Warnings, fmt.Sprintf("%s: %v", name, err))
+			return
+		}
+		manifest.Files = append(manifest.Files, name)
+	}
+
+	addFile("azure.yaml.redacted", func(path string) error {
+		return writeRedactedAzureYaml(azureYamlPath, path)
+	})
+	addFile("services.json", func(path string) error {
+		services, err := serviceinfo.GetServiceInfo(projectDir)
+		if err != nil {
+			return err
+		}
+		return writeJSONRedacted(path, services)
+	})
+	addFile("health.json", func(path string) error {
+		return writeHealthReport(ctx, path, projectDir, opts.service)
+	})
+	addFile("logs.json", func(path string) error {
+		return writeLogSnapshot(ctx, path, projectDir, opts)
+	})
+
+	if err := writeJSON(filepath.Join(outputDir, "manifest.json"), manifest); err != nil {
+		return fmt.Errorf("failed to write manifest: %w", err)
+	}
+
+	cliout.Success("Support bundle created: %s", outputDir)
+	cliout.Info("Included %d file(s)", len(manifest.Files)+1)
+	if len(manifest.Warnings) > 0 {
+		cliout.Warning("Completed with %d warning(s). See manifest.json.", len(manifest.Warnings))
+	}
+	return nil
+}
+
+func resolveSupportBundleOutput(projectDir, output string) (string, error) {
+	if output == "" {
+		name := "support-bundle-" + time.Now().UTC().Format("20060102-150405")
+		return filepath.Join(projectDir, ".azd", "support-bundles", name), nil
+	}
+	if err := security.ValidatePath(output); err != nil {
+		return "", fmt.Errorf("invalid output path: %w", err)
+	}
+	if filepath.IsAbs(output) {
+		return filepath.Clean(output), nil
+	}
+	return filepath.Join(projectDir, output), nil
+}
+
+func writeRedactedAzureYaml(sourcePath, targetPath string) error {
+	data, err := os.ReadFile(sourcePath) // #nosec G304 -- source path is discovered by findAzureYaml.
+	if err != nil {
+		return err
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		masked := redactSecretText(string(data))
+		return os.WriteFile(targetPath, []byte(masked), 0o600)
+	}
+	redactYAMLNode(&node, "")
+	out, err := yaml.Marshal(&node)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(targetPath, out, 0o600)
+}
+
+func redactYAMLNode(node *yaml.Node, parentKey string) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			value := node.Content[i+1]
+			if isSensitiveKey(key) {
+				replaceYAMLValue(value)
+				continue
+			}
+			redactYAMLNode(value, key)
+		}
+	case yaml.SequenceNode, yaml.DocumentNode:
+		for _, child := range node.Content {
+			redactYAMLNode(child, parentKey)
+		}
+	case yaml.ScalarNode:
+		if isSensitiveKey(parentKey) {
+			node.Value = "***"
+			return
+		}
+		node.Value = redactSecretText(node.Value)
+	}
+}
+
+func replaceYAMLValue(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+	node.Kind = yaml.ScalarNode
+	node.Tag = "!!str"
+	node.Value = "***"
+	node.Content = nil
+}
+
+func writeHealthReport(ctx context.Context, path, projectDir, serviceFilter string) error {
+	monitor, err := healthcheck.NewHealthMonitor(healthcheck.MonitorConfig{
+		ProjectDir:      projectDir,
+		DefaultEndpoint: defaultHealthEndpoint,
+		Timeout:         2 * time.Second,
+		LogLevel:        "error",
+		LogFormat:       "text",
+	})
+	if err != nil {
+		return err
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	report, err := monitor.Check(checkCtx, parseServiceFilter(serviceFilter))
+	if err != nil {
+		return err
+	}
+	return writeJSON(path, report)
+}
+
+func writeLogSnapshot(ctx context.Context, path, projectDir string, opts *supportBundleOptions) error {
+	logOpts := &logsOptions{
+		tail:    opts.tail,
+		level:   "all",
+		output:  jsonOutputVal,
+		source:  string(LogSourceLocal),
+		service: opts.service,
+	}
+	executor := newLogsExecutorForMCP(logOpts, projectDir)
+	logCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	collected, err := executor.collect(logCtx, nil)
+	if err != nil {
+		return err
+	}
+	for i := range collected.Entries {
+		collected.Entries[i].Message = redactSecretText(collected.Entries[i].Message)
+	}
+	for i := range collected.EntriesWithContext {
+		collected.EntriesWithContext[i].Message = redactSecretText(collected.EntriesWithContext[i].Message)
+	}
+	return writeJSONRedacted(path, collected)
+}
+
+func writeJSONRedacted(path string, value any) error {
+	var decoded any
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	return writeJSON(path, redactJSONValue(decoded, ""))
+}
+
+func writeJSON(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}
+
+func redactJSONValue(value any, key string) any {
+	if isSensitiveKey(key) {
+		return "***"
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, v := range typed {
+			out[k] = redactJSONValue(v, k)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, v := range typed {
+			out[i] = redactJSONValue(v, key)
+		}
+		return out
+	case string:
+		return redactSecretText(typed)
+	default:
+		return value
+	}
+}
+
+func isSensitiveKey(key string) bool {
+	upper := strings.ToUpper(key)
+	for _, part := range []string{"PASSWORD", "SECRET", "TOKEN", "KEY", "CREDENTIAL", "CONNECTION_STRING", "CONNECTIONSTRING", "AUTH"} {
+		if strings.Contains(upper, part) {
+			return true
+		}
+	}
+	return false
+}
+
+func redactSecretText(text string) string {
+	return secretValuePattern.ReplaceAllStringFunc(text, func(match string) string {
+		if idx := strings.IndexAny(match, "=:"); idx >= 0 {
+			return match[:idx+1] + "***"
+		}
+		return "***"
+	})
+}

--- a/cli/src/cmd/app/commands/support_bundle_test.go
+++ b/cli/src/cmd/app/commands/support_bundle_test.go
@@ -1,0 +1,113 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewSupportBundleCommand(t *testing.T) {
+	cmd := NewSupportBundleCommand()
+	if cmd == nil {
+		t.Fatal("NewSupportBundleCommand returned nil")
+	}
+	if cmd.Use != "support-bundle" {
+		t.Fatalf("Use = %q, want support-bundle", cmd.Use)
+	}
+	for _, name := range []string{"output", "tail", "service"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("%s flag not found", name)
+		}
+	}
+}
+
+func TestRedactSecretText(t *testing.T) {
+	got := redactSecretText("token=abc123456 password: hunter222 normal")
+	if strings.Contains(got, "abc123456") || strings.Contains(got, "hunter222") {
+		t.Fatalf("secret text was not redacted: %s", got)
+	}
+	if !strings.Contains(got, "normal") {
+		t.Fatalf("non-secret text was removed: %s", got)
+	}
+}
+
+func TestWriteRedactedAzureYaml(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "azure.yaml")
+	target := filepath.Join(dir, "azure.redacted.yaml")
+	data := []byte(`
+name: test
+services:
+  api:
+    host: local
+    environment:
+      API_KEY: supersecretvalue
+      PUBLIC_URL: http://localhost:3000
+`)
+	if err := os.WriteFile(source, data, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	if err := writeRedactedAzureYaml(source, target); err != nil {
+		t.Fatalf("writeRedactedAzureYaml failed: %v", err)
+	}
+	out, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	text := string(out)
+	if strings.Contains(text, "supersecretvalue") {
+		t.Fatalf("secret value was not redacted:\n%s", text)
+	}
+	if !strings.Contains(text, "PUBLIC_URL") {
+		t.Fatalf("non-secret value missing:\n%s", text)
+	}
+}
+
+func TestRunSupportBundleCreatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(`
+name: bundle-test
+services:
+  api:
+    host: local
+    language: go
+    environment:
+      API_TOKEN: secretvalue123
+`), 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+	t.Chdir(dir)
+
+	outDir := filepath.Join(dir, "bundle")
+	err := runSupportBundle(t.Context(), &supportBundleOptions{output: outDir, tail: 0})
+	if err != nil {
+		t.Fatalf("runSupportBundle failed: %v", err)
+	}
+
+	for _, name := range []string{"manifest.json", "azure.yaml.redacted", "services.json", "health.json", "logs.json"} {
+		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
+			t.Fatalf("%s was not created: %v", name, err)
+		}
+	}
+	var manifest supportBundleManifest
+	data, err := os.ReadFile(filepath.Join(outDir, "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("manifest is invalid JSON: %v", err)
+	}
+	if len(manifest.Files) == 0 {
+		t.Fatal("manifest has no files")
+	}
+	redacted, err := os.ReadFile(filepath.Join(outDir, "azure.yaml.redacted"))
+	if err != nil {
+		t.Fatalf("read redacted azure.yaml: %v", err)
+	}
+	if strings.Contains(string(redacted), "secretvalue123") {
+		t.Fatalf("support bundle contains unredacted secret:\n%s", string(redacted))
+	}
+}

--- a/cli/src/cmd/app/main.go
+++ b/cli/src/cmd/app/main.go
@@ -98,6 +98,7 @@ func main() {
 		commands.NewStopCommand(),
 		commands.NewRestartCommand(),
 		commands.NewAddCommand(),
+		commands.NewSupportBundleCommand(),
 		commands.NewMetadataCommand(func() *cobra.Command { return rootCmd }),
 	)
 


### PR DESCRIPTION
Closes #352

Adds `azd app support-bundle` to collect a local diagnostics folder with a manifest, redacted azure.yaml, service info, health data, and recent local logs.

Verification:
- `go build ./...` passed
- `go test ./src/cmd/app/commands -run 'TestNewSupportBundleCommand|TestRedactSecretText|TestWriteRedactedAzureYaml|TestRunSupportBundleCreatesFiles'` passed
- `go test ./...` had a Windows timing failure in `TestShutdownAllServices_ContextTimeout`; the failure is outside this change