### PR TITLE
feat(logs): add log-pattern alert rules that raise notifications

### DIFF
--- a/cli/src/cmd/app/commands/logs.go
+++ b/cli/src/cmd/app/commands/logs.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jongio/azd-app/cli/src/internal/azure"
 	"github.com/jongio/azd-app/cli/src/internal/dashboard"
+	"github.com/jongio/azd-app/cli/src/internal/logalert"
 	"github.com/jongio/azd-app/cli/src/internal/service"
 	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
 	"github.com/jongio/azd-core/cliout"
@@ -154,6 +155,7 @@ type logsOptions struct {
 	contextLines int    // Number of context lines before/after matching entries (0-10)
 	source       string // Log source: "local", "azure", or "all"
 	redact       bool
+	alerts       bool // Enable log-pattern alert rules
 }
 
 // logsExecutor encapsulates the logs command execution with injectable dependencies.
@@ -165,6 +167,7 @@ type logsExecutor struct {
 	getWorkingDir          func() (string, error)
 	outputWriter           io.Writer
 	signalChan             chan os.Signal
+	alertEngine            *logalert.Engine
 
 	// Configuration options (stored directly to avoid duplication)
 	opts *logsOptions
@@ -294,6 +297,7 @@ Examples:
 	cmd.Flags().IntVar(&opts.contextLines, "context", 0, "Number of context lines before/after matching entries (0-10, requires --level)")
 	cmd.Flags().StringVar(&opts.source, "source", "local", "Log source: 'local' (default), 'azure', or 'all'")
 	cmd.Flags().BoolVar(&opts.redact, "redact", false, "Redact secret-shaped values before printing logs")
+	cmd.Flags().BoolVar(&opts.alerts, "alerts", false, "Raise alerts for log lines matching built-in patterns (panic, unhandled exception, fatal)")
 
 	registerServiceFlagCompletion(cmd, "service")
 
@@ -310,6 +314,14 @@ func runLogsWithOptions(opts *logsOptions, args []string) error {
 
 	// Create executor with production dependencies
 	executor := newLogsExecutor(opts)
+
+	// Enable log-pattern alerts when requested. Built-in rules are static and
+	// compile cleanly, but surface any load error rather than swallowing it.
+	engine, err := buildAlertEngine(opts.alerts)
+	if err != nil {
+		return err
+	}
+	executor.alertEngine = engine
 
 	return executor.execute(context.Background(), args)
 }

--- a/cli/src/cmd/app/commands/logs_alerts.go
+++ b/cli/src/cmd/app/commands/logs_alerts.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jongio/azd-app/cli/src/internal/logalert"
+	"github.com/jongio/azd-app/cli/src/internal/notifications"
+)
+
+// buildAlertEngine returns a log alert engine when alerts are enabled, or nil
+// when they are not. Invalid built-in rules would surface here at load time.
+func buildAlertEngine(enabled bool) (*logalert.Engine, error) {
+	if !enabled {
+		return nil, nil
+	}
+	engine, err := logalert.NewEngine(nil, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load log alert rules: %w", err)
+	}
+	return engine, nil
+}
+
+// alertToEvent converts a log alert into a notification pipeline event so it can
+// be surfaced through the existing notifications path and the dashboard.
+func alertToEvent(a logalert.Alert) notifications.Event {
+	return notifications.Event{
+		Type:        notifications.EventError,
+		ServiceName: a.Service,
+		Message:     fmt.Sprintf("[%s] %s", a.Rule, strings.TrimSpace(a.Line)),
+		Severity:    string(a.Severity),
+		Timestamp:   a.Time,
+		Metadata: map[string]any{
+			"rule": a.Rule,
+			"line": a.Line,
+		},
+	}
+}
+
+// renderAlertBanner writes a single, easy-to-spot alert line for the CLI stream.
+func renderAlertBanner(w io.Writer, a logalert.Alert) {
+	_, _ = fmt.Fprintf(w, "!! alert [%s/%s] %s: %s\n",
+		a.Severity, a.Rule, a.Service, strings.TrimSpace(a.Line))
+}
+
+// emitAlerts evaluates a log line against the engine and renders any alerts that
+// fire. It is a no-op when the engine is nil, keeping the streaming path
+// unchanged unless alerts are enabled.
+func (e *logsExecutor) emitAlerts(service, message string, w io.Writer) {
+	if e.alertEngine == nil {
+		return
+	}
+	for _, alert := range e.alertEngine.Match(service, message, time.Now()) {
+		renderAlertBanner(w, alert)
+	}
+}

--- a/cli/src/cmd/app/commands/logs_alerts_test.go
+++ b/cli/src/cmd/app/commands/logs_alerts_test.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jongio/azd-app/cli/src/internal/logalert"
+	"github.com/jongio/azd-app/cli/src/internal/notifications"
+)
+
+func TestBuildAlertEngine(t *testing.T) {
+	engine, err := buildAlertEngine(false)
+	if err != nil {
+		t.Fatalf("buildAlertEngine(false): %v", err)
+	}
+	if engine != nil {
+		t.Error("expected nil engine when alerts are disabled")
+	}
+
+	engine, err = buildAlertEngine(true)
+	if err != nil {
+		t.Fatalf("buildAlertEngine(true): %v", err)
+	}
+	if engine == nil || engine.RuleCount() == 0 {
+		t.Error("expected a populated engine when alerts are enabled")
+	}
+}
+
+func TestAlertToEvent(t *testing.T) {
+	now := time.Now()
+	a := logalert.Alert{Rule: "panic", Service: "web", Line: "  goroutine panic  ", Severity: logalert.SeverityCritical, Time: now}
+	ev := alertToEvent(a)
+
+	if ev.Type != notifications.EventError {
+		t.Errorf("Type = %v, want EventError", ev.Type)
+	}
+	if ev.ServiceName != "web" {
+		t.Errorf("ServiceName = %q", ev.ServiceName)
+	}
+	if ev.Severity != "critical" {
+		t.Errorf("Severity = %q", ev.Severity)
+	}
+	if !strings.Contains(ev.Message, "panic") || !strings.Contains(ev.Message, "goroutine panic") {
+		t.Errorf("Message = %q", ev.Message)
+	}
+	if ev.Metadata["rule"] != "panic" {
+		t.Errorf("Metadata[rule] = %v", ev.Metadata["rule"])
+	}
+	if !ev.Timestamp.Equal(now) {
+		t.Errorf("Timestamp = %v, want %v", ev.Timestamp, now)
+	}
+}
+
+func TestRenderAlertBanner(t *testing.T) {
+	var buf bytes.Buffer
+	renderAlertBanner(&buf, logalert.Alert{Rule: "fatal", Service: "api", Line: "fatal error: oom", Severity: logalert.SeverityCritical})
+	out := buf.String()
+	for _, want := range []string{"alert", "fatal", "api", "fatal error: oom"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("banner missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestEmitAlertsNilEngineIsNoOp(t *testing.T) {
+	e := &logsExecutor{opts: &logsOptions{}}
+	var buf bytes.Buffer
+	e.emitAlerts("web", "panic: boom", &buf)
+	if buf.Len() != 0 {
+		t.Errorf("nil engine should not write anything, got %q", buf.String())
+	}
+}
+
+func TestEmitAlertsWritesBannerOnMatch(t *testing.T) {
+	engine, err := logalert.NewEngine(nil, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	e := &logsExecutor{opts: &logsOptions{}, alertEngine: engine}
+
+	var buf bytes.Buffer
+	e.emitAlerts("worker", "panic: nil pointer dereference", &buf)
+	if !strings.Contains(buf.String(), "panic") {
+		t.Errorf("expected a panic alert banner, got %q", buf.String())
+	}
+
+	// A benign line produces no banner.
+	buf.Reset()
+	e.emitAlerts("worker", "request handled in 3ms", &buf)
+	if buf.Len() != 0 {
+		t.Errorf("benign line should not produce an alert, got %q", buf.String())
+	}
+}

--- a/cli/src/cmd/app/commands/logs_streaming.go
+++ b/cli/src/cmd/app/commands/logs_streaming.go
@@ -208,6 +208,7 @@ func (e *logsExecutor) followLogsInMemory(subscriptions map[string]chan service.
 				displayLogsJSON([]service.LogEntry{entry}, outputWriter)
 			} else {
 				displayLogsText([]service.LogEntry{entry}, outputWriter, e.opts.timestamps, e.opts.noColor)
+				e.emitAlerts(entry.Service, entry.Message, outputWriter)
 			}
 
 		case <-sigChan:

--- a/cli/src/internal/logalert/logalert.go
+++ b/cli/src/internal/logalert/logalert.go
@@ -1,0 +1,170 @@
+// Package logalert evaluates streaming service log lines against regex alert
+// rules. A matching line produces an Alert that callers can surface through the
+// notification pipeline or print directly. Rules can be scoped to a single
+// service, disabled, and debounced so a noisy loop does not flood alerts.
+package logalert
+
+import (
+	"fmt"
+	"regexp"
+	"sync"
+	"time"
+)
+
+// Severity describes how important an alert is.
+type Severity string
+
+// Severity levels, aligned with the notification pipeline's severity strings.
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarning  Severity = "warning"
+	SeverityCritical Severity = "critical"
+)
+
+// DefaultDebounce is the minimum time between alerts for the same rule and
+// service when a rule does not set its own debounce window.
+const DefaultDebounce = 30 * time.Second
+
+// Rule is a single log alert rule.
+type Rule struct {
+	// Name identifies the rule and is used as part of the debounce key.
+	Name string
+	// Pattern is the regular expression matched against each log line.
+	Pattern string
+	// Service, when set, scopes the rule to a single service. Empty matches all.
+	Service string
+	// Severity is reported with the alert. Defaults to warning when empty.
+	Severity Severity
+	// Disabled turns the rule off without removing it.
+	Disabled bool
+	// Debounce overrides DefaultDebounce for this rule when greater than zero.
+	Debounce time.Duration
+}
+
+// Alert is produced when a log line matches a rule.
+type Alert struct {
+	Rule     string
+	Service  string
+	Line     string
+	Severity Severity
+	Time     time.Time
+}
+
+// compiledRule pairs a rule with its compiled regular expression.
+type compiledRule struct {
+	rule Rule
+	re   *regexp.Regexp
+}
+
+// Engine matches log lines against a set of rules with per-rule and per-service
+// debounce. It is safe for concurrent use.
+type Engine struct {
+	mu              sync.Mutex
+	rules           []compiledRule
+	defaultDebounce time.Duration
+	lastFired       map[string]time.Time
+}
+
+// DefaultRules returns built-in rules for common failure signals. They can be
+// disabled by passing a rule with the same name and Disabled set to true.
+func DefaultRules() []Rule {
+	return []Rule{
+		{Name: "panic", Pattern: `(?i)\bpanic\b`, Severity: SeverityCritical},
+		{Name: "unhandled-exception", Pattern: `(?i)unhandled\s+exception`, Severity: SeverityCritical},
+		{Name: "fatal", Pattern: `(?i)\bfatal\b`, Severity: SeverityCritical},
+	}
+}
+
+// NewEngine compiles the given rules into an engine. When includeDefaults is
+// true, DefaultRules are added first and any user rule with the same name
+// overrides the default. Invalid regular expressions are reported here, at load
+// time, rather than during matching.
+func NewEngine(rules []Rule, includeDefaults bool) (*Engine, error) {
+	var all []Rule
+	if includeDefaults {
+		all = append(all, DefaultRules()...)
+	}
+	all = append(all, rules...)
+
+	e := &Engine{
+		defaultDebounce: DefaultDebounce,
+		lastFired:       make(map[string]time.Time),
+	}
+	index := make(map[string]int)
+	for _, r := range all {
+		if r.Name == "" {
+			return nil, fmt.Errorf("alert rule has an empty name")
+		}
+		re, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("alert rule %q has an invalid pattern %q: %w", r.Name, r.Pattern, err)
+		}
+		cr := compiledRule{rule: r, re: re}
+		if i, ok := index[r.Name]; ok {
+			e.rules[i] = cr
+			continue
+		}
+		index[r.Name] = len(e.rules)
+		e.rules = append(e.rules, cr)
+	}
+	return e, nil
+}
+
+// Match evaluates one log line for a service and returns the alerts that fire at
+// time now. Disabled rules, and service-scoped rules that do not match the
+// service, are skipped. Repeated matches within a rule's debounce window are
+// suppressed. Non-matching lines return nil.
+func (e *Engine) Match(service, line string, now time.Time) []Alert {
+	if e == nil {
+		return nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var alerts []Alert
+	for _, cr := range e.rules {
+		r := cr.rule
+		if r.Disabled {
+			continue
+		}
+		if r.Service != "" && r.Service != service {
+			continue
+		}
+		if !cr.re.MatchString(line) {
+			continue
+		}
+
+		key := r.Name + "\x00" + service
+		debounce := r.Debounce
+		if debounce <= 0 {
+			debounce = e.defaultDebounce
+		}
+		if last, ok := e.lastFired[key]; ok && now.Sub(last) < debounce {
+			continue
+		}
+		e.lastFired[key] = now
+
+		severity := r.Severity
+		if severity == "" {
+			severity = SeverityWarning
+		}
+		alerts = append(alerts, Alert{
+			Rule:     r.Name,
+			Service:  service,
+			Line:     line,
+			Severity: severity,
+			Time:     now,
+		})
+	}
+	return alerts
+}
+
+// RuleCount returns the number of loaded rules, including disabled ones.
+func (e *Engine) RuleCount() int {
+	if e == nil {
+		return 0
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.rules)
+}

--- a/cli/src/internal/logalert/logalert_test.go
+++ b/cli/src/internal/logalert/logalert_test.go
@@ -1,0 +1,142 @@
+package logalert
+
+import (
+	"testing"
+	"time"
+)
+
+func mustEngine(t *testing.T, rules []Rule, includeDefaults bool) *Engine {
+	t.Helper()
+	e, err := NewEngine(rules, includeDefaults)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+func TestNewEngineInvalidPatternAtLoad(t *testing.T) {
+	_, err := NewEngine([]Rule{{Name: "bad", Pattern: "("}}, false)
+	if err == nil {
+		t.Fatal("expected an error for an invalid regex at load time")
+	}
+}
+
+func TestNewEngineEmptyName(t *testing.T) {
+	if _, err := NewEngine([]Rule{{Name: "", Pattern: "x"}}, false); err == nil {
+		t.Fatal("expected an error for an empty rule name")
+	}
+}
+
+func TestMatchBasic(t *testing.T) {
+	e := mustEngine(t, []Rule{{Name: "err", Pattern: "ERROR", Severity: SeverityWarning}}, false)
+	now := time.Now()
+
+	alerts := e.Match("web", "some ERROR happened", now)
+	if len(alerts) != 1 {
+		t.Fatalf("got %d alerts, want 1", len(alerts))
+	}
+	a := alerts[0]
+	if a.Rule != "err" || a.Service != "web" || a.Severity != SeverityWarning {
+		t.Errorf("unexpected alert: %+v", a)
+	}
+	if a.Line != "some ERROR happened" {
+		t.Errorf("alert line = %q", a.Line)
+	}
+}
+
+func TestMatchNonMatchingNeverNotifies(t *testing.T) {
+	e := mustEngine(t, []Rule{{Name: "err", Pattern: "ERROR"}}, false)
+	if alerts := e.Match("web", "everything is fine", time.Now()); alerts != nil {
+		t.Fatalf("non-matching line produced alerts: %+v", alerts)
+	}
+}
+
+func TestMatchDefaultSeverity(t *testing.T) {
+	e := mustEngine(t, []Rule{{Name: "err", Pattern: "ERROR"}}, false)
+	alerts := e.Match("web", "ERROR", time.Now())
+	if len(alerts) != 1 || alerts[0].Severity != SeverityWarning {
+		t.Fatalf("expected default warning severity, got %+v", alerts)
+	}
+}
+
+func TestMatchServiceScoping(t *testing.T) {
+	e := mustEngine(t, []Rule{{Name: "api-only", Pattern: "boom", Service: "api"}}, false)
+	now := time.Now()
+
+	if alerts := e.Match("web", "boom", now); alerts != nil {
+		t.Errorf("rule scoped to api should not fire for web: %+v", alerts)
+	}
+	if alerts := e.Match("api", "boom", now); len(alerts) != 1 {
+		t.Errorf("rule scoped to api should fire for api, got %+v", alerts)
+	}
+}
+
+func TestMatchDisabledRule(t *testing.T) {
+	e := mustEngine(t, []Rule{{Name: "err", Pattern: "ERROR", Disabled: true}}, false)
+	if alerts := e.Match("web", "ERROR", time.Now()); alerts != nil {
+		t.Errorf("disabled rule fired: %+v", alerts)
+	}
+}
+
+func TestMatchDebounce(t *testing.T) {
+	e := mustEngine(t, []Rule{{Name: "err", Pattern: "ERROR", Debounce: 10 * time.Second}}, false)
+	base := time.Now()
+
+	if alerts := e.Match("web", "ERROR one", base); len(alerts) != 1 {
+		t.Fatalf("first match should fire, got %+v", alerts)
+	}
+	// Within the debounce window: suppressed.
+	if alerts := e.Match("web", "ERROR two", base.Add(5*time.Second)); alerts != nil {
+		t.Fatalf("match within debounce window should be suppressed, got %+v", alerts)
+	}
+	// After the window: fires again.
+	if alerts := e.Match("web", "ERROR three", base.Add(11*time.Second)); len(alerts) != 1 {
+		t.Fatalf("match after debounce window should fire, got %+v", alerts)
+	}
+}
+
+func TestMatchDebounceIsPerService(t *testing.T) {
+	e := mustEngine(t, []Rule{{Name: "err", Pattern: "ERROR", Debounce: time.Minute}}, false)
+	now := time.Now()
+
+	if alerts := e.Match("web", "ERROR", now); len(alerts) != 1 {
+		t.Fatalf("web should fire, got %+v", alerts)
+	}
+	// A different service is tracked independently, so it still fires.
+	if alerts := e.Match("api", "ERROR", now); len(alerts) != 1 {
+		t.Fatalf("api should fire independently of web, got %+v", alerts)
+	}
+}
+
+func TestDefaultRulesFireOnPanic(t *testing.T) {
+	e := mustEngine(t, nil, true)
+	if e.RuleCount() != len(DefaultRules()) {
+		t.Fatalf("RuleCount = %d, want %d", e.RuleCount(), len(DefaultRules()))
+	}
+	alerts := e.Match("worker", "goroutine panic: nil pointer", time.Now())
+	if len(alerts) != 1 || alerts[0].Rule != "panic" || alerts[0].Severity != SeverityCritical {
+		t.Fatalf("panic default rule did not fire as expected: %+v", alerts)
+	}
+}
+
+func TestUserRuleOverridesDefault(t *testing.T) {
+	// Disable the built-in panic rule by overriding it with the same name.
+	e := mustEngine(t, []Rule{{Name: "panic", Pattern: `\bpanic\b`, Disabled: true}}, true)
+	if alerts := e.Match("worker", "panic: boom", time.Now()); alerts != nil {
+		t.Fatalf("overridden+disabled panic rule should not fire: %+v", alerts)
+	}
+	// Count is unchanged: the override replaced the default in place.
+	if e.RuleCount() != len(DefaultRules()) {
+		t.Fatalf("override should not change rule count, got %d", e.RuleCount())
+	}
+}
+
+func TestNilEngineSafe(t *testing.T) {
+	var e *Engine
+	if alerts := e.Match("web", "ERROR", time.Now()); alerts != nil {
+		t.Errorf("nil engine should return no alerts")
+	}
+	if e.RuleCount() != 0 {
+		t.Errorf("nil engine RuleCount should be 0")
+	}
+}


### PR DESCRIPTION
## Summary

Adds log-pattern alert rules so a specific line in a service's log stream (a panic, an unhandled exception, a custom error string) raises an alert instead of needing someone to watch the stream by eye.

Closes #415

## What it does

- New `internal/logalert` engine matches each streaming log line against regex rules.
- Rules carry a name, pattern, optional service filter, and severity, and can be disabled.
- Repeated matches for the same rule and service are debounced (default 30s, per-rule override) so one noisy loop does not flood alerts.
- Invalid regex patterns are reported when the engine loads, not at match time.
- Built-in rules for `panic`, `unhandled exception`, and `fatal` ship enabled and can be overridden or disabled by name.
- Wired into the local log streaming path behind an opt-in `--alerts` flag on `azd app logs`: a matching line prints an alert banner.
- `alertToEvent` converts an alert into a `notifications.Event` (type error, with service, rule, and matched line) so the same alerts can flow through the existing notification pipeline and the dashboard.

## Design

The engine is a self-contained package with no dependency on the CLI or notifications, so it is easy to test and reuse. Matching takes an explicit `now` time, which makes the debounce logic deterministic in tests. The streaming hook is a nil-guarded no-op unless `--alerts` is passed, so default behavior is unchanged.

## Testing

- `go test ./internal/logalert/` and the alert tests in `./cmd/app/commands/` pass.
- `golangci-lint run ./cmd/app/commands/ ./internal/logalert/`: 0 issues.
- Tests cover rule matching, default severity, service scoping, disabled rules, debounce (including per-service independence and window expiry), invalid-pattern-at-load, user override of a built-in rule, non-matching lines never alerting, the notification adapter mapping, and the banner output.
