### PR TITLE
ci: fix PR Build concurrency to prevent cross-PR cancellation

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -22,7 +22,7 @@ on:
         type: number
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
## Problem

`.github/workflows/pr-build.yml` scoped its concurrency group by `github.ref`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

For `pull_request_target` events (and `workflow_run`), `github.ref` resolves to `refs/heads/main` (the base/default branch), **not** the PR head branch. So every PR's preview build shared a single concurrency group: `PR Build-refs/heads/main`.

With `cancel-in-progress: true`, whenever GitHub queued a batch of PR events, all but the last-queued run got cancelled — showing red **Check Build Permission** / **Build PR Preview** checks on ~10 PRs at once.

Verified in run history: batches at 22:24 and 23:55 UTC on 2026-07-02 each cancelled ~10 different `idea/*` PRs, leaving only the last-queued run alive.

## Fix

Scope the concurrency group to the PR head branch, with fallbacks:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.event.workflow_run.head_branch || github.ref }}
  cancel-in-progress: true
```

- `pull_request_target` → `github.event.pull_request.head.ref` (PR head branch)
- `workflow_run` → `github.event.workflow_run.head_branch` (same branch, so it shares a group with the `pull_request_target` path for the same PR — which also prevents those two trigger paths from racing on the same release tag)
- `push` (prbuild) / `workflow_dispatch` → `github.ref`

This isolates each PR into its own concurrency group so different PRs no longer cancel each other, while still cancelling superseded in-progress runs *within* the same PR. `cancel-in-progress: true` is unchanged.

Unblocks the batch-cancelled `idea/*` PRs whose preview checks were showing red.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>