### PR TITLE
feat(cli): add app env command to print resolved service environment

### DIFF
--- a/cli/src/cmd/app/commands/env.go
+++ b/cli/src/cmd/app/commands/env.go
@@ -1,0 +1,199 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-core/cliout"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	envFormatDotenv = "dotenv"
+	envFormatShell  = "shell"
+	envFormatJSON   = "json"
+)
+
+var (
+	envFormat string
+	envNoMask bool
+	envFile   string
+)
+
+// NewEnvCommand creates the env command.
+func NewEnvCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env [service]",
+		Short: "Print the resolved environment for a service",
+		Long: `Print the effective environment a service receives when it runs.
+
+The output merges the process environment, the azd environment values, and the
+service-specific variables from azure.yaml, the same way "azd app run" resolves
+them. Pass a service name to print its environment, or run without a name to
+list the available services.
+
+Secret-shaped values are masked by default. Use --no-mask to print raw values,
+for example when piping the output into another command.
+
+Examples:
+  # Resolved environment for the api service (KEY=value lines)
+  azd app env api
+
+  # Shell export statements
+  azd app env api --format shell
+
+  # JSON object (also selected by the global --json flag)
+  azd app env api --format json
+
+  # Raw values, no masking
+  azd app env api --no-mask`,
+		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         runEnv,
+	}
+
+	cmd.Flags().StringVar(&envFormat, "format", envFormatDotenv, "Output format: dotenv, shell, or json")
+	cmd.Flags().BoolVar(&envNoMask, "no-mask", false, "Print raw values instead of masking secret-shaped values")
+	cmd.Flags().StringVar(&envFile, "env-file", "", "Path to a .env file to merge, matching azd app run")
+
+	return cmd
+}
+
+func runEnv(_ *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	azureYaml, err := service.ParseAzureYaml(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to load azure.yaml: %w", err)
+	}
+
+	names := make([]string, 0, len(azureYaml.Services))
+	for name := range azureYaml.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// No service name: list the available services and exit.
+	if len(args) == 0 {
+		return printServiceList(names)
+	}
+
+	serviceName := args[0]
+	if _, ok := azureYaml.Services[serviceName]; !ok {
+		if len(names) == 0 {
+			return fmt.Errorf("service %q not found. No services are defined in azure.yaml", serviceName)
+		}
+		return fmt.Errorf("service %q not found. Available services: %s",
+			serviceName, strings.Join(names, ", "))
+	}
+
+	format, err := resolveEnvFormat(envFormat)
+	if err != nil {
+		return err
+	}
+	// The global --json flag takes precedence over --format.
+	if cliout.IsJSON() {
+		format = envFormatJSON
+	}
+
+	svc := azureYaml.Services[serviceName]
+	resolved, err := service.ResolveEnvironment(context.Background(), svc, getAzureEnvironmentValues(), envFile, nil)
+	if err != nil {
+		return fmt.Errorf("failed to resolve environment for %q: %w", serviceName, err)
+	}
+
+	mask := !envNoMask
+	if format == envFormatJSON {
+		return cliout.PrintJSON(maskEnv(resolved, mask))
+	}
+
+	fmt.Print(formatEnv(resolved, format, mask))
+	return nil
+}
+
+// printServiceList prints the available service names so the user knows the
+// valid targets for "azd app env <service>".
+func printServiceList(names []string) error {
+	if cliout.IsJSON() {
+		return cliout.PrintJSON(map[string][]string{"services": names})
+	}
+	if len(names) == 0 {
+		cliout.Info("No services are defined in azure.yaml")
+		return nil
+	}
+	cliout.Info("Available services (pass one to print its environment):")
+	for _, name := range names {
+		fmt.Printf("  %s\n", name)
+	}
+	return nil
+}
+
+// resolveEnvFormat normalizes and validates the requested output format.
+func resolveEnvFormat(format string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", envFormatDotenv:
+		return envFormatDotenv, nil
+	case envFormatShell:
+		return envFormatShell, nil
+	case envFormatJSON:
+		return envFormatJSON, nil
+	default:
+		return "", fmt.Errorf("invalid --format %q: expected dotenv, shell, or json", format)
+	}
+}
+
+// maskEnv returns a copy of env with secret-shaped values masked when mask is
+// true, leaving values untouched otherwise.
+func maskEnv(env map[string]string, mask bool) map[string]string {
+	out := make(map[string]string, len(env))
+	for k, v := range env {
+		if mask {
+			out[k] = redactSecretValue(k, v)
+		} else {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// formatEnv renders the environment as sorted dotenv or shell lines. Secret
+// masking is applied first when mask is true.
+func formatEnv(env map[string]string, format string, mask bool) string {
+	masked := maskEnv(env, mask)
+
+	keys := make([]string, 0, len(masked))
+	for k := range masked {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		if format == envFormatShell {
+			fmt.Fprintf(&b, "export %s=%s\n", k, shellQuoteDouble(masked[k]))
+		} else {
+			fmt.Fprintf(&b, "%s=%s\n", k, masked[k])
+		}
+	}
+	return b.String()
+}
+
+// shellQuoteDouble wraps a value in double quotes, escaping the characters that
+// are special inside a double-quoted shell string so the result is safe to eval.
+func shellQuoteDouble(v string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		"`", "\\`",
+		`$`, `\$`,
+	)
+	return `"` + replacer.Replace(v) + `"`
+}

--- a/cli/src/cmd/app/commands/env_test.go
+++ b/cli/src/cmd/app/commands/env_test.go
@@ -1,0 +1,252 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jongio/azd-core/cliout"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEnvCommand(t *testing.T) {
+	cmd := NewEnvCommand()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "env [service]", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	require.NotNil(t, cmd.RunE)
+
+	for _, name := range []string{"format", "no-mask", "env-file"} {
+		assert.NotNil(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
+	}
+}
+
+func TestResolveEnvFormat(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", envFormatDotenv, false},
+		{"dotenv", envFormatDotenv, false},
+		{"DOTENV", envFormatDotenv, false},
+		{"shell", envFormatShell, false},
+		{"json", envFormatJSON, false},
+		{" json ", envFormatJSON, false},
+		{"yaml", "", true},
+	}
+	for _, tt := range tests {
+		got, err := resolveEnvFormat(tt.in)
+		if tt.wantErr {
+			require.Error(t, err, "input %q", tt.in)
+			continue
+		}
+		require.NoError(t, err, "input %q", tt.in)
+		assert.Equal(t, tt.want, got)
+	}
+}
+
+func TestMaskEnv(t *testing.T) {
+	env := map[string]string{
+		"PLAIN":         "value",
+		"DB_PASSWORD":   "supersecret",
+		"API_TOKEN":     "abcdef",
+		"SHORT_SECRET":  "ab",
+		"CONNECTIONURL": "postgres://host",
+	}
+
+	t.Run("masking on hides secret-shaped values", func(t *testing.T) {
+		got := maskEnv(env, true)
+		assert.Equal(t, "value", got["PLAIN"])
+		assert.Equal(t, "postgres://host", got["CONNECTIONURL"])
+		assert.NotEqual(t, "supersecret", got["DB_PASSWORD"])
+		assert.Contains(t, got["DB_PASSWORD"], "***")
+		assert.Equal(t, "***", got["SHORT_SECRET"])
+	})
+
+	t.Run("masking off keeps raw values", func(t *testing.T) {
+		got := maskEnv(env, false)
+		assert.Equal(t, "supersecret", got["DB_PASSWORD"])
+		assert.Equal(t, "ab", got["SHORT_SECRET"])
+	})
+}
+
+func TestFormatEnv(t *testing.T) {
+	env := map[string]string{
+		"B_KEY":       "two",
+		"A_KEY":       "one",
+		"DB_PASSWORD": "supersecret",
+	}
+
+	t.Run("dotenv is sorted KEY=value", func(t *testing.T) {
+		out := formatEnv(env, envFormatDotenv, false)
+		lines := splitNonEmpty(out)
+		require.Len(t, lines, 3)
+		assert.Equal(t, "A_KEY=one", lines[0])
+		assert.Equal(t, "B_KEY=two", lines[1])
+		assert.Equal(t, "DB_PASSWORD=supersecret", lines[2])
+	})
+
+	t.Run("shell emits quoted export lines", func(t *testing.T) {
+		out := formatEnv(env, envFormatShell, false)
+		assert.Contains(t, out, `export A_KEY="one"`)
+		assert.Contains(t, out, `export DB_PASSWORD="supersecret"`)
+	})
+
+	t.Run("masking applies before formatting", func(t *testing.T) {
+		out := formatEnv(env, envFormatDotenv, true)
+		assert.NotContains(t, out, "supersecret")
+		assert.Contains(t, out, "DB_PASSWORD=su***et")
+	})
+}
+
+func TestShellQuoteDouble(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"plain", `"plain"`},
+		{`with "quotes"`, `"with \"quotes\""`},
+		{`back\slash`, `"back\\slash"`},
+		{"dollar$var", `"dollar\$var"`},
+		{"tick`cmd`", "\"tick\\`cmd\\`\""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, shellQuoteDouble(tt.in), "input %q", tt.in)
+	}
+}
+
+func TestRunEnvCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeEnvTestAzureYaml(t, tmpDir)
+
+	// The env command honors the global cliout output format (the --json flag).
+	// Other tests in this package set that global to JSON and reset it with an
+	// invalid "text" value, which is a no-op, so the process-wide format can
+	// still be JSON when these subtests run. Capture and restore it here, and
+	// reset it in resetEnvFlags, so these subtests are hermetic regardless of
+	// execution order.
+	originalFormat := cliout.GetFormat()
+	defer func() { _ = cliout.SetFormat(string(originalFormat)) }()
+
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalDir) }()
+	require.NoError(t, os.Chdir(tmpDir))
+
+	t.Run("no argument lists services without error", func(t *testing.T) {
+		resetEnvFlags()
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+		assert.Contains(t, out, "api")
+		assert.Contains(t, out, "web")
+	})
+
+	t.Run("unknown service errors and lists available", func(t *testing.T) {
+		resetEnvFlags()
+		cmd := NewEnvCommand()
+		cmd.SetArgs([]string{"apii"})
+		runErr := cmd.Execute()
+		require.Error(t, runErr)
+		assert.Contains(t, runErr.Error(), `service "apii" not found`)
+		assert.Contains(t, runErr.Error(), "Available services")
+	})
+
+	t.Run("known service prints its resolved environment", func(t *testing.T) {
+		resetEnvFlags()
+		t.Setenv("SERVICE_ENV_MARKER", "marker-value")
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+		assert.Contains(t, out, "SERVICE_ENV_MARKER=marker-value")
+	})
+
+	t.Run("invalid format errors", func(t *testing.T) {
+		resetEnvFlags()
+		cmd := NewEnvCommand()
+		cmd.SetArgs([]string{"api", "--format", "yaml"})
+		runErr := cmd.Execute()
+		require.Error(t, runErr)
+		assert.Contains(t, runErr.Error(), "invalid --format")
+	})
+}
+
+// resetEnvFlags clears the package-level env command flag state between runs so
+// values set by one subtest do not leak into the next. It also resets the global
+// cliout output format so a JSON format leaked from another test does not force
+// the env command into JSON output.
+func resetEnvFlags() {
+	envFormat = envFormatDotenv
+	envNoMask = false
+	envFile = ""
+	_ = cliout.SetFormat("default")
+}
+
+func writeEnvTestAzureYaml(t *testing.T, dir string) {
+	t.Helper()
+	content := `name: envtestapp
+services:
+  api:
+    host: containerapp
+    language: python
+    project: ./api
+  web:
+    host: containerapp
+    language: js
+    project: ./web
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(content), 0o600))
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	// Drain the pipe concurrently so writes larger than the pipe buffer do not
+	// block the function under test.
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if readErr != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+
+	runErr := fn()
+	require.NoError(t, w.Close())
+	out := <-done
+	require.NoError(t, r.Close())
+	return out, runErr
+}
+
+func splitNonEmpty(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/cli/src/cmd/app/main.go
+++ b/cli/src/cmd/app/main.go
@@ -89,6 +89,7 @@ func main() {
 		commands.NewTestCommand(),
 		commands.NewLogsCommand(),
 		commands.NewInfoCommand(),
+		commands.NewEnvCommand(),
 		commands.NewHealthCommand(),
 		commands.NewVersionCommand(&extCtx.OutputFormat),
 		commands.NewNotificationsCommand(),


### PR DESCRIPTION
## What

Adds `azd app env [service]`, a command that prints the effective environment a service receives when it runs.

The output reuses the same resolution path as `azd app run`, so what you see is what a service actually gets: the process environment, azd environment values, anything from `--env-file`, and the service-specific variables from `azure.yaml`.

```
azd app env api                 # resolved env for the api service (KEY=value)
azd app env api --format shell  # export KEY="value" lines
azd app env api --format json   # JSON object, also selected by global --json
azd app env api --no-mask       # print raw values instead of masking
azd app env                     # list available service names
```

## Why

When a service misbehaves, I want to see the exact environment it runs with, or feed that same environment into a one-off command. `info` only shows a filtered subset of Azure-prefixed variables, not the full resolved set in a form I can pipe. This closes that gap.

## Behavior

- `--format` supports `dotenv` (default), `shell`, and `json`. The global `--json` flag maps to json output.
- Secret-shaped values are masked by default with the existing redaction helper. `--no-mask` prints raw values for local piping.
- No service argument lists available service names and exits without error.
- An unknown service name returns a clear error listing available services.

## Tests

Unit tests cover each format, masking on and off, the unknown-service error, the no-argument listing, and shell quoting of special characters. Build and lint are clean.

Closes #389
