### PR TITLE
feat(completion): add shell completion for --service flag values

### DIFF
--- a/cli/src/cmd/app/commands/completion.go
+++ b/cli/src/cmd/app/commands/completion.go
@@ -1,0 +1,92 @@
+package commands
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+
+	"github.com/spf13/cobra"
+)
+
+// serviceNamesFromAzureYaml returns the service names defined in the project's
+// azure.yaml, sorted alphabetically. It returns nil when azure.yaml cannot be
+// found or parsed so that shell completion degrades to no suggestions rather
+// than surfacing an error to the user's terminal.
+func serviceNamesFromAzureYaml() []string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+
+	azureYaml, err := service.ParseAzureYaml(cwd)
+	if err != nil || azureYaml == nil {
+		return nil
+	}
+
+	names := make([]string, 0, len(azureYaml.Services))
+	for name := range azureYaml.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// completeServiceNames is a cobra flag completion function for the --service
+// flag. It suggests service names read from azure.yaml.
+//
+// The --service flag accepts a comma-separated list, so completion only fills
+// in the segment after the last comma and skips names already chosen earlier in
+// the same value. It always returns ShellCompDirectiveNoFileComp so the shell
+// does not fall back to file-name completion.
+func completeServiceNames(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	all := serviceNamesFromAzureYaml()
+	if len(all) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	prefix, last, chosen := splitServiceCompletion(toComplete)
+
+	suggestions := make([]string, 0, len(all))
+	for _, name := range all {
+		if chosen[name] {
+			continue
+		}
+		if strings.HasPrefix(name, last) {
+			suggestions = append(suggestions, prefix+name)
+		}
+	}
+
+	return suggestions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// splitServiceCompletion breaks an in-progress --service value on commas. It
+// returns the already-typed prefix (everything up to and including the last
+// comma), the final segment still being typed, and the set of names already
+// present before the final segment.
+func splitServiceCompletion(toComplete string) (prefix, last string, chosen map[string]bool) {
+	chosen = make(map[string]bool)
+
+	idx := strings.LastIndex(toComplete, ",")
+	if idx < 0 {
+		return "", toComplete, chosen
+	}
+
+	prefix = toComplete[:idx+1]
+	last = toComplete[idx+1:]
+	for _, part := range strings.Split(toComplete[:idx], ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			chosen[part] = true
+		}
+	}
+	return prefix, last, chosen
+}
+
+// registerServiceFlagCompletion wires completeServiceNames to the given flag on
+// cmd. It is a no-op when the flag does not exist so callers can register it
+// unconditionally after defining flags.
+func registerServiceFlagCompletion(cmd *cobra.Command, flagName string) {
+	_ = cmd.RegisterFlagCompletionFunc(flagName, completeServiceNames)
+}

--- a/cli/src/cmd/app/commands/completion_test.go
+++ b/cli/src/cmd/app/commands/completion_test.go
@@ -1,0 +1,128 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// writeAzureYamlForCompletion writes a minimal azure.yaml with the given service
+// names into dir.
+func writeAzureYamlForCompletion(t *testing.T, dir string, names ...string) {
+	t.Helper()
+
+	content := "name: completion-test\nservices:\n"
+	for _, n := range names {
+		content += "  " + n + ":\n    language: node\n    host: local\n    project: ./" + n + "\n"
+	}
+
+	path := filepath.Join(dir, "azure.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write azure.yaml: %v", err)
+	}
+}
+
+func TestServiceNamesFromAzureYaml_Sorted(t *testing.T) {
+	dir := t.TempDir()
+	writeAzureYamlForCompletion(t, dir, "web", "api", "worker")
+	t.Chdir(dir)
+
+	got := serviceNamesFromAzureYaml()
+	want := []string{"api", "web", "worker"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("serviceNamesFromAzureYaml() = %v, want %v", got, want)
+	}
+}
+
+func TestServiceNamesFromAzureYaml_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if got := serviceNamesFromAzureYaml(); got != nil {
+		t.Errorf("serviceNamesFromAzureYaml() = %v, want nil when azure.yaml is missing", got)
+	}
+}
+
+func TestCompleteServiceNames(t *testing.T) {
+	dir := t.TempDir()
+	writeAzureYamlForCompletion(t, dir, "api", "web", "worker")
+	t.Chdir(dir)
+
+	tests := []struct {
+		name       string
+		toComplete string
+		want       []string
+	}{
+		{
+			name:       "empty prefix suggests all",
+			toComplete: "",
+			want:       []string{"api", "web", "worker"},
+		},
+		{
+			name:       "prefix filters",
+			toComplete: "w",
+			want:       []string{"web", "worker"},
+		},
+		{
+			name:       "comma keeps chosen and completes trailing segment",
+			toComplete: "api,w",
+			want:       []string{"api,web", "api,worker"},
+		},
+		{
+			name:       "comma excludes already chosen name",
+			toComplete: "web,w",
+			want:       []string{"web,worker"},
+		},
+		{
+			name:       "no match returns empty",
+			toComplete: "zzz",
+			want:       []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, directive := completeServiceNames(nil, nil, tt.toComplete)
+			if directive != cobra.ShellCompDirectiveNoFileComp {
+				t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+			}
+			if !reflect.DeepEqual(normalizeCompletion(got), normalizeCompletion(tt.want)) {
+				t.Errorf("completeServiceNames(%q) = %v, want %v", tt.toComplete, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompleteServiceNames_NoAzureYaml(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	got, directive := completeServiceNames(nil, nil, "")
+	if got != nil {
+		t.Errorf("completeServiceNames() = %v, want nil when azure.yaml is missing", got)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+	}
+}
+
+func TestRegisterServiceFlagCompletion(t *testing.T) {
+	cmd := &cobra.Command{Use: "demo"}
+	cmd.Flags().String("service", "", "service filter")
+
+	registerServiceFlagCompletion(cmd, "service")
+
+	// Registering an unknown flag must not panic.
+	registerServiceFlagCompletion(cmd, "does-not-exist")
+}
+
+// normalizeCompletion treats nil and empty slices as equal for comparison.
+func normalizeCompletion(s []string) []string {
+	if len(s) == 0 {
+		return []string{}
+	}
+	return s
+}

--- a/cli/src/cmd/app/commands/health.go
+++ b/cli/src/cmd/app/commands/health.go
@@ -125,6 +125,8 @@ Examples:
 	cmd.Flags().IntVar(&healthRateLimit, "rate-limit", 0, "Max health checks per second per service (0 = unlimited)")
 	cmd.Flags().DurationVar(&healthCacheTTL, "cache-ttl", 0, "Cache TTL for health results (0 = no caching)")
 
+	registerServiceFlagCompletion(cmd, "service")
+
 	return cmd
 }
 

--- a/cli/src/cmd/app/commands/logs.go
+++ b/cli/src/cmd/app/commands/logs.go
@@ -295,6 +295,8 @@ Examples:
 	cmd.Flags().StringVar(&opts.source, "source", "local", "Log source: 'local' (default), 'azure', or 'all'")
 	cmd.Flags().BoolVar(&opts.redact, "redact", false, "Redact secret-shaped values before printing logs")
 
+	registerServiceFlagCompletion(cmd, "service")
+
 	return cmd
 }
 

--- a/cli/src/cmd/app/commands/restart.go
+++ b/cli/src/cmd/app/commands/restart.go
@@ -48,6 +48,8 @@ Examples:
 	cmd.Flags().BoolVar(&restartAll, "all", false, "Restart all services")
 	cmd.Flags().BoolVarP(&restartYes, "yes", "y", false, "Skip confirmation prompt for --all")
 
+	registerServiceFlagCompletion(cmd, "service")
+
 	return cmd
 }
 

--- a/cli/src/cmd/app/commands/run.go
+++ b/cli/src/cmd/app/commands/run.go
@@ -64,6 +64,8 @@ func NewRunCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&runForce, "force", false, "Force clean dependency reinstall and auto-resolve port conflicts without prompting")
 	cmd.Flags().BoolVarP(&runTrust, "trust", "y", false, "Trust this workspace for code execution and remember the decision")
 
+	registerServiceFlagCompletion(cmd, "service")
+
 	return cmd
 }
 

--- a/cli/src/cmd/app/commands/start.go
+++ b/cli/src/cmd/app/commands/start.go
@@ -45,6 +45,8 @@ Examples:
 	cmd.Flags().StringVarP(&startService, "service", "s", "", "Service name(s) to start (comma-separated)")
 	cmd.Flags().BoolVar(&startAll, "all", false, "Start all stopped services")
 
+	registerServiceFlagCompletion(cmd, "service")
+
 	return cmd
 }
 

--- a/cli/src/cmd/app/commands/test.go
+++ b/cli/src/cmd/app/commands/test.go
@@ -91,6 +91,8 @@ func NewTestCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.NoSave, "no-save", false, "Don't prompt to save auto-detected test config")
 	cmd.Flags().StringVarP(&opts.Environment, "environment", "e", "", "Target azd environment name (loads vars from .azure/<env>/.env)")
 
+	registerServiceFlagCompletion(cmd, "service")
+
 	return cmd
 }
 


### PR DESCRIPTION
## What

Add shell completion for the `--service` flag across the commands that accept it: `run`, `health`, `logs`, `test`, `start`, and `restart`. When you type a service name and press Tab, the shell now suggests the service names defined in your `azure.yaml`.

## Why

Six commands take a `--service` value, but none of them offered completion for it. You had to remember exact service names or open `azure.yaml` to check. This adds the same Tab completion that shell users already expect from other CLIs, so targeting a specific service is faster and less error prone.

## How

A small reusable helper reads service names from `azure.yaml`, sorts them, and registers a cobra completion function on the `--service` flag of each command.

- Supports the comma-separated multi-service syntax (`--service api,web`) by completing only the segment after the last comma and skipping names already chosen.
- Returns `ShellCompDirectiveNoFileComp` so the shell does not fall back to file-name completion.
- Degrades to no suggestions when `azure.yaml` is missing or cannot be parsed, so completion never prints an error into the terminal.

```mermaid
flowchart LR
    A[User presses Tab after --service] --> B[completeServiceNames]
    B --> C{azure.yaml found and parsed?}
    C -->|no| D[return no suggestions]
    C -->|yes| E[read + sort service names]
    E --> F[split value on commas]
    F --> G[drop already-chosen names]
    G --> H[filter by typed prefix]
    H --> I[return matching service names]
```

## Testing

- `completion_test.go` covers sorted names, missing `azure.yaml`, prefix filtering, comma-separated filtering, and flag registration.
- `go build ./src/...`, `go vet`, and `gofmt -l` are clean.
- Existing command tests still pass.

Closes #383
