### PR TITLE
feat(clean): add `azd app clean` to reclaim disk from build artifacts

### DIFF
--- a/cli/src/cmd/app/commands/clean.go
+++ b/cli/src/cmd/app/commands/clean.go
@@ -1,0 +1,345 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/jongio/azd-core/cliout"
+	"github.com/spf13/cobra"
+)
+
+// cleanCategoryBuild marks build output and cache directories, removed by default.
+const cleanCategoryBuild = "build"
+
+// cleanCategoryDeps marks dependency directories, removed only with --deps.
+const cleanCategoryDeps = "deps"
+
+// cleanArtifactNames is the full allow-list of directory names clean may remove.
+// Any candidate whose base name is not in this set is rejected as a safety guard.
+var cleanArtifactNames = map[string]bool{
+	// Node build output and caches
+	"dist": true, "build": true, ".next": true, ".nuxt": true, "out": true,
+	"coverage": true, ".turbo": true,
+	// Python build output and caches
+	"__pycache__": true, ".pytest_cache": true, ".mypy_cache": true,
+	".ruff_cache": true, "htmlcov": true, ".tox": true,
+	// .NET build output
+	"bin": true, "obj": true,
+	// Dependency directories
+	"node_modules": true, ".venv": true, "venv": true,
+}
+
+// nodeBuildArtifacts are top-level build/cache directory names in a Node project.
+var nodeBuildArtifacts = []string{"dist", "build", ".next", ".nuxt", "out", "coverage", ".turbo"}
+
+// pythonBuildArtifacts are top-level build/cache directory names in a Python project.
+var pythonBuildArtifacts = []string{"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "build", "dist", "htmlcov", ".tox"}
+
+// dotnetBuildArtifacts are top-level build directory names in a .NET project.
+var dotnetBuildArtifacts = []string{"bin", "obj"}
+
+// cleanOptions holds the options for the clean command.
+type cleanOptions struct {
+	deps     bool
+	dryRun   bool
+	services []string
+	writer   io.Writer
+}
+
+// cleanTarget is a single directory clean will remove (or would remove in dry-run).
+type cleanTarget struct {
+	Service   string `json:"service"`
+	Path      string `json:"path"`
+	Category  string `json:"category"`
+	SizeBytes int64  `json:"sizeBytes"`
+}
+
+// cleanResult is the machine-readable summary of a clean run.
+type cleanResult struct {
+	DryRun     bool          `json:"dryRun"`
+	Targets    []cleanTarget `json:"targets"`
+	TotalBytes int64         `json:"totalBytes"`
+}
+
+// NewCleanCommand creates the clean command.
+func NewCleanCommand() *cobra.Command {
+	opts := &cleanOptions{writer: os.Stdout}
+
+	cmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Reclaim disk space from build artifacts and caches",
+		Long: `Remove build output and cache directories for the services defined in azure.yaml.
+
+By default clean removes build artifacts and caches (dist, build, bin, obj,
+__pycache__, .pytest_cache, and similar). Dependency directories such as
+node_modules and .venv are left in place unless you pass --deps.
+
+Only directories inside a detected service directory are ever removed, and only
+when their name matches a known artifact. Paths outside the project are never
+touched.
+
+Examples:
+  # Show what would be removed and how much space it frees
+  azd app clean --dry-run
+
+  # Remove build artifacts across all services
+  azd app clean
+
+  # Also remove dependency directories
+  azd app clean --deps
+
+  # Limit to one service
+  azd app clean --service api`,
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if flag := cmd.InheritedFlags().Lookup("output"); flag != nil && flag.Value.String() != "" {
+				return cliout.SetFormat(flag.Value.String())
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runClean(opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.deps, "deps", false, "Also remove dependency directories (node_modules, .venv)")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "List what would be removed and the reclaimable size without deleting")
+	cmd.Flags().StringSliceVarP(&opts.services, "service", "s", nil, "Limit to specific services (can be specified multiple times)")
+
+	return cmd
+}
+
+func runClean(opts *cleanOptions) error {
+	if opts == nil {
+		opts = &cleanOptions{}
+	}
+	if opts.writer == nil {
+		opts.writer = os.Stdout
+	}
+
+	searchRoot, err := getSearchRoot()
+	if err != nil {
+		return fmt.Errorf("failed to determine project root: %w", err)
+	}
+	workspaceRoot, err := resolveWorkspaceRoot(searchRoot)
+	if err != nil {
+		return err
+	}
+
+	nodeProjects, pythonProjects, dotnetProjects, err := detectProjectsFromAzureYaml(searchRoot)
+	if err != nil {
+		return err
+	}
+	projects := DetectedProjects{Node: nodeProjects, Python: pythonProjects, Dotnet: dotnetProjects}
+	if len(opts.services) > 0 {
+		projects = filterDetectedProjectsByService(projects, opts.services, searchRoot)
+	}
+
+	targets := collectCleanTargets(projects, opts.deps)
+
+	// Compute sizes for reporting.
+	var total int64
+	for i := range targets {
+		targets[i].SizeBytes = dirSize(targets[i].Path)
+		total += targets[i].SizeBytes
+	}
+
+	result := cleanResult{DryRun: opts.dryRun, Targets: targets, TotalBytes: total}
+
+	if opts.dryRun {
+		if cliout.IsJSON() {
+			return cliout.PrintJSON(result)
+		}
+		renderCleanText(opts.writer, result, false)
+		return nil
+	}
+
+	// Remove each target, guarded by a workspace containment check.
+	var freed int64
+	var removed []cleanTarget
+	var failures []string
+	for _, t := range targets {
+		if err := safeToRemove(t.Path, workspaceRoot); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", t.Path, err))
+			continue
+		}
+		if err := os.RemoveAll(t.Path); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", t.Path, err))
+			continue
+		}
+		freed += t.SizeBytes
+		removed = append(removed, t)
+	}
+
+	result.Targets = removed
+	result.TotalBytes = freed
+
+	if cliout.IsJSON() {
+		if len(failures) > 0 {
+			return fmt.Errorf("failed to remove %d path(s): %v", len(failures), failures)
+		}
+		return cliout.PrintJSON(result)
+	}
+
+	renderCleanText(opts.writer, result, true)
+	if len(failures) > 0 {
+		return fmt.Errorf("failed to remove %d path(s): %v", len(failures), failures)
+	}
+	return nil
+}
+
+// resolveWorkspaceRoot returns the absolute, symlink-resolved project root used
+// for containment checks before deleting anything.
+func resolveWorkspaceRoot(searchRoot string) (string, error) {
+	abs, err := filepath.Abs(searchRoot)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve project root: %w", err)
+	}
+	if resolved, symlinkErr := filepath.EvalSymlinks(abs); symlinkErr == nil {
+		abs = resolved
+	}
+	return abs, nil
+}
+
+// collectCleanTargets returns the artifact directories that exist for the detected
+// projects. When includeDeps is false, dependency directories are excluded.
+func collectCleanTargets(projects DetectedProjects, includeDeps bool) []cleanTarget {
+	var targets []cleanTarget
+	seen := make(map[string]bool)
+
+	add := func(service, dir, name, category string) {
+		path := filepath.Join(dir, name)
+		if seen[path] {
+			return
+		}
+		info, err := os.Stat(path)
+		if err != nil || !info.IsDir() {
+			return
+		}
+		seen[path] = true
+		targets = append(targets, cleanTarget{Service: service, Path: path, Category: category})
+	}
+
+	for _, p := range projects.Node {
+		for _, name := range nodeBuildArtifacts {
+			add(p.Dir, p.Dir, name, cleanCategoryBuild)
+		}
+		if includeDeps {
+			add(p.Dir, p.Dir, "node_modules", cleanCategoryDeps)
+		}
+	}
+	for _, p := range projects.Python {
+		for _, name := range pythonBuildArtifacts {
+			add(p.Dir, p.Dir, name, cleanCategoryBuild)
+		}
+		if includeDeps {
+			add(p.Dir, p.Dir, ".venv", cleanCategoryDeps)
+			add(p.Dir, p.Dir, "venv", cleanCategoryDeps)
+		}
+	}
+	for _, p := range projects.Dotnet {
+		dir := filepath.Dir(p.Path)
+		for _, name := range dotnetBuildArtifacts {
+			add(dir, dir, name, cleanCategoryBuild)
+		}
+	}
+
+	sort.Slice(targets, func(i, j int) bool { return targets[i].Path < targets[j].Path })
+	return targets
+}
+
+// safeToRemove verifies a path is a known artifact directory that lives inside the
+// workspace root and is not the workspace root itself. This is the last guard
+// before deletion.
+func safeToRemove(path, workspaceRoot string) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("cannot resolve path: %w", err)
+	}
+	if resolved, symlinkErr := filepath.EvalSymlinks(abs); symlinkErr == nil {
+		abs = resolved
+	}
+
+	if !cleanArtifactNames[filepath.Base(abs)] {
+		return fmt.Errorf("refusing to remove non-artifact directory")
+	}
+	if abs == workspaceRoot {
+		return fmt.Errorf("refusing to remove the project root")
+	}
+	rel, err := filepath.Rel(workspaceRoot, abs)
+	if err != nil || rel == "." || rel == ".." || filepath.IsAbs(rel) || hasParentPrefix(rel) {
+		return fmt.Errorf("refusing to remove path outside the project root")
+	}
+	return nil
+}
+
+// hasParentPrefix reports whether a relative path escapes its base (starts with "..").
+func hasParentPrefix(rel string) bool {
+	return rel == ".." || (len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator))
+}
+
+// dirSize returns the total size in bytes of all regular files under path.
+// Missing paths and unreadable entries contribute zero rather than failing.
+func dirSize(path string) int64 {
+	var total int64
+	_ = filepath.WalkDir(path, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if info, statErr := d.Info(); statErr == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+func renderCleanText(w io.Writer, result cleanResult, removed bool) {
+	if len(result.Targets) == 0 {
+		_, _ = fmt.Fprintln(w, "Nothing to clean. No build artifacts or caches found.")
+		return
+	}
+
+	if result.DryRun {
+		_, _ = fmt.Fprintln(w, "The following would be removed:")
+	} else if removed {
+		_, _ = fmt.Fprintln(w, "Removed:")
+	}
+
+	for _, t := range result.Targets {
+		_, _ = fmt.Fprintf(w, "  %-6s %s (%s)\n", t.Category, t.Path, humanBytes(t.SizeBytes))
+	}
+
+	label := "Reclaimable"
+	if removed {
+		label = "Freed"
+	}
+	_, _ = fmt.Fprintf(w, "\n%s: %s across %d director%s\n", label, humanBytes(result.TotalBytes), len(result.Targets), plural(len(result.Targets)))
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
+// humanBytes formats a byte count as a short human-readable string.
+func humanBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/cli/src/cmd/app/commands/clean_test.go
+++ b/cli/src/cmd/app/commands/clean_test.go
@@ -1,0 +1,234 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	types "github.com/jongio/azd-core/projecttype"
+)
+
+func TestNewCleanCommand(t *testing.T) {
+	cmd := NewCleanCommand()
+	if cmd == nil {
+		t.Fatal("NewCleanCommand returned nil")
+	}
+	if cmd.Use != "clean" {
+		t.Fatalf("Use = %q, want clean", cmd.Use)
+	}
+	for _, name := range []string{"deps", "dry-run", "service"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("flag %q not found", name)
+		}
+	}
+}
+
+func mkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	mkdirAll(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestCollectCleanTargets(t *testing.T) {
+	root := t.TempDir()
+	nodeDir := filepath.Join(root, "web")
+	pyDir := filepath.Join(root, "api")
+	netDir := filepath.Join(root, "svc")
+
+	mkdirAll(t, filepath.Join(nodeDir, "dist"))
+	mkdirAll(t, filepath.Join(nodeDir, "node_modules"))
+	mkdirAll(t, filepath.Join(pyDir, "__pycache__"))
+	mkdirAll(t, filepath.Join(pyDir, ".venv"))
+	mkdirAll(t, filepath.Join(netDir, "bin"))
+	mkdirAll(t, filepath.Join(netDir, "obj"))
+
+	projects := DetectedProjects{
+		Node:   []types.NodeProject{{Dir: nodeDir}},
+		Python: []types.PythonProject{{Dir: pyDir}},
+		Dotnet: []types.DotnetProject{{Path: filepath.Join(netDir, "svc.csproj")}},
+	}
+
+	// Default: build artifacts only, no dependency directories.
+	got := collectCleanTargets(projects, false)
+	paths := targetPaths(got)
+	for _, want := range []string{
+		filepath.Join(nodeDir, "dist"),
+		filepath.Join(pyDir, "__pycache__"),
+		filepath.Join(netDir, "bin"),
+		filepath.Join(netDir, "obj"),
+	} {
+		if !paths[want] {
+			t.Errorf("expected build target %s to be collected", want)
+		}
+	}
+	if paths[filepath.Join(nodeDir, "node_modules")] {
+		t.Error("node_modules should not be collected without --deps")
+	}
+	if paths[filepath.Join(pyDir, ".venv")] {
+		t.Error(".venv should not be collected without --deps")
+	}
+
+	// With deps: dependency directories are included and tagged accordingly.
+	got = collectCleanTargets(projects, true)
+	paths = targetPaths(got)
+	if !paths[filepath.Join(nodeDir, "node_modules")] {
+		t.Error("node_modules should be collected with --deps")
+	}
+	if !paths[filepath.Join(pyDir, ".venv")] {
+		t.Error(".venv should be collected with --deps")
+	}
+	for _, tgt := range got {
+		if filepath.Base(tgt.Path) == "node_modules" && tgt.Category != cleanCategoryDeps {
+			t.Errorf("node_modules category = %q, want %q", tgt.Category, cleanCategoryDeps)
+		}
+		if filepath.Base(tgt.Path) == "dist" && tgt.Category != cleanCategoryBuild {
+			t.Errorf("dist category = %q, want %q", tgt.Category, cleanCategoryBuild)
+		}
+	}
+}
+
+func targetPaths(targets []cleanTarget) map[string]bool {
+	m := make(map[string]bool, len(targets))
+	for _, t := range targets {
+		m[t.Path] = true
+	}
+	return m
+}
+
+func TestDirSize(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.txt"), "12345")       // 5 bytes
+	writeFile(t, filepath.Join(dir, "sub", "b.txt"), "1234") // 4 bytes
+
+	if got := dirSize(dir); got != 9 {
+		t.Fatalf("dirSize = %d, want 9", got)
+	}
+	if got := dirSize(filepath.Join(dir, "does-not-exist")); got != 0 {
+		t.Fatalf("dirSize(missing) = %d, want 0", got)
+	}
+}
+
+func TestSafeToRemove(t *testing.T) {
+	root := t.TempDir()
+	resolved, err := resolveWorkspaceRoot(root)
+	if err != nil {
+		t.Fatalf("resolveWorkspaceRoot: %v", err)
+	}
+
+	valid := filepath.Join(root, "dist")
+	mkdirAll(t, valid)
+	if err := safeToRemove(valid, resolved); err != nil {
+		t.Errorf("safeToRemove(valid) = %v, want nil", err)
+	}
+
+	// Non-artifact directory names are rejected.
+	nonArtifact := filepath.Join(root, "src")
+	mkdirAll(t, nonArtifact)
+	if err := safeToRemove(nonArtifact, resolved); err == nil {
+		t.Error("safeToRemove(src) should reject non-artifact directory")
+	}
+
+	// Artifact-named directory outside the workspace root is rejected.
+	outside := t.TempDir()
+	outsideArtifact := filepath.Join(outside, "dist")
+	mkdirAll(t, outsideArtifact)
+	if err := safeToRemove(outsideArtifact, resolved); err == nil {
+		t.Error("safeToRemove(outside) should reject path outside workspace")
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1048576, "1.0 MiB"},
+	}
+	for _, tt := range tests {
+		if got := humanBytes(tt.in); got != tt.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// setupCleanProject writes an azure.yaml with a single Node service and returns the
+// service directory. The caller chdirs into the project root.
+func setupCleanProject(t *testing.T) (root, serviceDir string) {
+	t.Helper()
+	root = t.TempDir()
+	azureYaml := "name: clean-test\nservices:\n  web:\n    host: local\n    language: js\n    project: ./web\n"
+	writeFile(t, filepath.Join(root, "azure.yaml"), azureYaml)
+	serviceDir = filepath.Join(root, "web")
+	writeFile(t, filepath.Join(serviceDir, "package.json"), "{\"name\":\"web\"}")
+	writeFile(t, filepath.Join(serviceDir, "dist", "bundle.js"), "console.log(1)")
+	writeFile(t, filepath.Join(serviceDir, "node_modules", "dep", "index.js"), "module.exports = 1")
+	return root, serviceDir
+}
+
+func TestRunCleanDryRun(t *testing.T) {
+	root, serviceDir := setupCleanProject(t)
+	t.Chdir(root)
+
+	var buf bytes.Buffer
+	if err := runClean(&cleanOptions{dryRun: true, writer: &buf}); err != nil {
+		t.Fatalf("runClean dry-run failed: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Reclaimable") {
+		t.Fatalf("dry-run output should report reclaimable size:\n%s", out)
+	}
+	if !strings.Contains(out, filepath.Join(serviceDir, "dist")) {
+		t.Fatalf("dry-run should list dist:\n%s", out)
+	}
+	// Dry-run must not delete anything.
+	if _, err := os.Stat(filepath.Join(serviceDir, "dist")); err != nil {
+		t.Fatalf("dry-run deleted dist: %v", err)
+	}
+}
+
+func TestRunCleanRemovesBuildKeepsDeps(t *testing.T) {
+	root, serviceDir := setupCleanProject(t)
+	t.Chdir(root)
+
+	var buf bytes.Buffer
+	if err := runClean(&cleanOptions{writer: &buf}); err != nil {
+		t.Fatalf("runClean failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Freed") {
+		t.Fatalf("output should report freed space:\n%s", buf.String())
+	}
+	if _, err := os.Stat(filepath.Join(serviceDir, "dist")); !os.IsNotExist(err) {
+		t.Errorf("dist should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(serviceDir, "node_modules")); err != nil {
+		t.Errorf("node_modules should be kept without --deps, stat err = %v", err)
+	}
+}
+
+func TestRunCleanWithDepsRemovesNodeModules(t *testing.T) {
+	root, serviceDir := setupCleanProject(t)
+	t.Chdir(root)
+
+	var buf bytes.Buffer
+	if err := runClean(&cleanOptions{deps: true, writer: &buf}); err != nil {
+		t.Fatalf("runClean --deps failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(serviceDir, "node_modules")); !os.IsNotExist(err) {
+		t.Errorf("node_modules should be removed with --deps, stat err = %v", err)
+	}
+}

--- a/cli/src/cmd/app/commands/clean_test.go
+++ b/cli/src/cmd/app/commands/clean_test.go
@@ -177,6 +177,17 @@ func setupCleanProject(t *testing.T) (root, serviceDir string) {
 	writeFile(t, filepath.Join(serviceDir, "package.json"), "{\"name\":\"web\"}")
 	writeFile(t, filepath.Join(serviceDir, "dist", "bundle.js"), "console.log(1)")
 	writeFile(t, filepath.Join(serviceDir, "node_modules", "dep", "index.js"), "module.exports = 1")
+
+	// clean canonicalizes service paths via filepath.EvalSymlinks (required for
+	// the path-containment guard and consistent with ParseAzureYaml), so its
+	// output uses the resolved path. On some platforms t.TempDir() is not already
+	// canonical: on Windows CI, TEMP uses an 8.3 short name (e.g. RUNNER~1) that
+	// EvalSymlinks expands to its long form (runneradmin); on macOS /var resolves
+	// to /private/var. Resolve serviceDir the same way so comparisons against
+	// clean's output match on every OS.
+	if resolved, err := filepath.EvalSymlinks(serviceDir); err == nil {
+		serviceDir = resolved
+	}
 	return root, serviceDir
 }
 

--- a/cli/src/cmd/app/main.go
+++ b/cli/src/cmd/app/main.go
@@ -86,6 +86,7 @@ func main() {
 		commands.NewReqsCommand(),
 		commands.NewRunCommand(),
 		commands.NewDepsCommand(),
+		commands.NewCleanCommand(),
 		commands.NewTestCommand(),
 		commands.NewLogsCommand(),
 		commands.NewInfoCommand(),


### PR DESCRIPTION
## Summary

Adds `azd app clean`, a command that reclaims disk space by removing build output and cache directories for the services defined in `azure.yaml`.

Closes #413

## What it does

- Removes build artifacts and caches by default: `dist`, `build`, `.next`, `.nuxt`, `out`, `coverage`, `.turbo` (Node); `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `htmlcov`, `.tox` (Python); `bin`, `obj` (.NET).
- Leaves dependency directories (`node_modules`, `.venv`, `venv`) in place unless you pass `--deps`.
- `--dry-run` lists what would be removed and the reclaimable size without deleting anything.
- `--service` limits the sweep to specific services.
- Honors the inherited `--output json` flag for machine-readable results.

## Safety

Deletion is guarded two ways: a candidate directory must have a base name in a fixed artifact allow-list, and it must resolve to a path inside the detected project root (symlinks resolved, project root itself refused). Anything outside a detected service directory is never touched.

## Testing

- `go test ./cmd/app/commands/ -run Clean` and related unit tests pass.
- `golangci-lint run ./cmd/app/commands/`: 0 issues.
- New tests cover target collection, dependency gating, size accounting, the safety guard (non-artifact, outside-root rejection), byte formatting, and end-to-end dry-run and real removal.
