### PR TITLE
feat(stop): add service-scoped stop with --service and --all

### DIFF
--- a/cli/src/cmd/app/commands/stop.go
+++ b/cli/src/cmd/app/commands/stop.go
@@ -17,6 +17,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	stopService string
+	stopAll     bool
+	stopYes     bool
+)
+
 // NewStopCommand creates the stop command.
 func NewStopCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -24,25 +30,90 @@ func NewStopCommand() *cobra.Command {
 		Short: "Stop running services and tear down the app",
 		Long: `Stop running services, execute lifecycle hooks, and tear down the app.
 
-Sends a shutdown signal to the running 'azd app run' process. This triggers
-graceful shutdown including prestop/poststop hooks, port release, and
-process cleanup — identical to pressing Ctrl+C in the run terminal.
+Without flags, stop sends a shutdown signal to the running 'azd app run'
+process. This triggers graceful shutdown including prestop/poststop hooks,
+port release, and process cleanup, identical to pressing Ctrl+C in the run
+terminal.
 
-Lifecycle hooks:
+Use --service to stop specific services while leaving the rest running, or
+--all to stop every running service without tearing down the app. This
+mirrors the start and restart commands.
+
+Lifecycle hooks (whole-app teardown only):
   prestop  - runs before services are stopped (e.g., drain connections)
   poststop - runs after all services are stopped (e.g., cleanup temp files)
 
 Examples:
   # Stop the running app (from any terminal in the project)
-  azd app stop`,
+  azd app stop
+
+  # Stop a specific service, leaving the rest running
+  azd app stop --service api
+
+  # Stop multiple services
+  azd app stop --service "api,web,worker"
+
+  # Stop all running services without tearing down the app
+  azd app stop --all
+
+  # JSON output
+  azd app stop --service api --output json`,
 		SilenceUsage: true,
 		RunE:         runStop,
 	}
 
+	cmd.Flags().StringVarP(&stopService, "service", "s", "", "Service name(s) to stop (comma-separated)")
+	cmd.Flags().BoolVar(&stopAll, "all", false, "Stop all running services")
+	cmd.Flags().BoolVarP(&stopYes, "yes", "y", false, "Skip confirmation prompt for --all")
+
 	return cmd
 }
 
+// runStop routes to service-scoped stop when --service or --all is set, and
+// otherwise falls back to whole-app teardown for backward compatibility.
 func runStop(cmd *cobra.Command, args []string) error {
+	if stopService != "" || stopAll {
+		return runStopServices()
+	}
+	return runStopApp()
+}
+
+// runStopServices stops specific services (or all running services) via the
+// service controller without tearing down the app, mirroring start/restart.
+func runStopServices() error {
+	cliout.CommandHeader("stop", "Stop services")
+
+	ctrl, err := NewServiceController("")
+	if err != nil {
+		return fmt.Errorf("failed to initialize: %w", err)
+	}
+
+	ctx, _, cleanup := setupContextWithSignalHandling()
+	defer cleanup()
+
+	var servicesToStop []string
+	if stopAll {
+		servicesToStop = ctrl.GetRunningServices()
+		if len(servicesToStop) == 0 {
+			handleNoServicesCase(ctrl, "running", "stop")
+			return nil
+		}
+		if !confirmBulkOperation(len(servicesToStop), "stop", stopYes) {
+			cliout.Info("Operation canceled")
+			return nil
+		}
+	} else {
+		servicesToStop, err = parseServiceList(stopService)
+		if err != nil {
+			return err
+		}
+	}
+
+	return executeServiceOperation(ctx, servicesToStop, ctrl.StopService, ctrl.BulkStop, "stop")
+}
+
+// runStopApp tears down the whole app by signaling the running dashboard.
+func runStopApp() error {
 	cliout.CommandHeader("stop", "Stop running services")
 
 	// Find project root

--- a/cli/src/cmd/app/commands/stop_test.go
+++ b/cli/src/cmd/app/commands/stop_test.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetStopFlags restores the package-level stop flag vars so tests do not leak
+// state into one another.
+func resetStopFlags(t *testing.T) {
+	t.Helper()
+	prevService, prevAll, prevYes := stopService, stopAll, stopYes
+	t.Cleanup(func() {
+		stopService, stopAll, stopYes = prevService, prevAll, prevYes
+	})
+	stopService, stopAll, stopYes = "", false, false
+}
+
+func TestNewStopCommandFlags(t *testing.T) {
+	cmd := NewStopCommand()
+
+	tests := []struct {
+		name       string
+		flag       string
+		shorthand  string
+		defaultVal string
+	}{
+		{name: "service flag", flag: "service", shorthand: "s", defaultVal: ""},
+		{name: "all flag", flag: "all", shorthand: "", defaultVal: "false"},
+		{name: "yes flag", flag: "yes", shorthand: "y", defaultVal: "false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := cmd.Flags().Lookup(tt.flag)
+			require.NotNil(t, f, "flag %q should be defined", tt.flag)
+			assert.Equal(t, tt.shorthand, f.Shorthand)
+			assert.Equal(t, tt.defaultVal, f.DefValue)
+		})
+	}
+}
+
+func TestRunStopServicesAllNoRunningServices(t *testing.T) {
+	resetStopFlags(t)
+	t.Chdir(t.TempDir())
+
+	stopAll = true
+
+	// With no registered/running services, --all should report that there is
+	// nothing to stop and return without error rather than tearing down.
+	err := runStopServices()
+	assert.NoError(t, err)
+}
+
+func TestRunStopRoutesToServicesWhenServiceSet(t *testing.T) {
+	resetStopFlags(t)
+	t.Chdir(t.TempDir())
+
+	// --all with an empty registry exercises the service-scoped path, which
+	// must succeed (no-op) instead of attempting whole-app teardown.
+	stopAll = true
+	require.NoError(t, runStop(nil, nil))
+}


### PR DESCRIPTION
## What

Add `--service` and `--all` flags to the `stop` command so you can stop specific services (or all running services) without tearing down the whole app.

- `azd app stop` (no flags): unchanged. Sends the shutdown signal and tears down the app, running prestop/poststop hooks, exactly as before.
- `azd app stop --service api`: stops just the named service and leaves the rest running.
- `azd app stop --service "api,web"`: stops several services.
- `azd app stop --all`: stops every running service, with a confirmation prompt (`--yes` to skip).

## Why

`start` and `restart` already accept `--service` and `--all`, but `stop` only did whole-app teardown. If you wanted to stop one service you had to stop everything and start the rest again. This closes that gap so the three lifecycle commands behave consistently.

## How

`runStop` routes to a service-scoped path when `--service` or `--all` is set, and otherwise falls back to the existing whole-app teardown. The service-scoped path reuses the shared `ServiceController` (the same `StopService`/`BulkStop` used by the dashboard), so flags, confirmation, no-op messaging, and JSON output match `start` and `restart`.

```mermaid
flowchart TD
    A[azd app stop] --> B{--service or --all set?}
    B -->|no| C[whole-app teardown]
    C --> C1[send shutdown signal + run stop hooks]
    B -->|yes| D[service-scoped stop]
    D --> E{--all?}
    E -->|yes| F[collect running services]
    F --> G{any running?}
    G -->|no| H[report nothing to stop]
    G -->|yes| I[confirm unless --yes]
    E -->|no| J[parse --service list]
    I --> K[StopService / BulkStop]
    J --> K
```

## Testing

- `stop_test.go` covers the flag wiring (`--service`/`-s`, `--all`, `--yes`/`-y` and defaults) and the `--all` no-running-services path.
- `go build ./src/...`, `go vet`, and `gofmt -l` are clean.
- Existing command tests still pass.

Closes #384
