### PR TITLE
feat(mcp): add wait-for-readiness to run_services tool

### DIFF
--- a/cli/src/cmd/app/commands/mcp_run_wait_test.go
+++ b/cli/src/cmd/app/commands/mcp_run_wait_test.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -134,4 +136,111 @@ func TestHandleRunServicesNonBlockingSkipsPolling(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.False(t, polled, "wait=false must not poll service readiness")
+}
+
+// TestHandleRunServicesWaitInvalidProjectDir verifies that requesting wait with
+// an invalid projectDir returns an error result and never starts the process
+// or polls readiness.
+func TestHandleRunServicesWaitInvalidProjectDir(t *testing.T) {
+	orig := pollServicesReadiness
+	defer func() { pollServicesReadiness = orig }()
+
+	polled := false
+	pollServicesReadiness = func(_ context.Context, _ string) ([]serviceReadiness, error) {
+		polled = true
+		return nil, nil
+	}
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	res, err := handleRunServices(context.Background(), testToolArgs(map[string]any{
+		"wait":       true,
+		"projectDir": missing,
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.IsError, "invalid project dir should return an error result")
+	assert.False(t, polled, "invalid project dir must short-circuit before polling")
+}
+
+func TestClampRunWaitTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"zero uses default", 0, defaultRunWaitTimeoutSeconds},
+		{"negative uses default", -10, defaultRunWaitTimeoutSeconds},
+		{"in range preserved", 30, 30},
+		{"max preserved", maxRunWaitTimeoutSeconds, maxRunWaitTimeoutSeconds},
+		{"over max is capped", maxRunWaitTimeoutSeconds + 1, maxRunWaitTimeoutSeconds},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, clampRunWaitTimeout(tt.in))
+		})
+	}
+}
+
+func TestToServiceReadiness(t *testing.T) {
+	running := func(health string) *serviceinfo.LocalServiceInfo {
+		return &serviceinfo.LocalServiceInfo{Status: serviceStatusRunning, Health: health}
+	}
+	services := []*serviceinfo.ServiceInfo{
+		nil, // must be skipped
+		{Name: "healthy", Local: running("healthy")},
+		{Name: "unknown-health", Local: running("")},
+		{Name: "unhealthy", Local: running(serviceHealthUnhealthy)},
+		{Name: "stopped", Local: &serviceinfo.LocalServiceInfo{Status: "not-running", Health: "unknown"}},
+		{Name: "no-local"},
+	}
+
+	got := toServiceReadiness(services)
+	require.Len(t, got, 5, "nil service entries must be skipped")
+
+	byName := map[string]serviceReadiness{}
+	for _, r := range got {
+		byName[r.Name] = r
+	}
+
+	assert.True(t, byName["healthy"].Ready)
+	assert.Equal(t, serviceStatusRunning, byName["healthy"].Status)
+	assert.Equal(t, "healthy", byName["healthy"].Health)
+
+	assert.True(t, byName["unknown-health"].Ready, "running service without a health probe counts as ready")
+	assert.False(t, byName["unhealthy"].Ready, "explicitly unhealthy service is not ready")
+	assert.False(t, byName["stopped"].Ready, "non-running service is not ready")
+
+	assert.False(t, byName["no-local"].Ready, "service without local info is not ready")
+	assert.Empty(t, byName["no-local"].Status)
+}
+
+func TestToServiceReadinessEmpty(t *testing.T) {
+	assert.Empty(t, toServiceReadiness(nil))
+}
+
+func TestBuildRunWaitResultReady(t *testing.T) {
+	res := runWaitResult{
+		Ready:    true,
+		Services: []serviceReadiness{{Name: "api", Ready: true}},
+	}
+	out := buildRunWaitResult(res, 4321, 120)
+	assert.Equal(t, "ready", out["status"])
+	assert.Equal(t, true, out["ready"])
+	assert.Equal(t, "All services are ready.", out["message"])
+	assert.Equal(t, 4321, out["pid"])
+	assert.NotNil(t, out["services"])
+}
+
+func TestBuildRunWaitResultTimeout(t *testing.T) {
+	res := runWaitResult{
+		Ready:    false,
+		TimedOut: true,
+		Services: []serviceReadiness{{Name: "web", Ready: false}},
+	}
+	out := buildRunWaitResult(res, 0, 45)
+	assert.Equal(t, "timeout", out["status"])
+	assert.Equal(t, false, out["ready"])
+	assert.Contains(t, out["message"], "45s")
+	_, hasPID := out["pid"]
+	assert.False(t, hasPID, "pid must be omitted when the process was not started")
 }

--- a/cli/src/cmd/app/commands/mcp_run_wait_test.go
+++ b/cli/src/cmd/app/commands/mcp_run_wait_test.go
@@ -1,0 +1,137 @@
+package commands
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllServicesReady(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []serviceReadiness
+		want bool
+	}{
+		{"empty is not ready", nil, false},
+		{
+			"all ready",
+			[]serviceReadiness{{Name: "api", Ready: true}, {Name: "web", Ready: true}},
+			true,
+		},
+		{
+			"one pending",
+			[]serviceReadiness{{Name: "api", Ready: true}, {Name: "web", Ready: false}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, allServicesReady(tt.in))
+		})
+	}
+}
+
+func TestWaitForServicesReadyAllReady(t *testing.T) {
+	orig := pollServicesReadiness
+	defer func() { pollServicesReadiness = orig }()
+
+	pollServicesReadiness = func(_ context.Context, _ string) ([]serviceReadiness, error) {
+		return []serviceReadiness{
+			{Name: "api", Status: "running", Health: "healthy", Ready: true},
+			{Name: "web", Status: "running", Health: "unknown", Ready: true},
+		}, nil
+	}
+
+	res := waitForServicesReady(context.Background(), "", time.Second, time.Millisecond)
+	assert.True(t, res.Ready)
+	assert.False(t, res.TimedOut)
+	require.Len(t, res.Services, 2)
+}
+
+func TestWaitForServicesReadyBecomesReadyAfterPolling(t *testing.T) {
+	orig := pollServicesReadiness
+	defer func() { pollServicesReadiness = orig }()
+
+	calls := 0
+	pollServicesReadiness = func(_ context.Context, _ string) ([]serviceReadiness, error) {
+		calls++
+		if calls < 3 {
+			return []serviceReadiness{
+				{Name: "api", Status: "starting", Ready: false},
+			}, nil
+		}
+		return []serviceReadiness{
+			{Name: "api", Status: "running", Health: "healthy", Ready: true},
+		}, nil
+	}
+
+	res := waitForServicesReady(context.Background(), "", 2*time.Second, time.Millisecond)
+	assert.True(t, res.Ready)
+	assert.False(t, res.TimedOut)
+	assert.GreaterOrEqual(t, calls, 3)
+}
+
+func TestWaitForServicesReadyTimeoutReportsPending(t *testing.T) {
+	orig := pollServicesReadiness
+	defer func() { pollServicesReadiness = orig }()
+
+	pollServicesReadiness = func(_ context.Context, _ string) ([]serviceReadiness, error) {
+		return []serviceReadiness{
+			{Name: "api", Status: "running", Health: "healthy", Ready: true},
+			{Name: "web", Status: "not-running", Ready: false},
+		}, nil
+	}
+
+	res := waitForServicesReady(context.Background(), "", 20*time.Millisecond, 5*time.Millisecond)
+	assert.False(t, res.Ready)
+	assert.True(t, res.TimedOut)
+	require.Len(t, res.Services, 2)
+
+	pending := map[string]bool{}
+	for _, s := range res.Services {
+		pending[s.Name] = s.Ready
+	}
+	assert.True(t, pending["api"], "api should be reported ready")
+	assert.False(t, pending["web"], "web should be reported pending")
+}
+
+func TestWaitForServicesReadyContextCancel(t *testing.T) {
+	orig := pollServicesReadiness
+	defer func() { pollServicesReadiness = orig }()
+
+	pollServicesReadiness = func(_ context.Context, _ string) ([]serviceReadiness, error) {
+		return []serviceReadiness{{Name: "api", Ready: false}}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res := waitForServicesReady(ctx, "", time.Hour, 10*time.Millisecond)
+	assert.False(t, res.Ready)
+	assert.True(t, res.TimedOut)
+}
+
+// TestHandleRunServicesNonBlockingSkipsPolling verifies the default path
+// (wait omitted) never polls readiness, preserving the fire-and-forget
+// behavior.
+func TestHandleRunServicesNonBlockingSkipsPolling(t *testing.T) {
+	orig := pollServicesReadiness
+	defer func() { pollServicesReadiness = orig }()
+
+	polled := false
+	pollServicesReadiness = func(_ context.Context, _ string) ([]serviceReadiness, error) {
+		polled = true
+		return nil, nil
+	}
+
+	// azd app run has no azure.yaml in the test working directory, so the
+	// process (if azd is installed) exits immediately. Either way, the
+	// non-blocking path must not poll readiness.
+	res, err := handleRunServices(context.Background(), testToolArgs(map[string]any{"wait": false}))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.False(t, polled, "wait=false must not poll service readiness")
+}

--- a/cli/src/cmd/app/commands/mcp_tools.go
+++ b/cli/src/cmd/app/commands/mcp_tools.go
@@ -348,7 +348,7 @@ func addRunServicesTool(b *azdext.MCPServerBuilder) {
 		"run_services", handleRunServices,
 		azdext.MCPToolOptions{
 			Title:       "Run Development Services",
-			Description: "Start development services defined in azure.yaml, Aspire, or docker compose. This command will start the application in the background and return information about the started services.",
+			Description: "Start development services defined in azure.yaml, Aspire, or docker compose. By default this starts the application in the background and returns immediately. Set wait=true to block until every service is ready (or timeoutSeconds elapses) and get each service's final state back.",
 		},
 		mcp.WithString(
 			"projectDir",
@@ -357,6 +357,14 @@ func addRunServicesTool(b *azdext.MCPServerBuilder) {
 		mcp.WithString(
 			"runtime",
 			mcp.Description("Optional runtime mode: 'azd' (default), 'aspire', 'pnpm', or 'docker-compose'."),
+		),
+		mcp.WithBoolean(
+			"wait",
+			mcp.Description("If true, block until all services are ready or timeoutSeconds elapses before returning. Default false (returns immediately after starting)."),
+		),
+		mcp.WithNumber(
+			"timeoutSeconds",
+			mcp.Description("Maximum seconds to wait for readiness when wait is true. Default 120."),
 		),
 	)
 }
@@ -372,6 +380,26 @@ func handleRunServices(ctx context.Context, args azdext.ToolArgs) (*mcp.CallTool
 			return mcpErrorResult("%s", valErr.Error()), nil
 		}
 		cmdArgs = append(cmdArgs, "--runtime", runtime)
+	}
+
+	wait := args.OptionalBool("wait", false)
+	timeoutSeconds := args.OptionalInt("timeoutSeconds", defaultRunWaitTimeoutSeconds)
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = defaultRunWaitTimeoutSeconds
+	}
+	if timeoutSeconds > maxRunWaitTimeoutSeconds {
+		timeoutSeconds = maxRunWaitTimeoutSeconds
+	}
+
+	// Resolve the directory used for readiness polling up front so an invalid
+	// path fails before we start the process.
+	pollDir := ""
+	if wait {
+		pd, pdErr := extractValidatedProjectDir(args)
+		if pdErr != nil {
+			return mcpErrorResult("Invalid project directory: %v", pdErr), nil
+		}
+		pollDir = pd
 	}
 
 	// Note: azd app run is interactive and long-running, so we run it in a non-blocking way
@@ -428,6 +456,27 @@ func handleRunServices(ctx context.Context, args azdext.ToolArgs) (*mcp.CallTool
 		_ = cmd.Wait()
 	}()
 
+	if wait {
+		waitRes := waitForServicesReady(ctx, pollDir, time.Duration(timeoutSeconds)*time.Second, runWaitPollInterval)
+		result := map[string]any{
+			"ready":    waitRes.Ready,
+			"services": waitRes.Services,
+		}
+		if pid > 0 {
+			result["pid"] = pid
+		}
+		if waitRes.TimedOut {
+			result["status"] = "timeout"
+			result["message"] = fmt.Sprintf(
+				"Timed out after %ds waiting for services to become ready. See services for the current state of each one.",
+				timeoutSeconds)
+		} else {
+			result["status"] = "ready"
+			result["message"] = "All services are ready."
+		}
+		return marshalToolResult(result)
+	}
+
 	result := map[string]any{
 		"status":  "started",
 		"message": "Services are starting in the background. Use get_services to check their status.",
@@ -437,6 +486,102 @@ func handleRunServices(ctx context.Context, args azdext.ToolArgs) (*mcp.CallTool
 	}
 
 	return marshalToolResult(result)
+}
+
+// Readiness constants and helpers backing the run_services wait behavior.
+const (
+	defaultRunWaitTimeoutSeconds = 120
+	maxRunWaitTimeoutSeconds     = 900
+	runWaitPollInterval          = 1 * time.Second
+
+	serviceStatusRunning   = "running"
+	serviceHealthUnhealthy = "unhealthy"
+)
+
+// serviceReadiness is the per-service state reported by the wait behavior.
+type serviceReadiness struct {
+	Name   string `json:"name"`
+	Status string `json:"status,omitempty"`
+	Health string `json:"health,omitempty"`
+	Ready  bool   `json:"ready"`
+}
+
+// runWaitResult is the structured result returned when run_services waits for
+// readiness. TimedOut distinguishes a timeout from a clean all-ready return so
+// the caller can tell why it stopped waiting.
+type runWaitResult struct {
+	Ready    bool               `json:"ready"`
+	TimedOut bool               `json:"timedOut"`
+	Services []serviceReadiness `json:"services"`
+}
+
+// pollServicesReadiness reads the current readiness of every service. It is a
+// package var so tests can stub the services source without a live dashboard.
+var pollServicesReadiness = collectServiceReadiness
+
+// collectServiceReadiness reuses the same service source as get_services and
+// info, then derives a ready flag per service. A service is ready once it is
+// running and not explicitly unhealthy; a running service without a health
+// probe reports "unknown" and counts as ready.
+func collectServiceReadiness(ctx context.Context, projectDir string) ([]serviceReadiness, error) {
+	services, err := collectServiceInfoForMCP(ctx, projectDir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]serviceReadiness, 0, len(services))
+	for _, svc := range services {
+		if svc == nil {
+			continue
+		}
+		r := serviceReadiness{Name: svc.Name}
+		if svc.Local != nil {
+			r.Status = svc.Local.Status
+			r.Health = svc.Local.Health
+			r.Ready = svc.Local.Status == serviceStatusRunning && svc.Local.Health != serviceHealthUnhealthy
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// allServicesReady reports whether every service is ready. An empty set is not
+// ready: it means no service state is available yet, so waiting should continue.
+func allServicesReady(rs []serviceReadiness) bool {
+	if len(rs) == 0 {
+		return false
+	}
+	for _, r := range rs {
+		if !r.Ready {
+			return false
+		}
+	}
+	return true
+}
+
+// waitForServicesReady polls readiness until every service is ready, the
+// timeout elapses, or the context is cancelled. On timeout or cancellation it
+// returns the last observed state with TimedOut set, never a bare error, so the
+// caller can report which services did and did not come up.
+func waitForServicesReady(ctx context.Context, projectDir string, timeout, interval time.Duration) runWaitResult {
+	deadline := time.Now().Add(timeout)
+	var last []serviceReadiness
+	for {
+		readiness, err := pollServicesReadiness(ctx, projectDir)
+		if err == nil {
+			last = readiness
+			if allServicesReady(readiness) {
+				return runWaitResult{Ready: true, Services: readiness}
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return runWaitResult{Ready: false, TimedOut: true, Services: last}
+		}
+		select {
+		case <-ctx.Done():
+			return runWaitResult{Ready: false, TimedOut: true, Services: last}
+		case <-time.After(interval):
+		}
+	}
 }
 
 // --- stop_services ---

--- a/cli/src/cmd/app/commands/mcp_tools.go
+++ b/cli/src/cmd/app/commands/mcp_tools.go
@@ -11,6 +11,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/jongio/azd-app/cli/src/internal/detector"
 	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
 	"github.com/jongio/azd-core/security"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -383,13 +384,7 @@ func handleRunServices(ctx context.Context, args azdext.ToolArgs) (*mcp.CallTool
 	}
 
 	wait := args.OptionalBool("wait", false)
-	timeoutSeconds := args.OptionalInt("timeoutSeconds", defaultRunWaitTimeoutSeconds)
-	if timeoutSeconds <= 0 {
-		timeoutSeconds = defaultRunWaitTimeoutSeconds
-	}
-	if timeoutSeconds > maxRunWaitTimeoutSeconds {
-		timeoutSeconds = maxRunWaitTimeoutSeconds
-	}
+	timeoutSeconds := clampRunWaitTimeout(args.OptionalInt("timeoutSeconds", defaultRunWaitTimeoutSeconds))
 
 	// Resolve the directory used for readiness polling up front so an invalid
 	// path fails before we start the process.
@@ -458,23 +453,7 @@ func handleRunServices(ctx context.Context, args azdext.ToolArgs) (*mcp.CallTool
 
 	if wait {
 		waitRes := waitForServicesReady(ctx, pollDir, time.Duration(timeoutSeconds)*time.Second, runWaitPollInterval)
-		result := map[string]any{
-			"ready":    waitRes.Ready,
-			"services": waitRes.Services,
-		}
-		if pid > 0 {
-			result["pid"] = pid
-		}
-		if waitRes.TimedOut {
-			result["status"] = "timeout"
-			result["message"] = fmt.Sprintf(
-				"Timed out after %ds waiting for services to become ready. See services for the current state of each one.",
-				timeoutSeconds)
-		} else {
-			result["status"] = "ready"
-			result["message"] = "All services are ready."
-		}
-		return marshalToolResult(result)
+		return marshalToolResult(buildRunWaitResult(waitRes, pid, timeoutSeconds))
 	}
 
 	result := map[string]any{
@@ -519,15 +498,34 @@ type runWaitResult struct {
 // package var so tests can stub the services source without a live dashboard.
 var pollServicesReadiness = collectServiceReadiness
 
+// clampRunWaitTimeout normalizes a caller-supplied readiness timeout (in
+// seconds) to the supported range: non-positive values fall back to the
+// default and anything above the maximum is capped.
+func clampRunWaitTimeout(seconds int) int {
+	if seconds <= 0 {
+		return defaultRunWaitTimeoutSeconds
+	}
+	if seconds > maxRunWaitTimeoutSeconds {
+		return maxRunWaitTimeoutSeconds
+	}
+	return seconds
+}
+
 // collectServiceReadiness reuses the same service source as get_services and
-// info, then derives a ready flag per service. A service is ready once it is
-// running and not explicitly unhealthy; a running service without a health
-// probe reports "unknown" and counts as ready.
+// info, then derives a ready flag per service via toServiceReadiness.
 func collectServiceReadiness(ctx context.Context, projectDir string) ([]serviceReadiness, error) {
 	services, err := collectServiceInfoForMCP(ctx, projectDir)
 	if err != nil {
 		return nil, err
 	}
+	return toServiceReadiness(services), nil
+}
+
+// toServiceReadiness maps service info to per-service readiness. A service is
+// ready once it is running and not explicitly unhealthy; a running service
+// without a health probe reports "unknown" and counts as ready. Nil entries
+// are skipped.
+func toServiceReadiness(services []*serviceinfo.ServiceInfo) []serviceReadiness {
 	out := make([]serviceReadiness, 0, len(services))
 	for _, svc := range services {
 		if svc == nil {
@@ -541,7 +539,7 @@ func collectServiceReadiness(ctx context.Context, projectDir string) ([]serviceR
 		}
 		out = append(out, r)
 	}
-	return out, nil
+	return out
 }
 
 // allServicesReady reports whether every service is ready. An empty set is not
@@ -582,6 +580,29 @@ func waitForServicesReady(ctx context.Context, projectDir string, timeout, inter
 		case <-time.After(interval):
 		}
 	}
+}
+
+// buildRunWaitResult builds the structured result returned by run_services when
+// it waits for readiness. It reports each service's final state and a
+// status/message that distinguishes a clean all-ready return from a timeout.
+func buildRunWaitResult(res runWaitResult, pid, timeoutSeconds int) map[string]any {
+	result := map[string]any{
+		"ready":    res.Ready,
+		"services": res.Services,
+	}
+	if pid > 0 {
+		result["pid"] = pid
+	}
+	if res.TimedOut {
+		result["status"] = "timeout"
+		result["message"] = fmt.Sprintf(
+			"Timed out after %ds waiting for services to become ready. See services for the current state of each one.",
+			timeoutSeconds)
+	} else {
+		result["status"] = "ready"
+		result["message"] = "All services are ready."
+	}
+	return result
 }
 
 // --- stop_services ---


### PR DESCRIPTION
## What

Adds an optional wait behavior to the `run_services` MCP tool so it can block until services are ready before returning.

- `wait` (bool, default `false`): when omitted, behavior is unchanged (starts in the background, returns `status: started`).
- `timeoutSeconds` (int, default `120`): bounds the wait when `wait` is true.

When `wait` is true, after starting `azd app run` the tool polls the same service source `get_services` and `info` use until every service is running (and not unhealthy), or the timeout elapses.

## Why

`run_services` returns as soon as the process starts. AI clients almost always follow it with `get_services` or a logs/health question before anything is actually listening, so they read empty or "not running" state and then guess and retry. Letting the caller opt into waiting removes that race without changing the default.

## Result shape

With `wait: true` the tool returns:

```json
{
  "status": "ready",
  "ready": true,
  "pid": 12345,
  "services": [
    { "name": "api", "status": "running", "health": "healthy", "ready": true },
    { "name": "web", "status": "running", "health": "unknown", "ready": true }
  ]
}
```

On timeout, `status` is `timeout`, `ready` is `false`, and `services` lists which ones did and did not come up (so the caller sees the pending services, not a generic failure).

## Readiness rule

A service is ready once it is running and not explicitly `unhealthy`. A running service with no health probe reports `unknown` and counts as ready, so services without a health check do not stall the wait.

## Tests

Unit tests stub the services source and cover the all-ready path, becoming ready after a few polls, timeout-with-pending (ready and pending services both reported), context cancellation, and that the default non-blocking path never polls. Build and lint are clean.

Closes #390
