### PR TITLE
feat(run): warn about hardcoded secrets in tracked config

### DIFF
--- a/cli/docs/commands/run.md
+++ b/cli/docs/commands/run.md
@@ -36,6 +36,7 @@ azd app run [flags]
 | `--force` | | bool | `false` | Force clean dependency reinstall (passes --force to deps) |
 | `--trust` | `-y` | bool | `false` | Trust this workspace for code execution and remember the decision |
 | `--web` | `-w` | bool | `false` | Open dashboard in browser |
+| `--skip-secret-scan` | | bool | `false` | Skip the advisory scan for hardcoded secrets in tracked config |
 
 ## Dashboard Browser Launch
 

--- a/cli/src/cmd/app/commands/run.go
+++ b/cli/src/cmd/app/commands/run.go
@@ -40,6 +40,7 @@ var (
 	runForce             bool
 	runTrust             bool
 	runNoTiming          bool
+	runSkipSecretScan    bool
 )
 
 // NewRunCommand creates the run command.
@@ -69,6 +70,7 @@ func NewRunCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&runTrust, "trust", "y", false, "Trust this workspace for code execution and remember the decision")
 	cmd.Flags().BoolVar(&runDetach, "detach", false, "Run the app in the background and return to the shell")
 	cmd.Flags().BoolVar(&runNoTiming, "no-timing", false, "Hide the per-service startup timing summary shown after services are ready")
+	cmd.Flags().BoolVar(&runSkipSecretScan, "skip-secret-scan", false, "Skip the advisory scan for hardcoded secrets in tracked config")
 
 	registerServiceFlagCompletion(cmd, "service")
 
@@ -282,6 +284,9 @@ func runAzdMode(ctx context.Context, azureYamlPath, azureYamlDir string) error {
 	if len(services) == 0 {
 		return fmt.Errorf("no services match filter: %s", runServiceFilter)
 	}
+
+	// Advisory security preflight: warn about literal secrets in tracked config.
+	runSecretScan(azureYaml, services, azureYamlDir)
 
 	// Propagate --force to port manager so port conflicts auto-resolve without prompting
 	if runForce {

--- a/cli/src/cmd/app/commands/run_secretscan.go
+++ b/cli/src/cmd/app/commands/run_secretscan.go
@@ -1,0 +1,123 @@
+package commands
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+
+	"github.com/jongio/azd-app/cli/src/internal/secretscan"
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-core/cliout"
+)
+
+// runSecretScan performs the advisory hardcoded-secret scan for the run
+// preflight. It inspects the environment blocks declared in azure.yaml and any
+// tracked .env files, then prints a short advisory when a literal secret value
+// is found. It never blocks the run and never mutates the child environment.
+func runSecretScan(azureYaml *service.AzureYaml, services map[string]service.Service, azureYamlDir string) {
+	if runSkipSecretScan {
+		return
+	}
+	if azureYaml != nil && azureYaml.Security != nil && azureYaml.Security.SkipSecretScan {
+		return
+	}
+	if cliout.IsJSON() {
+		return
+	}
+	reportSecretFindings(collectSecretFindings(services, azureYamlDir))
+}
+
+// collectSecretFindings gathers findings from every service environment block
+// and from each tracked .env file under azureYamlDir. It performs no output, so
+// callers and tests can inspect the result directly.
+func collectSecretFindings(services map[string]service.Service, azureYamlDir string) []secretscan.Finding {
+	var findings []secretscan.Finding
+	for _, name := range sortedServiceNames(services) {
+		svc := services[name]
+		findings = append(findings, secretscan.ScanEnv("azure.yaml (service: "+name+")", svc.GetEnvironment())...)
+	}
+	for _, path := range trackedEnvFiles(azureYamlDir) {
+		env, err := service.LoadDotEnv(path)
+		if err != nil {
+			continue
+		}
+		findings = append(findings, secretscan.ScanEnv(displayPath(azureYamlDir, path), env)...)
+	}
+	return findings
+}
+
+// sortedServiceNames returns the service names in stable order.
+func sortedServiceNames(services map[string]service.Service) []string {
+	names := make([]string, 0, len(services))
+	for name := range services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// trackedEnvFiles returns .env files under azureYamlDir that exist and are
+// tracked by git. Ignored files (the recommended place for local secrets) are
+// left out on purpose. If git is unavailable the result is empty.
+func trackedEnvFiles(azureYamlDir string) []string {
+	candidates := []string{filepath.Join(azureYamlDir, ".env")}
+	if runEnvFile != "" {
+		p := runEnvFile
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(azureYamlDir, p)
+		}
+		candidates = append(candidates, p)
+	}
+
+	seen := make(map[string]bool, len(candidates))
+	var tracked []string
+	for _, p := range candidates {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		if gitTracksFile(azureYamlDir, p) {
+			tracked = append(tracked, p)
+		}
+	}
+	return tracked
+}
+
+// gitTracksFile reports whether path is tracked by the git repository rooted at
+// or above dir. Any error (git missing, not a repo, file untracked) yields false.
+func gitTracksFile(dir, path string) bool {
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		rel = path
+	}
+	cmd := exec.Command("git", "-C", dir, "ls-files", "--error-unmatch", "--", rel)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run() == nil
+}
+
+// displayPath returns a short, workspace-relative label for a file path.
+func displayPath(base, path string) string {
+	if rel, err := filepath.Rel(base, path); err == nil {
+		return rel
+	}
+	return filepath.Base(path)
+}
+
+// reportSecretFindings prints the advisory. It is a no-op when there is nothing
+// to report.
+func reportSecretFindings(findings []secretscan.Finding) {
+	if len(findings) == 0 {
+		return
+	}
+	cliout.Warning("Possible hardcoded secrets in tracked config (%d):", len(findings))
+	for _, f := range findings {
+		cliout.Item("%s: %s (%s)", f.Source, f.Key, f.Detail)
+	}
+	cliout.Item("Move these to a Key Vault reference or a gitignored .env file. Use --skip-secret-scan to silence this check.")
+}

--- a/cli/src/cmd/app/commands/run_secretscan_test.go
+++ b/cli/src/cmd/app/commands/run_secretscan_test.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortedServiceNames(t *testing.T) {
+	services := map[string]service.Service{
+		"web": {}, "api": {}, "worker": {},
+	}
+	assert.Equal(t, []string{"api", "web", "worker"}, sortedServiceNames(services))
+	assert.Empty(t, sortedServiceNames(map[string]service.Service{}))
+}
+
+func TestDisplayPath(t *testing.T) {
+	base := filepath.Join("home", "dev", "app")
+	assert.Equal(t, ".env", displayPath(base, filepath.Join(base, ".env")))
+}
+
+func TestCollectSecretFindingsFromServices(t *testing.T) {
+	services := map[string]service.Service{
+		"api": {Environment: service.Environment{
+			"DB_PASSWORD":  "hunter2!",
+			"SERVICE_NAME": "orders-api",
+			"VAULT_REF":    "@Microsoft.KeyVault(SecretUri=https://v.vault.azure.net/secrets/p/1)",
+		}},
+		"web": {Environment: service.Environment{
+			"PUBLIC_URL": "https://localhost:3000",
+		}},
+	}
+
+	// Use a directory with no .env so only service blocks are scanned.
+	findings := collectSecretFindings(services, t.TempDir())
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, "DB_PASSWORD", findings[0].Key)
+	assert.Equal(t, "azure.yaml (service: api)", findings[0].Source)
+}
+
+func TestCollectSecretFindingsFromTrackedEnv(t *testing.T) {
+	dir := initGitRepo(t)
+	envPath := filepath.Join(dir, ".env")
+	require.NoError(t, os.WriteFile(envPath,
+		[]byte("DB_PASSWORD=hunter2!\nSERVICE_NAME=orders-api\n"), 0o600))
+	runGit(t, dir, "add", ".env")
+
+	findings := collectSecretFindings(nil, dir)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, "DB_PASSWORD", findings[0].Key)
+	assert.Equal(t, ".env", findings[0].Source)
+}
+
+func TestCollectSecretFindingsSkipsUntrackedEnv(t *testing.T) {
+	dir := initGitRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"),
+		[]byte("DB_PASSWORD=hunter2!\n"), 0o600))
+	// Do not add the file to git: an untracked .env must not be scanned.
+
+	assert.Empty(t, collectSecretFindings(nil, dir))
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+}

--- a/cli/src/internal/secretscan/secretscan.go
+++ b/cli/src/internal/secretscan/secretscan.go
@@ -1,0 +1,199 @@
+// Package secretscan provides an advisory scan that flags environment values
+// which look like real secrets sitting in tracked configuration. The run
+// preflight uses it to warn a developer before services start.
+//
+// The scan is deliberately advisory. It never blocks a run and never changes
+// the environment passed to child processes, matching the orchestrator's stance
+// that credential isolation belongs to the deployment environment. Its only job
+// is to point out a secret that has been written as a literal value into a file
+// that is tracked by source control, so it can be moved to a Key Vault reference
+// or a gitignored .env file before it spreads through clones and CI logs.
+package secretscan
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Finding describes one environment value that looks like a secret.
+type Finding struct {
+	// Source identifies where the value was read from, for example
+	// "azure.yaml (service: api)" or ".env".
+	Source string
+	// Key is the environment variable name.
+	Key string
+	// Detail explains, in one short phrase, why the value was flagged.
+	Detail string
+}
+
+// strongSecretKey matches variable names that strongly imply the value is a
+// secret. Bare "key" is intentionally excluded because names like
+// KEY_VAULT_NAME, PARTITION_KEY, or SSH_KEY_PATH are not themselves secrets.
+var strongSecretKey = regexp.MustCompile(`(?i)(password|passwd|\bpwd\b|secret|client[_-]?secret|(^|_)token($|_)|credential|private[_-]?key|api[_-]?key|access[_-]?key|secret[_-]?key|connection[_-]?string|conn[_-]?str|sas[_-]?token)`)
+
+// jwtPattern matches a JSON Web Token: three base64url segments joined by dots.
+var jwtPattern = regexp.MustCompile(`^eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}$`)
+
+// hexSecret matches a long run of hex, common for keys and hashes.
+var hexSecret = regexp.MustCompile(`^[0-9a-fA-F]{32,}$`)
+
+// base64ish matches a long base64 or base64url token.
+var base64ish = regexp.MustCompile(`^[A-Za-z0-9+/=_-]{24,}$`)
+
+// connStringSecret matches connection strings that embed a credential.
+var connStringSecret = regexp.MustCompile(`(?i)(password|pwd|accountkey|sharedaccesskey|accesskey)=[^;\s]+`)
+
+// placeholderValues are common stand-in values that are not real secrets.
+var placeholderValues = map[string]bool{
+	"changeme": true, "change-me": true, "changethis": true, "replaceme": true,
+	"password": true, "secret": true, "token": true, "example": true,
+	"examplevalue": true, "dummy": true, "placeholder": true, "todo": true,
+	"tbd": true, "none": true, "null": true, "test": true, "sample": true,
+}
+
+// Inspect reports whether a single key and value look like a hardcoded secret
+// and, when they do, a short reason. It returns false for empty values,
+// references (Key Vault or variable indirection), and obvious placeholders.
+func Inspect(key, value string) (bool, string) {
+	v := strings.TrimSpace(value)
+	if v == "" || isReference(v) || isPlaceholder(v) {
+		return false, ""
+	}
+
+	// Value-shape detectors fire regardless of the key name.
+	switch {
+	case jwtPattern.MatchString(v):
+		return true, "value looks like a JSON Web Token"
+	case connStringSecret.MatchString(v):
+		return true, "value looks like a connection string with an embedded credential"
+	case hexSecret.MatchString(v):
+		return true, "value looks like a long hex key"
+	case base64ish.MatchString(v) && hasLetter(v) && hasDigit(v):
+		return true, "value looks like a high-entropy token"
+	}
+
+	// Secret-named keys flag any remaining literal value that is not a path,
+	// URL, boolean, or number.
+	if strongSecretKey.MatchString(key) && looksLikeLiteralSecret(v) {
+		return true, "secret-named variable holds a literal value"
+	}
+	return false, ""
+}
+
+// ScanEnv inspects every entry in env and returns the findings, sorted by key
+// so output is stable across runs.
+func ScanEnv(source string, env map[string]string) []Finding {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var findings []Finding
+	for _, k := range keys {
+		if flagged, detail := Inspect(k, env[k]); flagged {
+			findings = append(findings, Finding{Source: source, Key: k, Detail: detail})
+		}
+	}
+	return findings
+}
+
+// isReference reports whether v is a Key Vault reference or a variable
+// indirection rather than a literal value. These are the recommended way to
+// carry a secret and must never be flagged.
+func isReference(v string) bool {
+	switch {
+	case strings.HasPrefix(v, "@Microsoft.KeyVault("):
+		return true
+	case strings.Contains(v, "${"), strings.Contains(v, "$("):
+		return true
+	case strings.HasPrefix(v, "$") && !strings.ContainsAny(v, " \t"):
+		return true
+	case strings.HasPrefix(v, "%") && strings.HasSuffix(v, "%"):
+		return true
+	default:
+		return false
+	}
+}
+
+// isPlaceholder reports whether v is a common stand-in rather than a real
+// secret, such as changeme, <your-key>, {password}, or a run of one character.
+func isPlaceholder(v string) bool {
+	lower := strings.ToLower(v)
+	if placeholderValues[lower] {
+		return true
+	}
+	if wrapped(v, '<', '>') || wrapped(v, '{', '}') {
+		return true
+	}
+	if strings.HasPrefix(lower, "your-") || strings.HasPrefix(lower, "your_") || strings.HasPrefix(lower, "yourvalue") {
+		return true
+	}
+	if len(v) > 0 && strings.Count(v, string(v[0])) == len(v) {
+		return true // e.g. ***** or xxxxx
+	}
+	return false
+}
+
+// looksLikeLiteralSecret excludes values that a secret-named key might
+// legitimately hold: filesystem paths, URLs, booleans, and plain numbers.
+func looksLikeLiteralSecret(v string) bool {
+	if isBoolOrNumber(v) {
+		return false
+	}
+	if strings.Contains(v, "://") {
+		return false
+	}
+	if isPathLike(v) {
+		return false
+	}
+	return true
+}
+
+func wrapped(v string, open, close byte) bool {
+	return len(v) >= 2 && v[0] == open && v[len(v)-1] == close
+}
+
+func isPathLike(v string) bool {
+	switch {
+	case strings.HasPrefix(v, "/"), strings.HasPrefix(v, "./"),
+		strings.HasPrefix(v, "../"), strings.HasPrefix(v, "~"):
+		return true
+	case len(v) >= 3 && v[1] == ':' && (v[2] == '\\' || v[2] == '/'):
+		return true // Windows drive path such as C:\ or C:/
+	default:
+		return false
+	}
+}
+
+func isBoolOrNumber(v string) bool {
+	switch strings.ToLower(v) {
+	case "true", "false", "yes", "no", "on", "off":
+		return true
+	}
+	for _, r := range v {
+		if (r < '0' || r > '9') && r != '.' && r != '-' && r != '+' {
+			return false
+		}
+	}
+	return v != ""
+}
+
+func hasLetter(v string) bool {
+	for _, r := range v {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDigit(v string) bool {
+	for _, r := range v {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/src/internal/secretscan/secretscan_test.go
+++ b/cli/src/internal/secretscan/secretscan_test.go
@@ -1,0 +1,87 @@
+package secretscan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectFlagsLiteralSecrets(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"password literal", "DB_PASSWORD", "hunter2!"},
+		{"client secret guid", "AZURE_CLIENT_SECRET", "literalClientSecretValue"},
+		{"api key value", "STRIPE_API_KEY", "A1b2C3d4E5f6G7h8I9j0K1l2M3n4"},
+		{"jwt token", "AUTH_TOKEN", "eyJhbGciOi.eyJzdWIiOi.SflKxwRJSM"},
+		{"hex key by shape", "SIGNING_MATERIAL", "0123456789abcdef0123456789abcdef"},
+		{"base64 token by shape", "OPAQUE_VALUE", "QWxhZGRpbjpvcGVuIHNlc2FtZTEyMzQ1"},
+		{"connection string", "STORAGE", "DefaultEndpointsProtocol=https;AccountKey=abc123def456ghi=="},
+		{"access key", "AWS_ACCESS_KEY", "literalAccessKeyValue"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagged, detail := Inspect(tt.key, tt.value)
+			assert.True(t, flagged, "expected %q=%q to be flagged", tt.key, tt.value)
+			assert.NotEmpty(t, detail)
+		})
+	}
+}
+
+func TestInspectIgnoresSafeValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"empty value", "DB_PASSWORD", ""},
+		{"whitespace only", "DB_PASSWORD", "   "},
+		{"key vault reference", "DB_PASSWORD", "@Microsoft.KeyVault(SecretUri=https://v.vault.azure.net/secrets/p/1)"},
+		{"env indirection braces", "DB_PASSWORD", "${DB_PASSWORD}"},
+		{"env indirection dollar", "DB_PASSWORD", "$DB_PASSWORD"},
+		{"windows env ref", "DB_PASSWORD", "%DB_PASSWORD%"},
+		{"placeholder changeme", "DB_PASSWORD", "changeme"},
+		{"placeholder angle", "API_KEY", "<your-api-key>"},
+		{"placeholder braces", "API_KEY", "{password}"},
+		{"repeated char", "API_KEY", "xxxxxxxx"},
+		{"boolean", "FEATURE_TOKEN_ENABLED", "true"},
+		{"number", "RETRY_COUNT", "12345"},
+		{"key vault name not a secret", "KEY_VAULT_NAME", "my-prod-vault"},
+		{"partition key not a secret", "PARTITION_KEY", "tenant-42"},
+		{"ssh key path not a secret", "SSH_KEY_PATH", "/home/dev/.ssh/id_rsa"},
+		{"secret dir path", "SECRETS_DIR", "/etc/app/secrets"},
+		{"non secret plain var", "SERVICE_NAME", "orders-api"},
+		{"secret url not literal", "TOKEN_ENDPOINT", "https://login.example.com/token"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagged, _ := Inspect(tt.key, tt.value)
+			assert.False(t, flagged, "expected %q=%q to be ignored", tt.key, tt.value)
+		})
+	}
+}
+
+func TestScanEnvReturnsSortedFindings(t *testing.T) {
+	env := map[string]string{
+		"DB_PASSWORD":  "hunter2!",
+		"API_KEY":      "A1b2C3d4E5f6G7h8I9j0K1l2M3n4",
+		"SERVICE_NAME": "orders-api",
+		"KEY_VAULT":    "@Microsoft.KeyVault(SecretUri=https://v.vault.azure.net/secrets/p/1)",
+	}
+
+	findings := ScanEnv("azure.yaml (service: api)", env)
+
+	require.Len(t, findings, 2)
+	// Sorted by key: API_KEY before DB_PASSWORD.
+	assert.Equal(t, "API_KEY", findings[0].Key)
+	assert.Equal(t, "DB_PASSWORD", findings[1].Key)
+	assert.Equal(t, "azure.yaml (service: api)", findings[0].Source)
+}
+
+func TestScanEnvEmpty(t *testing.T) {
+	assert.Empty(t, ScanEnv("x", nil))
+	assert.Empty(t, ScanEnv("x", map[string]string{}))
+}

--- a/cli/src/internal/service/types.go
+++ b/cli/src/internal/service/types.go
@@ -92,6 +92,7 @@ type AzureYaml struct {
 	Dashboard *DashboardConfig    `yaml:"dashboard,omitempty"`
 	Logs      *LogsConfig         `yaml:"logs,omitempty"`      // Project-level logging configuration
 	EnvFilter *EnvFilterConfig    `yaml:"envFilter,omitempty"` // Optional env-var filter configuration
+	Security  *SecurityConfig     `yaml:"security,omitempty"`  // Optional security preflight configuration
 }
 
 // EnvFilterConfig controls environment variable filtering at the dashboard-to-child-service
@@ -115,6 +116,14 @@ type EnvFilterConfig struct {
 	// even when they match a denylist pattern. Useful for non-sensitive vars caught
 	// by broad prefix patterns such as AZURE_* or AWS_*.
 	AdditionalAllowlist []string `yaml:"additionalAllowlist,omitempty"`
+}
+
+// SecurityConfig holds project-level toggles for the run preflight security
+// checks. All checks are advisory and default to enabled.
+type SecurityConfig struct {
+	// SkipSecretScan disables the advisory scan that flags literal secret
+	// values found in tracked configuration before a run starts.
+	SkipSecretScan bool `yaml:"skipSecretScan,omitempty"`
 }
 
 // DashboardConfig represents dashboard configuration in azure.yaml.


### PR DESCRIPTION
This adds an advisory security check to the `azd app run` preflight. Before services start, it scans the service `environment` blocks in azure.yaml and any tracked `.env` files, then warns when a value looks like a real secret sitting in source control.

```mermaid
flowchart TD
    A[azd app run] --> B[Parse azure.yaml + filter services]
    B --> C[Scan service env values]
    B --> D[Scan tracked .env files]
    C --> E{Looks like a literal secret?}
    D --> E
    E -->|Key Vault ref, indirection, placeholder| F[Skip]
    E -->|literal secret| G[Collect finding]
    G --> H[Print advisory: source, key, reason]
    H --> I[Continue starting services]
    F --> I
```

## What changed

- New `secretscan` package that classifies an env key and value. It flags JSON Web Tokens, long hex and high-entropy tokens, connection strings with an embedded credential, and literal values under secret-named keys. It never flags Key Vault references, `${VAR}` or `$(...)` indirections, placeholders like `changeme` or `<your-key>`, or plain paths, URLs, and numbers.
- Run preflight wiring that gathers findings from each service env block and from `.env` files that git tracks. Gitignored `.env` files, the recommended place for local secrets, are left alone.
- A `--skip-secret-scan` flag and an azure.yaml `security.skipSecretScan` toggle to silence the check.

The scan is advisory only. It does not block the run and does not change the environment passed to child processes, which keeps the existing stance that credential isolation belongs to the deployment environment.

## Testing

- `go test ./src/internal/secretscan/... ./src/cmd/app/commands/... ./src/internal/service/...` passes
- `golangci-lint run` on the changed packages reports 0 issues
- `gofmt` clean

Closes #424
