### PR TITLE
feat(run): auto-restart crashed services with a restart policy

### DIFF
--- a/cli/src/cmd/app/commands/run_orchestration.go
+++ b/cli/src/cmd/app/commands/run_orchestration.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/jongio/azd-app/cli/src/internal/executor"
 	"github.com/jongio/azd-app/cli/src/internal/notifications"
 	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-app/cli/src/internal/supervisor"
 	"github.com/jongio/azd-core/cliout"
 	"github.com/jongio/azd-core/registry"
 )
@@ -102,6 +104,7 @@ func monitorServicesUntilShutdown(result *service.OrchestrationResult, cwd strin
 		cliout.Warning("Notifications unavailable: %v", err)
 	} else {
 		notifMgr.Start()
+		configureAutoRestartSupervisor(ctx, notifMgr, result.Processes, cwd)
 		defer func() { _ = notifMgr.Stop() }()
 	}
 
@@ -177,6 +180,57 @@ func startServiceMonitors(ctx context.Context, wg *sync.WaitGroup, processes map
 		wg.Add(1)
 		go monitorServiceProcess(ctx, wg, name, process, projectDir)
 	}
+}
+
+func configureAutoRestartSupervisor(
+	ctx context.Context,
+	notifMgr *notifications.NotificationManager,
+	processes map[string]*service.ServiceProcess,
+	projectDir string,
+) {
+	if notifMgr == nil || len(processes) == 0 {
+		return
+	}
+
+	policies := make(map[string]service.RestartPolicy, len(processes))
+	for name, process := range processes {
+		if process == nil {
+			continue
+		}
+		policy := strings.ToLower(strings.TrimSpace(process.Runtime.Restart.Policy))
+		if policy != service.RestartPolicyOnFailure && policy != service.RestartPolicyAlways {
+			continue
+		}
+		policies[name] = process.Runtime.Restart
+	}
+
+	if len(policies) == 0 {
+		return
+	}
+
+	controller, err := NewServiceController(projectDir)
+	if err != nil {
+		cliout.Warning("Auto-restart unavailable: %v", err)
+		return
+	}
+
+	restartSupervisor := supervisor.New(ctx, policies, func(serviceName string) error {
+		restartResult := controller.RestartService(ctx, serviceName)
+		if restartResult == nil {
+			return fmt.Errorf("failed to restart service '%s': no result returned", serviceName)
+		}
+
+		if !restartResult.Success {
+			if restartResult.Error != "" {
+				return fmt.Errorf("failed to restart service '%s': %s", serviceName, restartResult.Error)
+			}
+			return fmt.Errorf("failed to restart service '%s': %s", serviceName, restartResult.Message)
+		}
+
+		return nil
+	})
+
+	notifMgr.AddStateListener(restartSupervisor.OnStateTransition)
 }
 
 // performGracefulShutdown stops all services and dashboard with a timeout.

--- a/cli/src/internal/notifications/integration.go
+++ b/cli/src/internal/notifications/integration.go
@@ -124,6 +124,14 @@ func (nm *NotificationManager) Start() {
 	}
 }
 
+// AddStateListener registers an additional listener on the shared state monitor.
+func (nm *NotificationManager) AddStateListener(listener monitor.StateListener) {
+	if listener == nil {
+		return
+	}
+	nm.stateMonitor.AddListener(listener)
+}
+
 // Stop stops monitoring and notification processing.
 func (nm *NotificationManager) Stop() error {
 	if !nm.started {

--- a/cli/src/internal/notifications/integration_test.go
+++ b/cli/src/internal/notifications/integration_test.go
@@ -102,6 +102,17 @@ func TestNotificationManager(t *testing.T) {
 		assert.Empty(t, history) // Initially empty
 	})
 
+	t.Run("AddStateListener", func(t *testing.T) {
+		cfg := DefaultNotificationManagerConfig(t.TempDir())
+		nm, err := NewNotificationManager(cfg)
+		require.NoError(t, err)
+
+		assert.NotPanics(t, func() {
+			nm.AddStateListener(nil)
+			nm.AddStateListener(func(monitor.StateTransition) {})
+		})
+	})
+
 	t.Run("IsNotificationsEnabled", func(t *testing.T) {
 		cfg := DefaultNotificationManagerConfig(t.TempDir())
 		nm, err := NewNotificationManager(cfg)

--- a/cli/src/internal/service/config.go
+++ b/cli/src/internal/service/config.go
@@ -4,6 +4,8 @@ package service
 import (
 	"fmt"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/jongio/azd-core/urlutil"
 )
@@ -43,6 +45,53 @@ func ValidateServiceConfig(serviceName string, svc *Service) error {
 		if err := urlutil.ValidateDomain(svc.Azure.CustomDomain); err != nil {
 			return fmt.Errorf("invalid azure.customDomain for service '%s': %w", serviceName, err)
 		}
+	}
+
+	if err := validateRestartConfig(serviceName, svc.Restart); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateRestartConfig(serviceName string, restart *RestartConfig) error {
+	if restart == nil {
+		return nil
+	}
+
+	policy := strings.ToLower(strings.TrimSpace(restart.Policy))
+	if policy == "" {
+		policy = RestartPolicyNever
+	}
+
+	switch policy {
+	case RestartPolicyNever, RestartPolicyOnFailure, RestartPolicyAlways:
+	default:
+		return fmt.Errorf(
+			"invalid restart.policy for service '%s': %q (must be one of: %s, %s, %s)",
+			serviceName,
+			restart.Policy,
+			RestartPolicyNever,
+			RestartPolicyOnFailure,
+			RestartPolicyAlways,
+		)
+	}
+
+	if restart.MaxRetries < 0 {
+		return fmt.Errorf("invalid restart.maxRetries for service '%s': must be >= 0", serviceName)
+	}
+
+	if restart.Backoff == "" {
+		return nil
+	}
+
+	duration, err := time.ParseDuration(restart.Backoff)
+	if err != nil {
+		return fmt.Errorf("invalid restart.backoff for service '%s': %w", serviceName, err)
+	}
+
+	if duration <= 0 {
+		return fmt.Errorf("invalid restart.backoff for service '%s': must be greater than 0", serviceName)
 	}
 
 	return nil

--- a/cli/src/internal/service/detector.go
+++ b/cli/src/internal/service/detector.go
@@ -63,6 +63,7 @@ func DetectServiceRuntime(serviceName string, service Service, usedPorts map[int
 		WorkingDir: projectDir,
 		Protocol:   "http",
 		Env:        make(map[string]string),
+		Restart:    service.GetRestartPolicy(),
 		HealthCheck: HealthCheckConfig{
 			Type:     defaultHealthCheckType,
 			Path:     "/",
@@ -179,6 +180,7 @@ func detectContainerRuntime(serviceName string, service Service, usedPorts map[i
 		Protocol:   "tcp",
 		Env:        make(map[string]string),
 		Type:       ServiceTypeContainer,
+		Restart:    service.GetRestartPolicy(),
 		HealthCheck: HealthCheckConfig{
 			Type:     defaultHealthCheckType,
 			Timeout:  60 * time.Second,

--- a/cli/src/internal/service/functions.go
+++ b/cli/src/internal/service/functions.go
@@ -337,6 +337,7 @@ func buildFunctionsRuntime(serviceName string, service Service, projectDir strin
 		WorkingDir:     projectDir,
 		Protocol:       "http",
 		Env:            make(map[string]string),
+		Restart:        service.GetRestartPolicy(),
 	}
 
 	// Assign port

--- a/cli/src/internal/service/restart_config_test.go
+++ b/cli/src/internal/service/restart_config_test.go
@@ -1,0 +1,83 @@
+package service_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectServiceRuntime_RestartPolicyConfiguration(t *testing.T) {
+	tests := []struct {
+		name               string
+		yamlContent        string
+		restartBlockExists bool
+		expectedPolicy     string
+		expectedMaxRetries int
+		expectedBackoff    time.Duration
+	}{
+		{
+			name: "explicit restart policy is parsed and resolved",
+			yamlContent: `name: restart-test
+services:
+  api:
+    host: containerapp
+    image: nginx:latest
+    ports: ["8080"]
+    restart:
+      policy: on-failure
+      maxRetries: 5
+      backoff: 250ms
+`,
+			restartBlockExists: true,
+			expectedPolicy:     service.RestartPolicyOnFailure,
+			expectedMaxRetries: 5,
+			expectedBackoff:    250 * time.Millisecond,
+		},
+		{
+			name: "restart defaults to never when block is omitted",
+			yamlContent: `name: restart-test
+services:
+  api:
+    host: containerapp
+    image: nginx:latest
+    ports: ["8080"]
+`,
+			restartBlockExists: false,
+			expectedPolicy:     service.RestartPolicyNever,
+			expectedMaxRetries: service.DefaultRestartMaxRetries,
+			expectedBackoff:    service.DefaultRestartBackoffBase,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			azureYamlPath := filepath.Join(tmpDir, "azure.yaml")
+			require.NoError(t, os.WriteFile(azureYamlPath, []byte(tt.yamlContent), 0o600))
+
+			parsed, err := service.ParseAzureYaml(tmpDir)
+			require.NoError(t, err)
+
+			svc, exists := parsed.Services["api"]
+			require.True(t, exists)
+
+			if tt.restartBlockExists {
+				require.NotNil(t, svc.Restart)
+			} else {
+				assert.Nil(t, svc.Restart)
+			}
+
+			runtime, err := service.DetectServiceRuntime("api", svc, map[int]bool{}, tmpDir, "azd")
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedPolicy, runtime.Restart.Policy)
+			assert.Equal(t, tt.expectedMaxRetries, runtime.Restart.MaxRetries)
+			assert.Equal(t, tt.expectedBackoff, runtime.Restart.BackoffBase)
+		})
+	}
+}

--- a/cli/src/internal/service/types.go
+++ b/cli/src/internal/service/types.go
@@ -58,6 +58,30 @@ const (
 	ServiceModeTask = "task"
 )
 
+// Restart policy constants define when azd app should automatically restart a crashed service.
+const (
+	// RestartPolicyNever disables automatic restarts (default).
+	RestartPolicyNever = "never"
+
+	// RestartPolicyOnFailure restarts services after unexpected exits.
+	RestartPolicyOnFailure = "on-failure"
+
+	// RestartPolicyAlways restarts services after any unexpected exit.
+	RestartPolicyAlways = "always"
+)
+
+// Auto-restart default settings.
+const (
+	// DefaultRestartMaxRetries is the default number of restart attempts per crash sequence.
+	DefaultRestartMaxRetries = 3
+
+	// DefaultRestartBackoffBase is the default delay before the first retry attempt.
+	DefaultRestartBackoffBase = time.Second
+
+	// MaxRestartBackoffBase is the maximum allowed base backoff duration.
+	MaxRestartBackoffBase = 30 * time.Second
+)
+
 // AzureYaml represents the parsed azure.yaml file.
 type AzureYaml struct {
 	Name      string              `yaml:"name"`
@@ -115,9 +139,29 @@ type Service struct {
 	HealthcheckEnabled *bool               `yaml:"-"`                     // Internal flag: nil = use default, false = explicitly disabled, true = explicitly enabled
 	Type               string              `yaml:"type,omitempty"`        // Service type: "http", "tcp", "process". Default: "http" if ports defined, "process" otherwise.
 	Mode               string              `yaml:"mode,omitempty"`        // Run mode (for type=process): "watch", "build", "daemon", "task". Default: "daemon".
+	Restart            *RestartConfig      `yaml:"restart,omitempty"`     // Optional auto-restart policy for unexpected service exits.
 	Local              *LocalServiceConfig `yaml:"local,omitempty"`       // Local development configuration
 	Azure              *AzureServiceConfig `yaml:"azure,omitempty"`       // Azure deployment configuration
 	URL                string              `yaml:"url,omitempty"`         // DEPRECATED: Use azure.customUrl instead. Custom URL for accessing the service.
+}
+
+// RestartConfig represents the user-configurable restart behavior in azure.yaml.
+type RestartConfig struct {
+	// Policy controls restart behavior: "never" (default), "on-failure", or "always".
+	Policy string `yaml:"policy,omitempty"`
+
+	// MaxRetries is the maximum number of automatic restart attempts before giving up.
+	MaxRetries int `yaml:"maxRetries,omitempty"`
+
+	// Backoff is the base delay before retrying (for example "1s", "500ms").
+	Backoff string `yaml:"backoff,omitempty"`
+}
+
+// RestartPolicy contains the resolved runtime restart settings for a service.
+type RestartPolicy struct {
+	Policy      string
+	MaxRetries  int
+	BackoffBase time.Duration
 }
 
 // LocalServiceConfig represents local development configuration for a service.
@@ -149,6 +193,7 @@ type serviceRaw struct {
 	Healthcheck any                 `yaml:"healthcheck,omitempty"`
 	Type        string              `yaml:"type,omitempty"`
 	Mode        string              `yaml:"mode,omitempty"`
+	Restart     *RestartConfig      `yaml:"restart,omitempty"`
 	Local       *LocalServiceConfig `yaml:"local,omitempty"`
 	Azure       *AzureServiceConfig `yaml:"azure,omitempty"`
 	URL         string              `yaml:"url,omitempty"`
@@ -175,6 +220,7 @@ func (s *Service) UnmarshalYAML(unmarshal func(any) error) error {
 	s.Logs = raw.Logs
 	s.Type = raw.Type
 	s.Mode = raw.Mode
+	s.Restart = raw.Restart
 	s.Local = raw.Local
 	s.Azure = raw.Azure
 	s.URL = raw.URL
@@ -288,6 +334,42 @@ func (s *Service) GetServiceMode() string {
 
 	// Default to daemon for process services
 	return ServiceModeDaemon
+}
+
+// GetRestartPolicy returns the resolved restart policy for runtime orchestration.
+func (s *Service) GetRestartPolicy() RestartPolicy {
+	policy := RestartPolicy{
+		Policy:      RestartPolicyNever,
+		MaxRetries:  DefaultRestartMaxRetries,
+		BackoffBase: DefaultRestartBackoffBase,
+	}
+
+	if s == nil || s.Restart == nil {
+		return policy
+	}
+
+	switch normalized := strings.TrimSpace(strings.ToLower(s.Restart.Policy)); normalized {
+	case "", RestartPolicyNever:
+		policy.Policy = RestartPolicyNever
+	case RestartPolicyOnFailure, RestartPolicyAlways:
+		policy.Policy = normalized
+	}
+
+	if s.Restart.MaxRetries > 0 {
+		policy.MaxRetries = s.Restart.MaxRetries
+	}
+
+	if s.Restart.Backoff != "" {
+		if parsed, err := time.ParseDuration(s.Restart.Backoff); err == nil && parsed > 0 {
+			policy.BackoffBase = parsed
+		}
+	}
+
+	if policy.BackoffBase > MaxRestartBackoffBase {
+		policy.BackoffBase = MaxRestartBackoffBase
+	}
+
+	return policy
 }
 
 // IsProcessService returns true if this is a process-type service (no network endpoint).
@@ -546,6 +628,7 @@ type ServiceRuntime struct {
 	ShouldUpdateAzureYaml bool   // True if user wants port added to azure.yaml
 	Type                  string // Service type: "http", "tcp", "process"
 	Mode                  string // Run mode (for type=process): "watch", "build", "daemon", "task"
+	Restart               RestartPolicy
 }
 
 // PortMapping represents a port mapping (Docker Compose style).

--- a/cli/src/internal/supervisor/supervisor.go
+++ b/cli/src/internal/supervisor/supervisor.go
@@ -1,0 +1,260 @@
+// Package supervisor provides automatic restart supervision for crashed services.
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jongio/azd-app/cli/src/internal/monitor"
+	"github.com/jongio/azd-app/cli/src/internal/service"
+)
+
+const (
+	crashTransitionPrefix      = "Process crashed - PID "
+	recoveryStartedDescription = "Service started successfully"
+	recoveryHealthyDescription = "Service became healthy"
+)
+
+// RestartFunc performs a service restart operation.
+type RestartFunc func(serviceName string) error
+
+// Supervisor manages per-service restart attempts and triggers automatic restarts.
+type Supervisor struct {
+	ctx      context.Context
+	restart  RestartFunc
+	mu       sync.Mutex
+	policies map[string]service.RestartPolicy
+	attempts map[string]int
+}
+
+// New creates a restart supervisor bound to a context and service policy map.
+func New(ctx context.Context, policies map[string]service.RestartPolicy, restart RestartFunc) *Supervisor {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	normalizedPolicies := make(map[string]service.RestartPolicy, len(policies))
+	for serviceName, policy := range policies {
+		normalizedPolicies[serviceName] = normalizePolicy(policy)
+	}
+
+	return &Supervisor{
+		ctx:      ctx,
+		restart:  restart,
+		policies: normalizedPolicies,
+		attempts: make(map[string]int),
+	}
+}
+
+// ShouldRestart decides if a restart should be attempted for a transition.
+func ShouldRestart(policy service.RestartPolicy, exitedUnexpectedly bool, attempt int) bool {
+	if !exitedUnexpectedly || attempt <= 0 {
+		return false
+	}
+
+	normalized := normalizePolicy(policy)
+	if normalized.Policy == service.RestartPolicyNever {
+		return false
+	}
+
+	return attempt <= normalized.MaxRetries
+}
+
+// BackoffDuration returns the exponential backoff delay for an attempt.
+func BackoffDuration(attempt int, base time.Duration) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	if base <= 0 {
+		base = service.DefaultRestartBackoffBase
+	}
+
+	if base > service.MaxRestartBackoffBase {
+		return service.MaxRestartBackoffBase
+	}
+
+	delay := base
+	for i := 1; i < attempt; i++ {
+		if delay >= service.MaxRestartBackoffBase/2 {
+			return service.MaxRestartBackoffBase
+		}
+		delay *= 2
+	}
+
+	if delay > service.MaxRestartBackoffBase {
+		return service.MaxRestartBackoffBase
+	}
+
+	return delay
+}
+
+// OnStateTransition handles state transitions and schedules restarts when needed.
+func (s *Supervisor) OnStateTransition(transition monitor.StateTransition) {
+	if s == nil || s.restart == nil || transition.ServiceName == "" {
+		return
+	}
+
+	select {
+	case <-s.ctx.Done():
+		return
+	default:
+	}
+
+	if isRecoveryTransition(transition) {
+		s.resetAttempts(transition.ServiceName)
+		return
+	}
+
+	if !isCrashTransition(transition) {
+		return
+	}
+
+	policy, exists := s.getPolicy(transition.ServiceName)
+	if !exists {
+		return
+	}
+
+	unexpectedExit := isUnexpectedExit(transition)
+	attempt := s.peekNextAttempt(transition.ServiceName)
+	if !ShouldRestart(policy, unexpectedExit, attempt) {
+		if unexpectedExit && policy.Policy != service.RestartPolicyNever && attempt > policy.MaxRetries {
+			slog.Warn("auto-restart retry limit reached",
+				"service", transition.ServiceName,
+				"maxRetries", policy.MaxRetries)
+		}
+		return
+	}
+
+	s.setAttempt(transition.ServiceName, attempt)
+	backoff := BackoffDuration(attempt, policy.BackoffBase)
+
+	slog.Warn("service crash detected, scheduling auto-restart",
+		"service", transition.ServiceName,
+		"attempt", attempt,
+		"maxRetries", policy.MaxRetries,
+		"backoff", backoff)
+
+	go s.restartAfterBackoff(transition.ServiceName, attempt, backoff)
+}
+
+func (s *Supervisor) restartAfterBackoff(serviceName string, attempt int, backoff time.Duration) {
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+
+	select {
+	case <-s.ctx.Done():
+		return
+	case <-timer.C:
+	}
+
+	if err := s.restart(serviceName); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		slog.Error("auto-restart failed",
+			"service", serviceName,
+			"attempt", attempt,
+			"error", err)
+		return
+	}
+
+	slog.Info("service restarted automatically",
+		"service", serviceName,
+		"attempt", attempt)
+}
+
+func (s *Supervisor) getPolicy(serviceName string) (service.RestartPolicy, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	policy, exists := s.policies[serviceName]
+	return policy, exists
+}
+
+func (s *Supervisor) peekNextAttempt(serviceName string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.attempts[serviceName] + 1
+}
+
+func (s *Supervisor) setAttempt(serviceName string, attempt int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.attempts[serviceName] = attempt
+}
+
+func (s *Supervisor) resetAttempts(serviceName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.attempts, serviceName)
+}
+
+func normalizePolicy(policy service.RestartPolicy) service.RestartPolicy {
+	switch normalized := strings.ToLower(strings.TrimSpace(policy.Policy)); normalized {
+	case service.RestartPolicyOnFailure, service.RestartPolicyAlways:
+		policy.Policy = normalized
+	default:
+		policy.Policy = service.RestartPolicyNever
+	}
+
+	if policy.MaxRetries <= 0 {
+		policy.MaxRetries = service.DefaultRestartMaxRetries
+	}
+
+	if policy.BackoffBase <= 0 {
+		policy.BackoffBase = service.DefaultRestartBackoffBase
+	}
+
+	if policy.BackoffBase > service.MaxRestartBackoffBase {
+		policy.BackoffBase = service.MaxRestartBackoffBase
+	}
+
+	return policy
+}
+
+func isCrashTransition(transition monitor.StateTransition) bool {
+	return transition.Severity == monitor.SeverityCritical &&
+		strings.HasPrefix(transition.Description, crashTransitionPrefix)
+}
+
+func isUnexpectedExit(transition monitor.StateTransition) bool {
+	if transition.ToState == nil {
+		return true
+	}
+
+	switch strings.ToLower(strings.TrimSpace(transition.ToState.Status)) {
+	case "stopping", "stopped", "not-running", "completed", "built":
+		return false
+	default:
+		return true
+	}
+}
+
+func isRecoveryTransition(transition monitor.StateTransition) bool {
+	if transition.Severity != monitor.SeverityInfo {
+		return false
+	}
+
+	if transition.Description == recoveryStartedDescription || transition.Description == recoveryHealthyDescription {
+		return true
+	}
+
+	if transition.ToState == nil {
+		return false
+	}
+
+	status := strings.ToLower(strings.TrimSpace(transition.ToState.Status))
+	if status == "running" || status == "ready" {
+		return true
+	}
+
+	return strings.ToLower(strings.TrimSpace(transition.ToState.Health)) == "healthy"
+}

--- a/cli/src/internal/supervisor/supervisor_test.go
+++ b/cli/src/internal/supervisor/supervisor_test.go
@@ -1,0 +1,249 @@
+package supervisor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jongio/azd-app/cli/src/internal/monitor"
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldRestart(t *testing.T) {
+	tests := []struct {
+		name             string
+		policy           service.RestartPolicy
+		exitedUnexpected bool
+		attempt          int
+		expected         bool
+	}{
+		{
+			name: "never policy never restarts",
+			policy: service.RestartPolicy{
+				Policy:     service.RestartPolicyNever,
+				MaxRetries: 3,
+			},
+			exitedUnexpected: true,
+			attempt:          1,
+			expected:         false,
+		},
+		{
+			name: "on-failure restarts within retry cap",
+			policy: service.RestartPolicy{
+				Policy:     service.RestartPolicyOnFailure,
+				MaxRetries: 2,
+			},
+			exitedUnexpected: true,
+			attempt:          2,
+			expected:         true,
+		},
+		{
+			name: "always policy stops after retry cap",
+			policy: service.RestartPolicy{
+				Policy:     service.RestartPolicyAlways,
+				MaxRetries: 2,
+			},
+			exitedUnexpected: true,
+			attempt:          3,
+			expected:         false,
+		},
+		{
+			name: "unexpected exit required for restart",
+			policy: service.RestartPolicy{
+				Policy:     service.RestartPolicyAlways,
+				MaxRetries: 3,
+			},
+			exitedUnexpected: false,
+			attempt:          1,
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ShouldRestart(tt.policy, tt.exitedUnexpected, tt.attempt)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestBackoffDuration(t *testing.T) {
+	t.Run("increases exponentially", func(t *testing.T) {
+		base := 100 * time.Millisecond
+		assert.Equal(t, 100*time.Millisecond, BackoffDuration(1, base))
+		assert.Equal(t, 200*time.Millisecond, BackoffDuration(2, base))
+		assert.Equal(t, 400*time.Millisecond, BackoffDuration(3, base))
+	})
+
+	t.Run("caps at maximum duration", func(t *testing.T) {
+		base := 10 * time.Second
+		assert.Equal(t, service.MaxRestartBackoffBase, BackoffDuration(3, base))
+		assert.Equal(t, service.MaxRestartBackoffBase, BackoffDuration(10, base))
+	})
+}
+
+func TestSupervisorOnStateTransition_RestartsUntilMaxRetries(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	policies := map[string]service.RestartPolicy{
+		"api": {
+			Policy:      service.RestartPolicyOnFailure,
+			MaxRetries:  2,
+			BackoffBase: time.Millisecond,
+		},
+	}
+
+	var mu sync.Mutex
+	restartCalls := 0
+	supervisor := New(ctx, policies, func(serviceName string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		restartCalls++
+		assert.Equal(t, "api", serviceName)
+		return nil
+	})
+
+	crash := newCrashTransition("api", "running")
+	supervisor.OnStateTransition(crash)
+	supervisor.OnStateTransition(crash)
+	supervisor.OnStateTransition(crash)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return restartCalls == 2
+	}, time.Second, 10*time.Millisecond)
+
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	assert.Equal(t, 2, restartCalls)
+	mu.Unlock()
+}
+
+func TestSupervisorOnStateTransition_PolicyNeverDoesNotRestart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	supervisor := New(ctx, map[string]service.RestartPolicy{
+		"api": {
+			Policy:      service.RestartPolicyNever,
+			MaxRetries:  5,
+			BackoffBase: time.Millisecond,
+		},
+	}, func(string) error {
+		t.Fatal("restart callback should not be called for never policy")
+		return nil
+	})
+
+	supervisor.OnStateTransition(newCrashTransition("api", "running"))
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestSupervisorOnStateTransition_DoesNotRestartExpectedStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	supervisor := New(ctx, map[string]service.RestartPolicy{
+		"api": {
+			Policy:      service.RestartPolicyOnFailure,
+			MaxRetries:  3,
+			BackoffBase: time.Millisecond,
+		},
+	}, func(string) error {
+		t.Fatal("restart callback should not be called for stopped service transitions")
+		return nil
+	})
+
+	supervisor.OnStateTransition(newCrashTransition("api", "stopped"))
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestSupervisorOnStateTransition_DoesNotRestartAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	supervisor := New(ctx, map[string]service.RestartPolicy{
+		"api": {
+			Policy:      service.RestartPolicyOnFailure,
+			MaxRetries:  3,
+			BackoffBase: time.Millisecond,
+		},
+	}, func(string) error {
+		t.Fatal("restart callback should not run after cancellation")
+		return nil
+	})
+
+	supervisor.OnStateTransition(newCrashTransition("api", "running"))
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestSupervisorOnStateTransition_ResetsAttemptsAfterRecovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	policies := map[string]service.RestartPolicy{
+		"worker": {
+			Policy:      service.RestartPolicyOnFailure,
+			MaxRetries:  1,
+			BackoffBase: time.Millisecond,
+		},
+	}
+
+	var mu sync.Mutex
+	restartCalls := 0
+	supervisor := New(ctx, policies, func(serviceName string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		restartCalls++
+		assert.Equal(t, "worker", serviceName)
+		return nil
+	})
+
+	crash := newCrashTransition("worker", "running")
+	supervisor.OnStateTransition(crash)
+	supervisor.OnStateTransition(crash)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return restartCalls == 1
+	}, time.Second, 10*time.Millisecond)
+
+	supervisor.OnStateTransition(monitor.StateTransition{
+		ServiceName: "worker",
+		Severity:    monitor.SeverityInfo,
+		Description: "Service started successfully",
+		ToState: &monitor.ServiceState{
+			Name:   "worker",
+			Status: "running",
+			Health: "healthy",
+		},
+	})
+
+	supervisor.OnStateTransition(crash)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return restartCalls == 2
+	}, time.Second, 10*time.Millisecond)
+}
+
+func newCrashTransition(serviceName, status string) monitor.StateTransition {
+	return monitor.StateTransition{
+		ServiceName: serviceName,
+		Severity:    monitor.SeverityCritical,
+		Description: "Process crashed - PID 4242 no longer exists",
+		ToState: &monitor.ServiceState{
+			Name:   serviceName,
+			Status: status,
+		},
+	}
+}

--- a/web/src/pages/reference/azure-yaml.astro
+++ b/web/src/pages/reference/azure-yaml.astro
@@ -75,6 +75,39 @@ const serviceModes = `services:
     command: npm run migrate
     mode: task`;
 
+const restartPolicyExample = `services:
+  # Node.js API
+  api:
+    language: TypeScript
+    project: ./api
+    command: npm run dev
+    restart:
+      policy: on-failure
+      maxRetries: 5
+      backoff: 1s
+
+  # Go worker
+  worker:
+    language: Go
+    project: ./worker
+    command: go run ./cmd/worker
+    type: process
+    restart:
+      policy: always
+      maxRetries: 3
+      backoff: 500ms
+
+  # Python queue processor
+  queue:
+    language: Python
+    project: ./queue
+    command: python main.py
+    type: process
+    restart:
+      policy: on-failure
+      maxRetries: 4
+      backoff: 2s`;
+
 const advancedService = `services:
   api:
     # Core properties
@@ -585,6 +618,7 @@ const quickReference = `# Property Quick Reference
 ### Dependencies & Health
 - uses - Service/resource dependencies
 - healthcheck - Health monitoring
+- restart - Auto-restart policy for unexpected exits
 
 ### Configuration (azd app)
 - logs - Service logging config
@@ -950,6 +984,7 @@ const resourceTypesExample = `resources:
         <a href="#name" class="text-blue-600 dark:text-blue-400 hover:underline">→ name - Your app's identity</a>
         <a href="#services" class="text-blue-600 dark:text-blue-400 hover:underline">→ services - The heart of your config</a>
         <a href="#service-types" class="text-blue-600 dark:text-blue-400 hover:underline">→ Service Types & Modes</a>
+        <a href="#restart-policy" class="text-blue-600 dark:text-blue-400 hover:underline">→ Auto-Restart Policy</a>
         <a href="#healthchecks" class="text-blue-600 dark:text-blue-400 hover:underline">→ Health Checks</a>
         <a href="#docker" class="text-blue-600 dark:text-blue-400 hover:underline">→ Docker & Containers</a>
         <a href="#resources" class="text-blue-600 dark:text-blue-400 hover:underline">→ Azure Resources</a>
@@ -1094,6 +1129,23 @@ const resourceTypesExample = `resources:
           <Code code={serviceModes} lang="yaml" />
         </div>
 
+        <div id="restart-policy" class="scroll-mt-8">
+          <h3 class="text-2xl font-bold mb-4 mt-8">Auto-Restart Policy</h3>
+          <p class="text-neutral-700 dark:text-neutral-300 mb-4">
+            By default, services are <strong>not</strong> auto-restarted when they crash. Set
+            <code class="px-2 py-1 bg-neutral-100 dark:bg-neutral-800 rounded">restart</code>
+            per service to opt in.
+          </p>
+          <ul class="list-disc list-inside space-y-1 text-neutral-700 dark:text-neutral-300 mb-4 ml-4">
+            <li><code>policy: never</code> - default, no automatic restarts</li>
+            <li><code>policy: on-failure</code> - restart unexpected exits only</li>
+            <li><code>policy: always</code> - restart any unexpected exit</li>
+            <li><code>maxRetries</code> - retry cap before giving up (default: 3)</li>
+            <li><code>backoff</code> - retry delay base using Go duration format (default: 1s)</li>
+          </ul>
+          <Code code={restartPolicyExample} lang="yaml" />
+        </div>
+
         <!-- Advanced Service Config -->
         <h3 class="text-2xl font-bold mb-4 mt-10">Complete Service Configuration</h3>
         <p class="text-neutral-700 dark:text-neutral-300 mb-4">
@@ -1204,6 +1256,13 @@ const resourceTypesExample = `resources:
                 <td class="py-3 px-4">auto</td>
                 <td class="py-3 px-4">azd app</td>
                 <td class="py-3 px-4">Health check config or false to disable</td>
+              </tr>
+              <tr class="border-t border-neutral-200 dark:border-neutral-700">
+                <td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400">restart</code></td>
+                <td class="py-3 px-4">object</td>
+                <td class="py-3 px-4">policy: never</td>
+                <td class="py-3 px-4">azd app</td>
+                <td class="py-3 px-4">Auto-restart policy for crashed services (policy, maxRetries, backoff)</td>
               </tr>
               <tr class="border-t border-neutral-200 dark:border-neutral-700">
                 <td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400">logs</code></td>


### PR DESCRIPTION
## What this does

Adds an opt-in per-service restart policy so services that exit unexpectedly during `azd app run` are restarted automatically, with backoff and a retry cap. Today the CLI records the crash but leaves the service stopped, so you have to run `azd app restart` by hand.

This is separate from file-change restart. It targets a process that exits on its own (crash), not an edit-triggered reload.

## How it works

- New optional `restart` block in `azure.yaml` per service:
  - `policy`: `never` (default), `on-failure`, or `always`
  - `maxRetries`: retry cap before giving up (default 3)
  - `backoff`: base delay using Go duration format, for example `1s` or `500ms` (default 1s)
- The policy is validated at config load and resolved into `ServiceRuntime`.
- A new `supervisor` package listens for crash transitions from the existing state monitor and calls the service controller to restart. It tracks attempts per service, applies exponential backoff with a cap, stops after `maxRetries`, and resets the counter when a service recovers.
- The supervisor is only attached when at least one service opts in, and it does not fire during shutdown. Default `never` means no behavior change for existing projects.

## Tests

- Unit tests for the restart decision function across all three policies and the retry cap.
- Unit tests for backoff (increasing, capped).
- Supervisor tests: crash triggers the expected number of restarts and stops after the cap; `never` never restarts; attempt counter resets on recovery.
- Config parsing tests: a `restart` block resolves correctly; absence defaults to `never`.

## Docs

Added an Auto-Restart Policy section with Node, Go, and Python examples to the azure.yaml reference.

Closes #402
