### PR TITLE
feat(notifications): add webhook handler to the notification pipeline

### DIFF
--- a/cli/src/internal/config/notifications.go
+++ b/cli/src/internal/config/notifications.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -34,6 +35,15 @@ type NotificationPreferences struct {
 	// RateLimitWindow defines the deduplication window (default: 5 minutes)
 	// Format: "5m", "10s", etc. (parsed via time.ParseDuration)
 	RateLimitWindow string `json:"rateLimitWindow,omitempty"`
+
+	// WebhookEnabled controls whether qualifying events are POSTed to WebhookURL.
+	WebhookEnabled bool `json:"webhookEnabled,omitempty"`
+
+	// WebhookURL is the http(s) endpoint that receives event JSON when WebhookEnabled is true.
+	WebhookURL string `json:"webhookUrl,omitempty"`
+
+	// WebhookHeaders are optional headers added to each webhook request (e.g. an auth token).
+	WebhookHeaders map[string]string `json:"webhookHeaders,omitempty"`
 
 	mu sync.RWMutex `json:"-"`
 }
@@ -240,6 +250,17 @@ func (p *NotificationPreferences) Validate() error {
 		}
 	}
 
+	// Validate webhook URL when webhook delivery is enabled
+	if p.WebhookEnabled {
+		if p.WebhookURL == "" {
+			return errors.New("webhook is enabled but webhookUrl is empty")
+		}
+		u, err := url.Parse(p.WebhookURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return fmt.Errorf("invalid webhook URL %q: must be an absolute http or https URL", p.WebhookURL)
+		}
+	}
+
 	return nil
 }
 
@@ -362,6 +383,35 @@ func (p *NotificationPreferences) GetRateLimitDuration() time.Duration {
 		return 5 * time.Minute // Default: 5 minutes
 	}
 	return duration
+}
+
+// WebhookConfigured reports whether webhook delivery is enabled with a URL set.
+func (p *NotificationPreferences) WebhookConfigured() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.WebhookEnabled && p.WebhookURL != ""
+}
+
+// GetWebhookURL returns the configured webhook URL.
+func (p *NotificationPreferences) GetWebhookURL() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.WebhookURL
+}
+
+// GetWebhookHeaders returns a copy of the configured webhook headers, or nil
+// when none are set. The copy prevents callers from mutating shared state.
+func (p *NotificationPreferences) GetWebhookHeaders() map[string]string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if len(p.WebhookHeaders) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(p.WebhookHeaders))
+	for k, v := range p.WebhookHeaders {
+		out[k] = v
+	}
+	return out
 }
 
 // isValidTimeFormat checks if a time string is in HH:MM format (24-hour).

--- a/cli/src/internal/notifications/integration.go
+++ b/cli/src/internal/notifications/integration.go
@@ -72,6 +72,14 @@ func NewNotificationManager(cfg NotificationManagerConfig) (*NotificationManager
 		pipeline.RegisterHandler(osHandler)
 	}
 
+	// Create webhook handler if a webhook URL is configured. This forwards
+	// events to an external system (chat webhook, local listener) so state
+	// changes are visible for headless runs, shared boxes, and CI.
+	if webhookHandler := NewWebhookHandler(prefs); webhookHandler != nil {
+		pipeline.RegisterHandler(webhookHandler)
+		logging.Debug("Webhook notifications enabled")
+	}
+
 	// Create state monitor
 	monitorConfig := monitor.MonitorConfig{
 		Interval:        cfg.MonitorInterval,

--- a/cli/src/internal/notifications/webhook.go
+++ b/cli/src/internal/notifications/webhook.go
@@ -1,0 +1,139 @@
+// Package notifications provides the event pipeline for routing state changes to notifications
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/jongio/azd-app/cli/src/internal/config"
+	"github.com/jongio/azd-app/cli/src/internal/monitor"
+)
+
+// defaultWebhookTimeout bounds each webhook request so a slow or unresponsive
+// endpoint cannot stall the notification pipeline or other handlers.
+const defaultWebhookTimeout = 5 * time.Second
+
+// webhookStatePayload is the JSON representation of a service state transition.
+type webhookStatePayload struct {
+	Status string `json:"status"`
+	Health string `json:"health"`
+	PID    int    `json:"pid,omitempty"`
+	Port   int    `json:"port,omitempty"`
+}
+
+// WebhookEventPayload is the JSON body POSTed to the configured webhook URL.
+type WebhookEventPayload struct {
+	Type      string               `json:"type"`
+	Service   string               `json:"service"`
+	Severity  string               `json:"severity"`
+	Message   string               `json:"message"`
+	Timestamp time.Time            `json:"timestamp"`
+	OldState  *webhookStatePayload `json:"oldState,omitempty"`
+	NewState  *webhookStatePayload `json:"newState,omitempty"`
+}
+
+// WebhookHandler POSTs qualifying notification events as JSON to a configured
+// URL. It applies the same severity filter and rate limit as the OS
+// notification handler and fails soft: delivery errors are returned for the
+// pipeline to log and never block other handlers beyond the request timeout.
+type WebhookHandler struct {
+	url      string
+	headers  map[string]string
+	config   *config.NotificationPreferences
+	client   *http.Client
+	lastSent map[string]time.Time
+	mu       sync.Mutex
+}
+
+// NewWebhookHandler builds a webhook handler from notification preferences.
+// It returns nil when webhook delivery is not configured, so callers can skip
+// registration without a separate enabled check.
+func NewWebhookHandler(cfg *config.NotificationPreferences) *WebhookHandler {
+	if cfg == nil || !cfg.WebhookConfigured() {
+		return nil
+	}
+	return &WebhookHandler{
+		url:      cfg.GetWebhookURL(),
+		headers:  cfg.GetWebhookHeaders(),
+		config:   cfg,
+		client:   &http.Client{Timeout: defaultWebhookTimeout},
+		lastSent: make(map[string]time.Time),
+	}
+}
+
+// Handle POSTs the event to the webhook URL when it passes the severity filter
+// and rate limit. Delivery failures are returned so the pipeline can log them.
+func (h *WebhookHandler) Handle(ctx context.Context, event Event) error {
+	if !h.config.ShouldNotify(event.ServiceName, event.Severity) {
+		return nil
+	}
+
+	// Rate limiting mirrors the OS notification handler: dedupe by
+	// service and event type within the configured window.
+	h.mu.Lock()
+	key := fmt.Sprintf("%s:%s", event.ServiceName, event.Type)
+	if lastSent, ok := h.lastSent[key]; ok {
+		if time.Since(lastSent) < h.config.GetRateLimitDuration() {
+			h.mu.Unlock()
+			return nil
+		}
+	}
+	h.lastSent[key] = time.Now()
+	h.mu.Unlock()
+
+	body, err := json.Marshal(buildWebhookPayload(event))
+	if err != nil {
+		return fmt.Errorf("failed to encode webhook payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to build webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// buildWebhookPayload maps a pipeline Event to its JSON webhook representation.
+func buildWebhookPayload(event Event) WebhookEventPayload {
+	return WebhookEventPayload{
+		Type:      string(event.Type),
+		Service:   event.ServiceName,
+		Severity:  event.Severity,
+		Message:   event.Message,
+		Timestamp: event.Timestamp,
+		OldState:  toWebhookState(event.OldState),
+		NewState:  toWebhookState(event.NewState),
+	}
+}
+
+// toWebhookState converts a monitor service state to its webhook payload form.
+func toWebhookState(s *monitor.ServiceState) *webhookStatePayload {
+	if s == nil {
+		return nil
+	}
+	return &webhookStatePayload{
+		Status: s.Status,
+		Health: s.Health,
+		PID:    s.PID,
+		Port:   s.Port,
+	}
+}

--- a/cli/src/internal/notifications/webhook_test.go
+++ b/cli/src/internal/notifications/webhook_test.go
@@ -1,0 +1,184 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jongio/azd-app/cli/src/internal/config"
+	"github.com/jongio/azd-app/cli/src/internal/monitor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func webhookTestPrefs(url string) *config.NotificationPreferences {
+	prefs := config.DefaultNotificationPreferences()
+	prefs.WebhookEnabled = true
+	prefs.WebhookURL = url
+	prefs.SeverityFilter = "all"
+	prefs.RateLimitWindow = "5m"
+	return prefs
+}
+
+func webhookTestEvent() Event {
+	return Event{
+		Type:        EventServiceStateChange,
+		ServiceName: "api",
+		Severity:    "warning",
+		Message:     "service became unhealthy",
+		Timestamp:   time.Now(),
+		OldState:    &monitor.ServiceState{Status: "running", Health: "healthy", PID: 42, Port: 8080},
+		NewState:    &monitor.ServiceState{Status: "running", Health: "unhealthy", PID: 42, Port: 8080},
+	}
+}
+
+func TestNewWebhookHandlerDisabled(t *testing.T) {
+	// Not enabled
+	prefs := config.DefaultNotificationPreferences()
+	assert.Nil(t, NewWebhookHandler(prefs), "handler should be nil when webhook is not enabled")
+
+	// Enabled but no URL
+	prefs2 := config.DefaultNotificationPreferences()
+	prefs2.WebhookEnabled = true
+	assert.Nil(t, NewWebhookHandler(prefs2), "handler should be nil when webhook URL is empty")
+
+	// Nil config
+	assert.Nil(t, NewWebhookHandler(nil), "handler should be nil for nil config")
+}
+
+func TestWebhookHandlerPostsPayload(t *testing.T) {
+	var received atomic.Int64
+	var body []byte
+	var contentType, customHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		contentType = r.Header.Get("Content-Type")
+		customHeader = r.Header.Get("X-Token")
+		b, _ := io.ReadAll(r.Body)
+		body = b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	prefs := webhookTestPrefs(server.URL)
+	prefs.WebhookHeaders = map[string]string{"X-Token": "secret123"}
+
+	h := NewWebhookHandler(prefs)
+	require.NotNil(t, h)
+
+	event := webhookTestEvent()
+	require.NoError(t, h.Handle(context.Background(), event))
+
+	require.Equal(t, int64(1), received.Load())
+	assert.Equal(t, "application/json", contentType)
+	assert.Equal(t, "secret123", customHeader)
+
+	var payload WebhookEventPayload
+	require.NoError(t, json.Unmarshal(body, &payload))
+	assert.Equal(t, string(EventServiceStateChange), payload.Type)
+	assert.Equal(t, "api", payload.Service)
+	assert.Equal(t, "warning", payload.Severity)
+	assert.Equal(t, "service became unhealthy", payload.Message)
+	assert.False(t, payload.Timestamp.IsZero())
+	require.NotNil(t, payload.OldState)
+	require.NotNil(t, payload.NewState)
+	assert.Equal(t, "healthy", payload.OldState.Health)
+	assert.Equal(t, "unhealthy", payload.NewState.Health)
+}
+
+func TestWebhookHandlerSeverityFilter(t *testing.T) {
+	var received atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	prefs := webhookTestPrefs(server.URL)
+	prefs.SeverityFilter = "critical" // only critical qualifies
+
+	h := NewWebhookHandler(prefs)
+	require.NotNil(t, h)
+
+	event := webhookTestEvent() // severity "warning"
+	require.NoError(t, h.Handle(context.Background(), event))
+
+	assert.Equal(t, int64(0), received.Load(), "warning event should be filtered out by critical-only filter")
+}
+
+func TestWebhookHandlerRateLimit(t *testing.T) {
+	var received atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	prefs := webhookTestPrefs(server.URL)
+	prefs.RateLimitWindow = "1h" // effectively dedupe within the test
+
+	h := NewWebhookHandler(prefs)
+	require.NotNil(t, h)
+
+	event := webhookTestEvent()
+	require.NoError(t, h.Handle(context.Background(), event))
+	require.NoError(t, h.Handle(context.Background(), event))
+
+	assert.Equal(t, int64(1), received.Load(), "duplicate event within the window should be sent once")
+}
+
+func TestWebhookHandlerFailSoft(t *testing.T) {
+	// Server that returns an error status.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	prefs := webhookTestPrefs(server.URL)
+	h := NewWebhookHandler(prefs)
+	require.NotNil(t, h)
+
+	// Should return an error but not panic.
+	assert.NotPanics(t, func() {
+		err := h.Handle(context.Background(), webhookTestEvent())
+		assert.Error(t, err)
+	})
+}
+
+func TestWebhookHandlerUnreachableDoesNotPanic(t *testing.T) {
+	prefs := webhookTestPrefs("http://127.0.0.1:0") // invalid port, connection fails fast
+	h := NewWebhookHandler(prefs)
+	require.NotNil(t, h)
+
+	assert.NotPanics(t, func() {
+		err := h.Handle(context.Background(), webhookTestEvent())
+		assert.Error(t, err)
+	})
+}
+
+func TestWebhookConfigValidation(t *testing.T) {
+	// Enabled with a valid URL passes.
+	prefs := config.DefaultNotificationPreferences()
+	prefs.WebhookEnabled = true
+	prefs.WebhookURL = "https://example.com/hook"
+	require.NoError(t, prefs.Validate())
+
+	// Enabled with empty URL fails.
+	prefs.WebhookURL = ""
+	require.Error(t, prefs.Validate())
+
+	// Enabled with a non-http scheme fails.
+	prefs.WebhookURL = "ftp://example.com/hook"
+	require.Error(t, prefs.Validate())
+
+	// Disabled with empty URL is fine.
+	prefs.WebhookEnabled = false
+	prefs.WebhookURL = ""
+	require.NoError(t, prefs.Validate())
+}


### PR DESCRIPTION
## What

Adds a webhook handler to the notification pipeline so service events can be forwarded to an external system (a chat webhook or a small local listener), not just OS notifications and the dashboard.

## Why

State changes today go to the desktop and the dashboard. That works when I am at my machine with the dashboard open, but it does nothing for a headless run, a shared dev box, or CI. There was no way to forward these events anywhere else.

## How it works

- Notification preferences gain three fields: `webhookEnabled`, `webhookUrl`, and optional `webhookHeaders`. When `webhookEnabled` is true, the URL must be an absolute http or https endpoint (validated on load).
- When a URL is configured, `NewNotificationManager` registers a `WebhookHandler` alongside the OS and dashboard handlers. When it is not configured, nothing is registered.
- Each qualifying event is POSTed as a JSON body:

```json
{
  "type": "service_state_change",
  "service": "api",
  "severity": "warning",
  "message": "service became unhealthy",
  "timestamp": "2026-07-02T03:00:00Z",
  "oldState": { "status": "running", "health": "healthy", "pid": 42, "port": 8080 },
  "newState": { "status": "running", "health": "unhealthy", "pid": 42, "port": 8080 }
}
```

- The webhook applies the same severity filter and rate limit as the OS notification handler, so it will not get flooded.
- Each request has a 5s timeout and fails soft: a delivery error is returned for the pipeline to log and never blocks other handlers or service execution.

## Scope

Single attempt per event, no retry queue. The payload is a plain JSON event, not provider-specific formatting (Slack blocks, Teams cards). Email and SMS are out of scope.

## Tests

`httptest`-based tests verify the payload shape and custom headers, that a disabled or URL-less config builds no handler, severity filtering, rate-limit dedupe, and that a failing or unreachable endpoint returns an error without panicking. Config validation is covered for enabled/disabled and bad-scheme cases. Build and lint are clean.

Closes #391
