### PR TITLE
feat(proxy): add a unified local reverse proxy for services

### DIFF
--- a/cli/docs/commands/proxy.md
+++ b/cli/docs/commands/proxy.md
@@ -1,0 +1,65 @@
+# azd app proxy
+
+Route local requests to running services through one local origin.
+
+## Synopsis
+
+```bash
+azd app proxy [flags]
+```
+
+## Description
+
+`azd app proxy` starts one local HTTP listener and path-routes requests to services that are currently running.
+
+Each service is exposed as:
+
+`/<service>/... -> http://localhost:<service-port>/...`
+
+The proxy strips the `/<service>` prefix before forwarding. For example, `/api/users` forwards to `/users` on the `api` service.
+
+Requests to `/` return a list of available routes.
+
+## Flags
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--port` | | int | `8080` | Port for the proxy listener |
+
+## Examples
+
+### Start proxy on the default port
+
+```bash
+azd app proxy
+```
+
+### Start proxy on a custom port
+
+```bash
+azd app proxy --port 9090
+```
+
+### Example route table
+
+```text
+Proxy listening on http://localhost:8080
+/api/    -> http://localhost:5001
+/web/    -> http://localhost:3000
+```
+
+### Call a proxied endpoint
+
+```bash
+curl http://localhost:8080/api/users
+```
+
+## Error Behavior
+
+- If no services are running with valid local ports, the command exits with an error.
+- If a route exists but the target service is unavailable, the proxy returns `502 Bad Gateway`.
+
+## Related Commands
+
+- [azd app run](run.md) - Start services and populate the local service registry
+- [azd app info](info.md) - Show currently running services and ports

--- a/cli/src/cmd/app/commands/proxy.go
+++ b/cli/src/cmd/app/commands/proxy.go
@@ -1,0 +1,283 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/jongio/azd-core/registry"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultProxyPort       = 8080
+	defaultProxyTargetHost = "localhost"
+)
+
+var proxyPort int
+
+// NewProxyCommand creates the proxy command.
+func NewProxyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proxy",
+		Short: "Route local requests to running services",
+		Long: `Start a local reverse proxy for running services.
+
+Each running service with a local port gets a path route:
+  /<service>/... -> http://localhost:<port>/...
+
+The proxy strips the /<service> prefix before forwarding. For example,
+/api/users forwards to /users on the api service.`,
+		Example: `  # Start proxy on the default port
+  azd app proxy
+
+  # Start proxy on a custom port
+  azd app proxy --port 9090
+
+  # Example route table
+  Proxy listening on http://localhost:8080
+  /api/ -> http://localhost:5001
+  /web/ -> http://localhost:3000`,
+		SilenceUsage: true,
+		RunE:         runProxy,
+	}
+
+	cmd.Flags().IntVar(&proxyPort, "port", defaultProxyPort, "Port for the proxy listener")
+
+	return cmd
+}
+
+func runProxy(cmd *cobra.Command, _ []string) error {
+	if proxyPort < 1 || proxyPort > 65535 {
+		return fmt.Errorf("port must be between 1 and 65535: %d", proxyPort)
+	}
+
+	ctrl, err := NewServiceController("")
+	if err != nil {
+		return fmt.Errorf("failed to initialize service controller: %w", err)
+	}
+
+	routes, err := buildProxyRoutes(ctrl.registry.ListAll())
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Proxy listening on http://localhost:%d\n", proxyPort)
+	printRouteTable(routes)
+
+	server := &http.Server{
+		Addr:              fmt.Sprintf(":%d", proxyPort),
+		Handler:           newProxyHandler(routes),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if shutdownErr := server.Shutdown(shutdownCtx); shutdownErr != nil && !errors.Is(shutdownErr, context.Canceled) {
+			return fmt.Errorf("failed to stop proxy server: %w", shutdownErr)
+		}
+		return nil
+	case listenErr := <-errCh:
+		if listenErr != nil && !errors.Is(listenErr, http.ErrServerClosed) {
+			return fmt.Errorf("failed to start proxy server on port %d: %w", proxyPort, listenErr)
+		}
+		return nil
+	}
+}
+
+func buildProxyRoutes(entries []*registry.ServiceRegistryEntry) (map[string]*url.URL, error) {
+	routes := make(map[string]*url.URL)
+
+	for _, entry := range entries {
+		if entry == nil || entry.Name == "" || entry.Port <= 0 || !isRunning(entry.Status) {
+			continue
+		}
+
+		target := &url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort(resolveRouteHost(entry), strconv.Itoa(entry.Port)),
+		}
+		routes[entry.Name] = target
+	}
+
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("no running services with a local port were found. Start services with 'azd app run' and try again")
+	}
+
+	return routes, nil
+}
+
+func resolveRouteHost(entry *registry.ServiceRegistryEntry) string {
+	if entry == nil || entry.URL == "" {
+		return defaultProxyTargetHost
+	}
+
+	parsedURL, err := url.Parse(entry.URL)
+	if err != nil || parsedURL.Hostname() == "" {
+		return defaultProxyTargetHost
+	}
+
+	return parsedURL.Hostname()
+}
+
+func printRouteTable(routes map[string]*url.URL) {
+	for _, name := range sortedRouteNames(routes) {
+		fmt.Printf("/%s/ -> %s\n", name, routes[name].String())
+	}
+}
+
+type proxyHandler struct {
+	routes    map[string]*url.URL
+	proxies   map[string]*httputil.ReverseProxy
+	available string
+}
+
+func newProxyHandler(routes map[string]*url.URL) http.Handler {
+	copiedRoutes := make(map[string]*url.URL, len(routes))
+	proxies := make(map[string]*httputil.ReverseProxy, len(routes))
+
+	for name, target := range routes {
+		targetCopy := *target
+		copiedRoutes[name] = &targetCopy
+		proxies[name] = newServiceReverseProxy(name, &targetCopy)
+	}
+
+	return &proxyHandler{
+		routes:    copiedRoutes,
+		proxies:   proxies,
+		available: strings.Join(routePrefixes(copiedRoutes), ", "),
+	}
+}
+
+func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "" || r.URL.Path == "/" {
+		h.writeRouteListing(w)
+		return
+	}
+
+	serviceName, rewrittenPath, ok := splitProxyPath(r.URL.Path)
+	if !ok {
+		h.writeNotFound(w, r.URL.Path)
+		return
+	}
+
+	proxy, exists := h.proxies[serviceName]
+	if !exists {
+		h.writeNotFound(w, r.URL.Path)
+		return
+	}
+
+	proxyRequest := cloneRequestWithPath(r, rewrittenPath)
+	proxy.ServeHTTP(w, proxyRequest)
+}
+
+func (h *proxyHandler) writeRouteListing(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = fmt.Fprintln(w, "Available proxy routes:")
+	for _, name := range sortedRouteNames(h.routes) {
+		_, _ = fmt.Fprintf(w, "/%s/ -> %s\n", name, h.routes[name].String())
+	}
+}
+
+func (h *proxyHandler) writeNotFound(w http.ResponseWriter, route string) {
+	http.Error(
+		w,
+		fmt.Sprintf("Unknown route %q. Available routes: %s", route, h.available),
+		http.StatusNotFound,
+	)
+}
+
+func newServiceReverseProxy(serviceName string, target *url.URL) *httputil.ReverseProxy {
+	targetQuery := target.RawQuery
+
+	return &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = target.Host
+
+			switch {
+			case targetQuery == "":
+			case req.URL.RawQuery == "":
+				req.URL.RawQuery = targetQuery
+			default:
+				req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+			}
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			http.Error(
+				w,
+				fmt.Sprintf("Gateway error: service %q is unavailable: %v", serviceName, err),
+				http.StatusBadGateway,
+			)
+		},
+	}
+}
+
+func splitProxyPath(path string) (service string, rewrittenPath string, ok bool) {
+	trimmed := strings.TrimPrefix(path, "/")
+	if trimmed == "" {
+		return "", "", false
+	}
+
+	parts := strings.SplitN(trimmed, "/", 2)
+	service = parts[0]
+	if service == "" {
+		return "", "", false
+	}
+
+	rewrittenPath = "/"
+	if len(parts) == 2 && parts[1] != "" {
+		rewrittenPath = "/" + parts[1]
+	}
+
+	return service, rewrittenPath, true
+}
+
+func cloneRequestWithPath(r *http.Request, rewrittenPath string) *http.Request {
+	cloned := r.Clone(r.Context())
+	clonedURL := *r.URL
+	clonedURL.Path = rewrittenPath
+	clonedURL.RawPath = ""
+	cloned.URL = &clonedURL
+	return cloned
+}
+
+func routePrefixes(routes map[string]*url.URL) []string {
+	names := sortedRouteNames(routes)
+	prefixes := make([]string, 0, len(names))
+	for _, name := range names {
+		prefixes = append(prefixes, fmt.Sprintf("/%s/", name))
+	}
+	return prefixes
+}
+
+func sortedRouteNames(routes map[string]*url.URL) []string {
+	names := make([]string, 0, len(routes))
+	for name := range routes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cli/src/cmd/app/commands/proxy_test.go
+++ b/cli/src/cmd/app/commands/proxy_test.go
@@ -1,0 +1,185 @@
+package commands
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/constants"
+	"github.com/jongio/azd-core/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildProxyRoutes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		entries     []*registry.ServiceRegistryEntry
+		expectError bool
+		validate    func(t *testing.T, routes map[string]*url.URL)
+	}{
+		{
+			name: "filters to running services with ports",
+			entries: []*registry.ServiceRegistryEntry{
+				{Name: "api", Status: constants.StatusRunning, Port: 5001},
+				{Name: "web", Status: constants.StatusReady, Port: 3000, URL: "http://127.0.0.1:3000"},
+				{Name: "worker", Status: constants.StatusStopped, Port: 7000},
+				{Name: "queue", Status: constants.StatusRunning, Port: 0},
+			},
+			validate: func(t *testing.T, routes map[string]*url.URL) {
+				require.Len(t, routes, 2)
+				require.Contains(t, routes, "api")
+				require.Contains(t, routes, "web")
+				assert.Equal(t, "http://localhost:5001", routes["api"].String())
+				assert.Equal(t, "http://127.0.0.1:3000", routes["web"].String())
+			},
+		},
+		{
+			name: "returns error when no eligible services are running",
+			entries: []*registry.ServiceRegistryEntry{
+				{Name: "api", Status: constants.StatusStopped, Port: 5001},
+				{Name: "web", Status: constants.StatusRunning, Port: 0},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			routes, err := buildProxyRoutes(tt.entries)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.validate != nil {
+				tt.validate(t, routes)
+			}
+		})
+	}
+}
+
+func TestProxyHandlerStripsServicePrefix(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, r.URL.Path)
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler := newProxyHandler(map[string]*url.URL{
+		"api": mustParseURL(t, upstream.URL),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users", nil)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "/users", recorder.Body.String())
+}
+
+func TestProxyHandlerForwardsRequestsToMatchingService(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "check=true", r.URL.RawQuery)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, "forwarded")
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler := newProxyHandler(map[string]*url.URL{
+		"web": mustParseURL(t, upstream.URL),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/web/status?check=true", nil)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusCreated, recorder.Code)
+	assert.Equal(t, "forwarded", recorder.Body.String())
+}
+
+func TestProxyHandlerReturnsHelpfulNotFoundForUnknownRoute(t *testing.T) {
+	t.Parallel()
+
+	handler := newProxyHandler(map[string]*url.URL{
+		"api": mustParseURL(t, "http://localhost:5001"),
+		"web": mustParseURL(t, "http://localhost:3000"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/unknown/path", nil)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Available routes")
+	assert.Contains(t, recorder.Body.String(), "/api/")
+	assert.Contains(t, recorder.Body.String(), "/web/")
+}
+
+func TestProxyHandlerReturnsBadGatewayWhenUpstreamUnavailable(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	upstreamURL := upstream.URL
+	upstream.Close()
+
+	handler := newProxyHandler(map[string]*url.URL{
+		"api": mustParseURL(t, upstreamURL),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusBadGateway, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), `service "api"`)
+}
+
+func TestNewProxyCommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewProxyCommand()
+	require.NotNil(t, cmd)
+
+	portFlag := cmd.Flags().Lookup("port")
+	require.NotNil(t, portFlag)
+	assert.Equal(t, "int", portFlag.Value.Type())
+	assert.Equal(t, "8080", portFlag.DefValue)
+}
+
+func TestProxyHandlerRootListsAvailableRoutes(t *testing.T) {
+	t.Parallel()
+
+	handler := newProxyHandler(map[string]*url.URL{
+		"api": mustParseURL(t, "http://localhost:5001"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Available proxy routes")
+	assert.Contains(t, recorder.Body.String(), "/api/ -> http://localhost:5001")
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+
+	parsedURL, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	require.NotEmpty(t, strings.TrimSpace(parsedURL.Host))
+	return parsedURL
+}

--- a/cli/src/cmd/app/main.go
+++ b/cli/src/cmd/app/main.go
@@ -98,6 +98,7 @@ func main() {
 		commands.NewStartCommand(),
 		commands.NewStopCommand(),
 		commands.NewRestartCommand(),
+		commands.NewProxyCommand(),
 		commands.NewAddCommand(),
 		commands.NewSupportBundleCommand(),
 		commands.NewGraphCommand(),

--- a/web/src/pages/reference/cli/index.astro
+++ b/web/src/pages/reference/cli/index.astro
@@ -11,6 +11,9 @@ azd app deps
 # Start development environment
 azd app run
 
+# Start local reverse proxy
+azd app proxy
+
 # Monitor service health
 azd app health --stream
 
@@ -113,6 +116,17 @@ azd app mcp serve`;
       <p class="text-neutral-700 dark:text-neutral-300">Restart services.</p>
       <div class="mt-4 text-sm text-neutral-600 dark:text-neutral-400">
         3 flags • 4 examples
+      </div>
+    </a>
+
+    <a href="/azd-app/reference/cli/proxy/" class="block p-6 bg-neutral-100 dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:border-blue-500 dark:hover:border-blue-500 transition-colors">
+      <div class="flex items-start justify-between mb-2">
+        <code class="text-lg font-semibold text-blue-600 dark:text-blue-400">azd app proxy</code>
+        <span class="text-xs px-2 py-1 bg-green-200 dark:bg-green-900 text-green-800 dark:text-green-300 rounded">Full Docs</span>
+      </div>
+      <p class="text-neutral-700 dark:text-neutral-300">Route local requests to running services through one local origin.</p>
+      <div class="mt-4 text-sm text-neutral-600 dark:text-neutral-400">
+        1 flag • 3 examples
       </div>
     </a>
 

--- a/web/src/pages/reference/cli/proxy.astro
+++ b/web/src/pages/reference/cli/proxy.astro
@@ -1,0 +1,92 @@
+---
+import Layout from '../../../components/Layout.astro';
+import { Code } from 'astro-expressive-code/components';
+
+const usageCode = 'azd app proxy [flags]';
+const example0 = 'azd app proxy';
+const example1 = 'azd app proxy --port 9090';
+const example2 = 'curl http://localhost:8080/api/users';
+const routeTableExample = `Proxy listening on http://localhost:8080
+/api/    -> http://localhost:5001
+/web/    -> http://localhost:3000`;
+---
+
+<Layout title="proxy - CLI Reference" description="Route local requests to running services through one local origin.">
+  <div class="max-w-4xl mx-auto px-4 py-12">
+    <nav class="text-sm mb-8">
+      <ol class="flex items-center gap-2 text-neutral-500">
+        <li><a href="/azd-app/" class="hover:text-blue-500">Home</a></li>
+        <li>/</li>
+        <li><a href="/azd-app/reference/cli/" class="hover:text-blue-500">CLI Reference</a></li>
+        <li>/</li>
+        <li class="text-neutral-900 dark:text-white">proxy</li>
+      </ol>
+    </nav>
+
+    <div class="mb-8">
+      <h1 class="text-4xl font-bold mb-4">azd app proxy</h1>
+      <p class="text-xl text-neutral-700 dark:text-neutral-300">
+        Route local requests to running services through one local origin.
+      </p>
+    </div>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">Usage</h2>
+    <Code code={usageCode} lang="bash" frame="terminal" />
+
+    <h2 class="text-2xl font-bold mt-12 mb-4">Flags</h2>
+    <div class="overflow-x-auto my-8">
+      <table class="min-w-full text-sm rounded-lg overflow-hidden border border-neutral-200 dark:border-neutral-700">
+        <thead>
+          <tr class="bg-neutral-200 dark:bg-neutral-700">
+            <th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Flag</th>
+            <th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Short</th>
+            <th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Type</th>
+            <th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Default</th>
+            <th class="text-left py-3 px-4 font-semibold text-neutral-900 dark:text-neutral-100">Description</th>
+          </tr>
+        </thead>
+        <tbody class="bg-neutral-100 dark:bg-neutral-800">
+          <tr class="border-t border-neutral-200 dark:border-neutral-700">
+            <td class="py-3 px-4"><code class="text-blue-600 dark:text-blue-400 bg-transparent">--port</code></td>
+            <td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">-</td>
+            <td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">int</td>
+            <td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">8080</td>
+            <td class="py-3 px-4 text-neutral-700 dark:text-neutral-300">Port for the proxy listener</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2 class="text-2xl font-bold mt-12 mb-4">How routing works</h2>
+    <p class="text-neutral-700 dark:text-neutral-300 mb-4">
+      The proxy maps each running service to a path prefix. Requests to <code>/&lt;service&gt;/...</code>
+      forward to that service and remove the prefix before forwarding.
+    </p>
+    <Code code={routeTableExample} lang="text" frame="terminal" />
+
+    <h2 class="text-2xl font-bold mt-12 mb-6">Examples</h2>
+    <div class="space-y-4">
+      <Code code={example0} lang="bash" frame="terminal" />
+      <Code code={example1} lang="bash" frame="terminal" />
+      <Code code={example2} lang="bash" frame="terminal" />
+    </div>
+
+    <div class="mt-12 p-6 bg-blue-100 dark:bg-blue-900/40 rounded-lg border border-blue-300 dark:border-blue-700">
+      <h3 class="text-lg font-semibold mb-2 text-neutral-900 dark:text-neutral-100">📚 Detailed Documentation</h3>
+      <p class="text-neutral-700 dark:text-neutral-300 mb-4">
+        For complete command details and behavior notes, see the full command specification.
+      </p>
+      <a href="https://github.com/jongio/azd-app/blob/main/cli/docs/commands/proxy.md" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 text-blue-700 dark:text-blue-400 hover:underline">
+        View full proxy specification →
+      </a>
+    </div>
+
+    <div class="mt-12 pt-8 border-t border-neutral-200 dark:border-neutral-700">
+      <div class="flex justify-between">
+        <a href="/azd-app/reference/cli/" class="text-blue-600 dark:text-blue-400 hover:underline">
+          ← Back to CLI Reference
+        </a>
+      </div>
+    </div>
+  </div>
+</Layout>


### PR DESCRIPTION
## What this does

Adds `azd app proxy`, one HTTP listener that path-routes to running services. Today each service runs on its own local port, so calling one service from another (or sharing a single origin, or avoiding CORS) means hardcoding ports that shift between runs. This gives you one stable origin for the whole app during local development.

## How it works

- `azd app proxy` starts a reverse proxy with a `--port` flag (default 8080).
- Routes are built from the running service registry (service name to local port). Only running services with a valid port are included.
- Path-based routing: `/<service>/...` forwards to that service and strips the `/<service>` prefix, so `/api/users` reaches `/users` on the api service.
- A request to `/` lists the available routes. An unknown route returns a 404 that names the available routes.
- When an upstream is down, the proxy returns a 502 with the service name instead of crashing.
- The route table and proxy URL are printed on start. Uses the standard library `net/http/httputil`, so no new dependency.

Example on start:

```
Proxy listening on http://localhost:8080
/api/ -> http://localhost:5001
/web/ -> http://localhost:3000
```

## Tests

- Route building filters to running services with ports and errors when none are eligible.
- Prefix handling rewrites `/api/users` to `/users` on the upstream (verified with an httptest echo server).
- Forwarding passes the upstream response back.
- Unknown route returns a helpful 404; a down upstream returns 502 (no panic).
- `NewProxyCommand()` exposes the `--port` flag.

## Docs

Added a command reference page at `web/src/pages/reference/cli/proxy.astro` (plus a card on the CLI index) and `cli/docs/commands/proxy.md`, both with an example route table.

Closes #401
