### PR TITLE
feat(cli): suggest available services when a name is not found

### DIFF
--- a/cli/src/cmd/app/commands/commands_test.go
+++ b/cli/src/cmd/app/commands/commands_test.go
@@ -135,8 +135,8 @@ func TestNewInfoCommand(t *testing.T) {
 		t.Fatal("NewInfoCommand() returned nil")
 	}
 
-	if cmd.Use != "info" {
-		t.Errorf("Use = %q, want %q", cmd.Use, "info")
+	if cmd.Use != "info [service...]" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "info [service...]")
 	}
 
 	if cmd.Short == "" {

--- a/cli/src/cmd/app/commands/health.go
+++ b/cli/src/cmd/app/commands/health.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/jongio/azd-app/cli/src/internal/healthcheck"
+	"github.com/jongio/azd-app/cli/src/internal/service"
 
 	"github.com/spf13/cobra"
 )
@@ -247,6 +249,23 @@ func runHealth(cmd *cobra.Command, args []string) error {
 
 	// Parse service filter
 	serviceFilter := parseServiceFilter(healthService)
+
+	// Validate requested service names against azure.yaml so an unknown name
+	// produces a helpful "did you mean" error instead of an empty report.
+	if len(serviceFilter) > 0 {
+		if azureYaml, yamlErr := service.ParseAzureYaml(projectDir); yamlErr == nil {
+			names := make([]string, 0, len(azureYaml.Services))
+			for name := range azureYaml.Services {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			for _, requested := range serviceFilter {
+				if _, resolveErr := resolveServiceName(requested, names); resolveErr != nil {
+					return resolveErr
+				}
+			}
+		}
+	}
 
 	// Handle interrupt signals for graceful shutdown
 	setupSignalHandler(ctx, cancel)

--- a/cli/src/cmd/app/commands/info.go
+++ b/cli/src/cmd/app/commands/info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,9 +27,9 @@ const (
 // NewInfoCommand creates the info command.
 func NewInfoCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "info",
+		Use:          "info [service...]",
 		Short:        "Show information about running services",
-		Long:         `Displays comprehensive information about all running services including URLs, status, health, and metadata`,
+		Long:         `Displays comprehensive information about all running services including URLs, status, health, and metadata. Pass one or more service names to show only those services.`,
 		SilenceUsage: true,
 		RunE:         runInfo,
 	}
@@ -75,6 +76,14 @@ func runInfo(cmd *cobra.Command, args []string) error {
 	// Get Azure environment values for environment variable display
 	azureEnv := getAzureEnvironmentValues()
 
+	// Filter to the requested services when names are passed as arguments.
+	if len(args) > 0 {
+		allServices, err = filterServicesByName(allServices, args)
+		if err != nil {
+			return err
+		}
+	}
+
 	// For JSON output
 	if cliout.IsJSON() {
 		return printInfoJSON(cwd, allServices, azureEnv)
@@ -83,6 +92,29 @@ func runInfo(cmd *cobra.Command, args []string) error {
 	// Default output
 	printInfoDefault(cwd, allServices, azureEnv)
 	return nil
+}
+
+// filterServicesByName returns only the services whose names are in the
+// requested list. Each requested name is validated against the available
+// services, returning a helpful "did you mean" error when a name is unknown.
+func filterServicesByName(services []*serviceinfo.ServiceInfo, requested []string) ([]*serviceinfo.ServiceInfo, error) {
+	available := make([]string, 0, len(services))
+	byName := make(map[string]*serviceinfo.ServiceInfo, len(services))
+	for _, svc := range services {
+		available = append(available, svc.Name)
+		byName[svc.Name] = svc
+	}
+	sort.Strings(available)
+
+	filtered := make([]*serviceinfo.ServiceInfo, 0, len(requested))
+	for _, name := range requested {
+		resolved, err := resolveServiceName(name, available)
+		if err != nil {
+			return nil, err
+		}
+		filtered = append(filtered, byName[resolved])
+	}
+	return filtered, nil
 }
 
 // printInfoJSON outputs service information in JSON format.

--- a/cli/src/cmd/app/commands/logs.go
+++ b/cli/src/cmd/app/commands/logs.go
@@ -617,8 +617,7 @@ func (e *logsExecutor) validateServiceFilter(serviceFilter, serviceNames []strin
 	// Validate each filter service
 	for _, filterName := range serviceFilter {
 		if _, ok := serviceSet[filterName]; !ok {
-			return fmt.Errorf("service '%s' not found (available: %s)",
-				filterName, strings.Join(serviceNames, ", "))
+			return serviceNotFoundError(filterName, serviceNames)
 		}
 	}
 	return nil

--- a/cli/src/cmd/app/commands/service_control.go
+++ b/cli/src/cmd/app/commands/service_control.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -122,10 +123,28 @@ func (c *ServiceController) validateAndGetService(serviceName string) (*registry
 
 	entry, exists := c.registry.GetService(serviceName)
 	if !exists {
-		return nil, newErrorResult(serviceName, fmt.Sprintf("service '%s' not found", serviceName))
+		return nil, newErrorResult(serviceName, serviceNotFoundError(serviceName, c.availableServiceNames()).Error())
 	}
 
 	return entry, nil
+}
+
+// availableServiceNames returns the names of the services defined for this
+// project. It prefers the service definitions in azure.yaml (the source of
+// truth, available even before anything has been started) and falls back to
+// the runtime registry when azure.yaml cannot be parsed.
+func (c *ServiceController) availableServiceNames() []string {
+	if azureYaml, err := service.ParseAzureYaml(c.projectDir); err == nil {
+		names := make([]string, 0, len(azureYaml.Services))
+		for name := range azureYaml.Services {
+			names = append(names, name)
+		}
+		if len(names) > 0 {
+			sort.Strings(names)
+			return names
+		}
+	}
+	return c.GetAllServices()
 }
 
 // isRunning returns true if the service status indicates it's running.
@@ -313,7 +332,12 @@ func (c *ServiceController) performStart(ctx context.Context, entry *registry.Se
 
 	svcDef, exists := azureYaml.Services[serviceName]
 	if !exists {
-		return fmt.Errorf("service '%s' not found in azure.yaml", serviceName)
+		names := make([]string, 0, len(azureYaml.Services))
+		for name := range azureYaml.Services {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return serviceNotFoundError(serviceName, names)
 	}
 
 	// Detect runtime

--- a/cli/src/cmd/app/commands/service_suggest.go
+++ b/cli/src/cmd/app/commands/service_suggest.go
@@ -1,0 +1,121 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+// serviceSuggestMaxDistance caps how far apart (in case-insensitive edit
+// distance) a requested name and a defined service name may be before the name
+// stops being offered as a "did you mean" suggestion. It is deliberately small
+// so that only genuine typos are suggested, not unrelated names.
+const serviceSuggestMaxDistance = 3
+
+// resolveServiceName validates a requested service name against the list of
+// available service names. It returns the matched name on an exact
+// (case-sensitive) match, otherwise a formatted "not found" error that lists
+// the available services and, when a close match exists, a single "Did you
+// mean X?" suggestion.
+//
+// The returned error is a plain error value so callers can surface it as text
+// or embed its message in a structured (JSON) error field without extra
+// formatting.
+func resolveServiceName(requested string, available []string) (string, error) {
+	for _, name := range available {
+		if name == requested {
+			return name, nil
+		}
+	}
+	return "", serviceNotFoundError(requested, available)
+}
+
+// serviceNotFoundError builds a consistent error for an unknown service name.
+// It always lists the available services and appends a single suggestion when
+// one is close enough (case-insensitive, small edit distance).
+func serviceNotFoundError(requested string, available []string) error {
+	if len(available) == 0 {
+		return fmt.Errorf("service %q not found. No services are defined in azure.yaml", requested)
+	}
+
+	msg := fmt.Sprintf("service %q not found. Available services: %s",
+		requested, strings.Join(available, ", "))
+
+	if suggestion := suggestServiceName(requested, available); suggestion != "" {
+		msg += fmt.Sprintf(". Did you mean %q?", suggestion)
+	}
+
+	return fmt.Errorf("%s", msg)
+}
+
+// suggestServiceName returns the single closest available service name to the
+// requested name, or an empty string when nothing is close. Matching is
+// case-insensitive, but the returned name keeps its original casing.
+func suggestServiceName(requested string, available []string) string {
+	reqLower := strings.ToLower(strings.TrimSpace(requested))
+	if reqLower == "" {
+		return ""
+	}
+
+	best := ""
+	bestDist := -1
+	for _, name := range available {
+		dist := levenshtein(reqLower, strings.ToLower(name))
+		if bestDist == -1 || dist < bestDist {
+			bestDist = dist
+			best = name
+		}
+	}
+
+	if best == "" {
+		return ""
+	}
+
+	// Scale the allowed distance with the requested length so that short names
+	// require a closer match, and cap it so unrelated names are never offered.
+	threshold := len(reqLower)/2 + 1
+	if threshold > serviceSuggestMaxDistance {
+		threshold = serviceSuggestMaxDistance
+	}
+	if bestDist > threshold {
+		return ""
+	}
+
+	return best
+}
+
+// levenshtein computes the Levenshtein edit distance between two strings using
+// the standard two-row dynamic programming approach.
+func levenshtein(a, b string) int {
+	ar := []rune(a)
+	br := []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+
+	prev := make([]int, len(br)+1)
+	curr := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(ar); i++ {
+		curr[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			curr[j] = min(
+				curr[j-1]+1,    // insertion
+				prev[j]+1,      // deletion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[len(br)]
+}

--- a/cli/src/cmd/app/commands/service_suggest_test.go
+++ b/cli/src/cmd/app/commands/service_suggest_test.go
@@ -1,0 +1,143 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{"both empty", "", "", 0},
+		{"empty a", "", "abc", 3},
+		{"empty b", "abc", "", 3},
+		{"identical", "api", "api", 0},
+		{"one insertion", "web", "webb", 1},
+		{"one deletion", "backendd", "backend", 1},
+		{"one substitution", "web", "web", 0},
+		{"substitution", "cat", "bat", 1},
+		{"multiple edits", "kitten", "sitting", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, levenshtein(tt.a, tt.b))
+			// Distance is symmetric.
+			assert.Equal(t, tt.want, levenshtein(tt.b, tt.a))
+		})
+	}
+}
+
+func TestSuggestServiceName(t *testing.T) {
+	available := []string{"api", "web", "worker"}
+	tests := []struct {
+		name      string
+		requested string
+		available []string
+		want      string
+	}{
+		{"exact match returns itself", "api", available, "api"},
+		{"case-only mismatch suggests correct casing", "API", available, "api"},
+		{"close typo suggests match", "webb", available, "web"},
+		{"short typo suggests match", "ap", available, "api"},
+		{"far-off name has no suggestion", "database", available, ""},
+		{"unrelated short name has no suggestion", "xyz", available, ""},
+		{"empty request has no suggestion", "", available, ""},
+		{"empty available has no suggestion", "api", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, suggestServiceName(tt.requested, tt.available))
+		})
+	}
+}
+
+func TestResolveServiceName(t *testing.T) {
+	available := []string{"api", "web", "worker"}
+
+	t.Run("exact match returns name without error", func(t *testing.T) {
+		got, err := resolveServiceName("web", available)
+		require.NoError(t, err)
+		assert.Equal(t, "web", got)
+	})
+
+	t.Run("case-only mismatch is not found but suggests", func(t *testing.T) {
+		_, err := resolveServiceName("Web", available)
+		require.Error(t, err)
+		msg := err.Error()
+		assert.Contains(t, msg, `service "Web" not found`)
+		assert.Contains(t, msg, "Available services: api, web, worker")
+		assert.Contains(t, msg, `Did you mean "web"?`)
+	})
+
+	t.Run("close typo includes suggestion", func(t *testing.T) {
+		_, err := resolveServiceName("webb", available)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `Did you mean "web"?`)
+	})
+
+	t.Run("far-off name omits suggestion but lists services", func(t *testing.T) {
+		_, err := resolveServiceName("database", available)
+		require.Error(t, err)
+		msg := err.Error()
+		assert.Contains(t, msg, `service "database" not found`)
+		assert.Contains(t, msg, "Available services: api, web, worker")
+		assert.NotContains(t, msg, "Did you mean")
+	})
+
+	t.Run("empty service list reports no services defined", func(t *testing.T) {
+		_, err := resolveServiceName("api", nil)
+		require.Error(t, err)
+		msg := err.Error()
+		assert.Contains(t, msg, `service "api" not found`)
+		assert.Contains(t, msg, "No services are defined")
+		assert.NotContains(t, msg, "Did you mean")
+	})
+
+	t.Run("available names keep original casing", func(t *testing.T) {
+		_, err := resolveServiceName("frontent", []string{"Frontend", "Backend"})
+		require.Error(t, err)
+		msg := err.Error()
+		assert.Contains(t, msg, "Frontend")
+		assert.Contains(t, msg, "Backend")
+		assert.Contains(t, msg, `Did you mean "Frontend"?`)
+	})
+
+	t.Run("error message is a single line", func(t *testing.T) {
+		_, err := resolveServiceName("webb", available)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "\n")
+		assert.False(t, strings.HasSuffix(err.Error(), "\n"))
+	})
+}
+
+func TestFilterServicesByName(t *testing.T) {
+	services := []*serviceinfo.ServiceInfo{
+		{Name: "api"},
+		{Name: "web"},
+		{Name: "worker"},
+	}
+
+	t.Run("filters to requested services", func(t *testing.T) {
+		got, err := filterServicesByName(services, []string{"web", "api"})
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, "web", got[0].Name)
+		assert.Equal(t, "api", got[1].Name)
+	})
+
+	t.Run("unknown name returns suggestion error", func(t *testing.T) {
+		_, err := filterServicesByName(services, []string{"webb"})
+		require.Error(t, err)
+		msg := err.Error()
+		assert.Contains(t, msg, `service "webb" not found`)
+		assert.Contains(t, msg, `Did you mean "web"?`)
+	})
+}


### PR DESCRIPTION
## What

`azd app` now tells you the available services and suggests the closest match when you pass a service name that does not exist.

Before, an unknown name would either produce a bare "service not found" or, for `logs`, a plain list. There was no hint about a likely typo, so you had to open `azure.yaml` to check the real names.

## Changes

- Add a shared `resolveServiceName` helper (`service_suggest.go`) that validates a requested name against the services defined in `azure.yaml`. On a miss it returns an error that lists the available services and, when a close match exists, adds a single `Did you mean "X"?` suggestion.
- Matching for the suggestion is case-insensitive and uses a small Levenshtein edit distance with a length-scaled threshold, so only genuine typos are suggested. Reported names keep their original casing.
- Wire the helper into the commands that select a service: `logs`, `health`, `restart`, `start`, `stop`, and `info`.
- `azd app info` now accepts optional positional service names to filter its output, and validates them through the same helper.

## Example

```
$ azd app health --service webb
Error: service "webb" not found. Available services: api, web, worker. Did you mean "web"?
```

## Testing

- New unit tests cover the edit distance, the suggestion threshold (exact match, case-only mismatch, close typo, far-off name, empty list), the formatted error, and the `info` filter path.
- `go build ./src/...`, `go test ./src/cmd/app/commands/`, and `golangci-lint run ./src/cmd/app/commands/...` all pass.

Closes #388
