### PR TITLE
feat(run): warn when a service binds to all network interfaces

### DIFF
--- a/cli/docs/commands/run.md
+++ b/cli/docs/commands/run.md
@@ -36,6 +36,7 @@ azd app run [flags]
 | `--force` | | bool | `false` | Force clean dependency reinstall (passes --force to deps) |
 | `--trust` | `-y` | bool | `false` | Trust this workspace for code execution and remember the decision |
 | `--web` | `-w` | bool | `false` | Open dashboard in browser |
+| `--skip-exposure-check` | | bool | `false` | Skip the warning shown when a service binds to all network interfaces |
 
 ## Dashboard Browser Launch
 

--- a/cli/src/cmd/app/commands/run.go
+++ b/cli/src/cmd/app/commands/run.go
@@ -40,6 +40,7 @@ var (
 	runForce             bool
 	runTrust             bool
 	runNoTiming          bool
+	runSkipExposureCheck bool
 )
 
 // NewRunCommand creates the run command.
@@ -69,6 +70,7 @@ func NewRunCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&runTrust, "trust", "y", false, "Trust this workspace for code execution and remember the decision")
 	cmd.Flags().BoolVar(&runDetach, "detach", false, "Run the app in the background and return to the shell")
 	cmd.Flags().BoolVar(&runNoTiming, "no-timing", false, "Hide the per-service startup timing summary shown after services are ready")
+	cmd.Flags().BoolVar(&runSkipExposureCheck, "skip-exposure-check", false, "Skip the warning shown when a service binds to all network interfaces")
 
 	registerServiceFlagCompletion(cmd, "service")
 
@@ -282,6 +284,9 @@ func runAzdMode(ctx context.Context, azureYamlPath, azureYamlDir string) error {
 	if len(services) == 0 {
 		return fmt.Errorf("no services match filter: %s", runServiceFilter)
 	}
+
+	// Advisory: warn when a service binds to every network interface.
+	runExposureCheck(services, azureYamlDir, azureYaml)
 
 	// Propagate --force to port manager so port conflicts auto-resolve without prompting
 	if runForce {

--- a/cli/src/cmd/app/commands/run_netexposure.go
+++ b/cli/src/cmd/app/commands/run_netexposure.go
@@ -1,0 +1,135 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/jongio/azd-app/cli/src/internal/netexposure"
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-core/cliout"
+)
+
+// runExposureCheck warns when any service is configured to bind to every
+// network interface (for example HOST=0.0.0.0 or ASPNETCORE_URLS=http://+:5000).
+// Binding to all interfaces makes a local service reachable by anyone on the
+// same network, which is rarely intended on a developer machine.
+//
+// The check is advisory: it never blocks the run or changes how a service
+// starts. It can be silenced with --skip-exposure-check or by setting
+// security.skipExposureCheck in azure.yaml.
+func runExposureCheck(services map[string]service.Service, azureYamlDir string, azureYaml *service.AzureYaml) {
+	if runSkipExposureCheck {
+		return
+	}
+	if azureYaml != nil && azureYaml.Security != nil && azureYaml.Security.SkipExposureCheck {
+		return
+	}
+
+	findings := collectExposureFindings(services, azureYamlDir)
+	if len(findings) == 0 {
+		return
+	}
+	reportExposureFindings(findings)
+}
+
+// collectExposureFindings gathers all-interface bind findings from each
+// service's declared environment and from any .env files near the project or a
+// service directory.
+func collectExposureFindings(services map[string]service.Service, azureYamlDir string) []netexposure.Finding {
+	var findings []netexposure.Finding
+	seen := make(map[string]bool)
+
+	add := func(list []netexposure.Finding) {
+		for _, f := range list {
+			dedupeKey := f.Source + "\x00" + f.Key
+			if seen[dedupeKey] {
+				continue
+			}
+			seen[dedupeKey] = true
+			findings = append(findings, f)
+		}
+	}
+
+	for _, name := range sortedExposureServiceNames(services) {
+		svc := services[name]
+		source := fmt.Sprintf("azure.yaml (service: %s)", name)
+		add(netexposure.ScanEnv(source, svc.GetEnvironment()))
+	}
+
+	for _, path := range exposureEnvFiles(services, azureYamlDir) {
+		env, err := service.LoadDotEnv(path)
+		if err != nil {
+			continue
+		}
+		add(netexposure.ScanEnv(exposureDisplayPath(azureYamlDir, path), env))
+	}
+
+	return findings
+}
+
+// exposureEnvFiles returns the set of .env files to scan: the project-root
+// .env plus one per service directory. Order is deterministic.
+func exposureEnvFiles(services map[string]service.Service, azureYamlDir string) []string {
+	seen := make(map[string]bool)
+	var paths []string
+
+	addPath := func(p string) {
+		if p == "" || seen[p] {
+			return
+		}
+		if info, err := os.Stat(p); err != nil || info.IsDir() {
+			return
+		}
+		seen[p] = true
+		paths = append(paths, p)
+	}
+
+	addPath(filepath.Join(azureYamlDir, ".env"))
+	for _, name := range sortedExposureServiceNames(services) {
+		svc := services[name]
+		if svc.Project != "" {
+			addPath(filepath.Join(azureYamlDir, svc.Project, ".env"))
+		}
+	}
+
+	return paths
+}
+
+// reportExposureFindings prints an advisory warning describing each finding and
+// how to bind to loopback instead. It stays quiet in JSON output mode.
+func reportExposureFindings(findings []netexposure.Finding) {
+	if cliout.IsJSON() {
+		return
+	}
+
+	noun := "value"
+	if len(findings) != 1 {
+		noun = "values"
+	}
+	cliout.Warning("Found %d configuration %s that bind a service to all network interfaces:", len(findings), noun)
+	for _, f := range findings {
+		cliout.Item("%s: %s=%s", f.Source, f.Key, f.Value)
+	}
+	cliout.Info("Binding to 0.0.0.0 (or ::) exposes the service to your whole network. For local development, bind to 127.0.0.1 instead.")
+	cliout.Info("Silence this check with --skip-exposure-check or security.skipExposureCheck in azure.yaml.")
+}
+
+func sortedExposureServiceNames(services map[string]service.Service) []string {
+	names := make([]string, 0, len(services))
+	for name := range services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// exposureDisplayPath returns path relative to azureYamlDir when possible, so
+// warnings show a short, readable location.
+func exposureDisplayPath(azureYamlDir, path string) string {
+	if rel, err := filepath.Rel(azureYamlDir, path); err == nil {
+		return rel
+	}
+	return path
+}

--- a/cli/src/cmd/app/commands/run_netexposure_test.go
+++ b/cli/src/cmd/app/commands/run_netexposure_test.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectExposureFindingsFromServiceEnv(t *testing.T) {
+	services := map[string]service.Service{
+		"api": {
+			Environment: service.Environment{
+				"HOST":         "0.0.0.0",
+				"BIND_ADDRESS": "127.0.0.1",
+			},
+		},
+		"worker": {
+			Environment: service.Environment{
+				"ASPNETCORE_URLS": "http://+:5000",
+			},
+		},
+	}
+
+	findings := collectExposureFindings(services, t.TempDir())
+
+	require.Len(t, findings, 2)
+	// Sorted by service name: api before worker.
+	assert.Equal(t, "azure.yaml (service: api)", findings[0].Source)
+	assert.Equal(t, "HOST", findings[0].Key)
+	assert.Equal(t, "azure.yaml (service: worker)", findings[1].Source)
+	assert.Equal(t, "ASPNETCORE_URLS", findings[1].Key)
+}
+
+func TestCollectExposureFindingsFromDotEnv(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	require.NoError(t, os.WriteFile(envPath, []byte("HOST=0.0.0.0\nPORT=8080\n"), 0o600))
+
+	findings := collectExposureFindings(map[string]service.Service{}, dir)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, ".env", findings[0].Source)
+	assert.Equal(t, "HOST", findings[0].Key)
+	assert.Equal(t, "0.0.0.0", findings[0].Value)
+}
+
+func TestCollectExposureFindingsServiceDotEnv(t *testing.T) {
+	dir := t.TempDir()
+	svcDir := filepath.Join(dir, "api")
+	require.NoError(t, os.MkdirAll(svcDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(svcDir, ".env"), []byte("LISTEN_ADDR=[::]:9000\n"), 0o600))
+
+	services := map[string]service.Service{
+		"api": {Project: "api"},
+	}
+
+	findings := collectExposureFindings(services, dir)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, filepath.Join("api", ".env"), findings[0].Source)
+	assert.Equal(t, "LISTEN_ADDR", findings[0].Key)
+}
+
+func TestCollectExposureFindingsNoFindings(t *testing.T) {
+	services := map[string]service.Service{
+		"api": {
+			Environment: service.Environment{
+				"HOST": "127.0.0.1",
+				"PORT": "8080",
+			},
+		},
+	}
+
+	assert.Empty(t, collectExposureFindings(services, t.TempDir()))
+}
+
+func TestExposureEnvFilesSkipsMissing(t *testing.T) {
+	dir := t.TempDir()
+	services := map[string]service.Service{
+		"api": {Project: "api"},
+	}
+
+	assert.Empty(t, exposureEnvFiles(services, dir))
+}

--- a/cli/src/internal/netexposure/netexposure.go
+++ b/cli/src/internal/netexposure/netexposure.go
@@ -1,0 +1,137 @@
+// Package netexposure provides an advisory check that flags services configured
+// to bind to every network interface during local development. Binding to
+// 0.0.0.0 or the IPv6 equivalent makes a local service reachable by anyone on
+// the same network, which is rarely what a developer wants on a laptop.
+//
+// Like the other run preflight checks, this one is advisory. It prints a
+// warning and never blocks the run or changes how a service starts.
+package netexposure
+
+import (
+	"sort"
+	"strings"
+)
+
+// Finding describes one service configuration value that exposes the service on
+// all interfaces.
+type Finding struct {
+	// Source identifies where the value was read from, for example
+	// "azure.yaml (service: api)" or ".env".
+	Source string
+	// Key is the environment variable name.
+	Key string
+	// Value is the offending bind value, trimmed.
+	Value string
+}
+
+// bindKeys are environment variable names whose value is a bind host or a
+// host:port pair.
+var bindKeys = map[string]bool{
+	"HOST": true, "HOSTNAME": true, "BIND": true, "BIND_ADDR": true,
+	"BIND_ADDRESS": true, "LISTEN": true, "LISTEN_ADDR": true,
+	"LISTEN_ADDRESS": true, "SERVER_HOST": true, "HTTP_HOST": true,
+	"APP_HOST": true, "ADDR": true, "ADDRESS": true,
+}
+
+// bindSuffixes match variable names that end in a bind-host segment, such as
+// ADMIN_HOST or GRPC_LISTEN_ADDR. A wildcard host is only ever a bind target,
+// never a connect target, so matching by suffix is safe.
+var bindSuffixes = []string{"_HOST", "_HOSTNAME", "_ADDR", "_ADDRESS", "_BIND", "_LISTEN"}
+
+// urlKeys are environment variable names whose value is one or more URLs. Some
+// runtimes accept a semicolon-separated list, for example ASPNETCORE_URLS.
+var urlKeys = map[string]bool{
+	"ASPNETCORE_URLS": true, "URLS": true, "DOTNET_URLS": true,
+}
+
+// wildcardHosts are host values that mean "all interfaces".
+var wildcardHosts = map[string]bool{
+	"0.0.0.0": true, "::": true, "[::]": true, "*": true, "+": true,
+}
+
+// Inspect reports whether a single key and value configure an all-interfaces
+// bind. It returns false for loopback addresses, specific IPs, and values that
+// are not bind hints.
+func Inspect(key, value string) bool {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return false
+	}
+	upper := strings.ToUpper(strings.TrimSpace(key))
+
+	if isBindKey(upper) {
+		return isWildcardHost(hostOnly(v))
+	}
+	if urlKeys[upper] || strings.Contains(v, "://") {
+		for _, part := range strings.Split(v, ";") {
+			if isWildcardHost(hostFromURL(part)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ScanEnv inspects every entry in env and returns the findings, sorted by key.
+func ScanEnv(source string, env map[string]string) []Finding {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var findings []Finding
+	for _, k := range keys {
+		if Inspect(k, env[k]) {
+			findings = append(findings, Finding{Source: source, Key: k, Value: strings.TrimSpace(env[k])})
+		}
+	}
+	return findings
+}
+
+func isBindKey(upper string) bool {
+	if bindKeys[upper] {
+		return true
+	}
+	for _, suffix := range bindSuffixes {
+		if strings.HasSuffix(upper, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isWildcardHost(host string) bool {
+	return wildcardHosts[strings.TrimSpace(host)]
+}
+
+// hostOnly returns the host portion of a bind value that may include a port,
+// such as "0.0.0.0:8080" or "[::]:8080". A bare IPv6 address like "::" is
+// returned unchanged.
+func hostOnly(v string) string {
+	if strings.HasPrefix(v, "[") {
+		if end := strings.Index(v, "]"); end != -1 {
+			return v[:end+1]
+		}
+	}
+	if strings.Count(v, ":") == 1 {
+		return v[:strings.IndexByte(v, ':')]
+	}
+	return v
+}
+
+// hostFromURL extracts the host from a URL such as "http://0.0.0.0:5000" or the
+// ASP.NET forms "http://+:5000" and "http://*:5000". It returns an empty string
+// when raw is not a URL.
+func hostFromURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	i := strings.Index(raw, "://")
+	if i == -1 {
+		return ""
+	}
+	rest := raw[i+3:]
+	if slash := strings.IndexByte(rest, '/'); slash != -1 {
+		rest = rest[:slash]
+	}
+	return hostOnly(rest)
+}

--- a/cli/src/internal/netexposure/netexposure_test.go
+++ b/cli/src/internal/netexposure/netexposure_test.go
@@ -1,0 +1,77 @@
+package netexposure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectFlagsWildcardBinds(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"host ipv4 wildcard", "HOST", "0.0.0.0"},
+		{"host ipv4 with port", "HOST", "0.0.0.0:8080"},
+		{"bind ipv6 wildcard", "BIND_ADDRESS", "::"},
+		{"bind ipv6 bracket port", "LISTEN_ADDR", "[::]:9000"},
+		{"star host", "SERVER_HOST", "*"},
+		{"aspnet plus form", "ASPNETCORE_URLS", "http://+:5000"},
+		{"aspnet star form", "ASPNETCORE_URLS", "http://*:5000"},
+		{"aspnet ipv4 wildcard", "ASPNETCORE_URLS", "http://0.0.0.0:5000"},
+		{"aspnet multi url one wildcard", "ASPNETCORE_URLS", "http://localhost:5000;http://0.0.0.0:5001"},
+		{"generic url wildcard", "PUBLIC_ENDPOINT", "https://0.0.0.0:443/api"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, Inspect(tt.key, tt.value), "expected %q=%q to be flagged", tt.key, tt.value)
+		})
+	}
+}
+
+func TestInspectIgnoresSafeBinds(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"empty", "HOST", ""},
+		{"loopback ipv4", "HOST", "127.0.0.1"},
+		{"loopback ipv4 port", "HOST", "127.0.0.1:8080"},
+		{"localhost", "HOST", "localhost"},
+		{"loopback ipv6", "BIND_ADDRESS", "::1"},
+		{"specific ip", "HOST", "192.168.1.10"},
+		{"non bind key wildcard value", "REGION", "0.0.0.0"},
+		{"aspnet localhost only", "ASPNETCORE_URLS", "http://localhost:5000"},
+		{"url localhost", "PUBLIC_ENDPOINT", "https://localhost:443/api"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, Inspect(tt.key, tt.value), "expected %q=%q to be ignored", tt.key, tt.value)
+		})
+	}
+}
+
+func TestScanEnvReturnsSortedFindings(t *testing.T) {
+	env := map[string]string{
+		"HOST":         "0.0.0.0",
+		"ADMIN_HOST":   "0.0.0.0",
+		"SERVICE_NAME": "orders-api",
+		"BIND_ADDRESS": "127.0.0.1",
+	}
+
+	findings := ScanEnv("azure.yaml (service: api)", env)
+
+	require.Len(t, findings, 2)
+	assert.Equal(t, "ADMIN_HOST", findings[0].Key)
+	assert.Equal(t, "HOST", findings[1].Key)
+	assert.Equal(t, "0.0.0.0", findings[0].Value)
+	assert.Equal(t, "azure.yaml (service: api)", findings[0].Source)
+}
+
+func TestScanEnvEmpty(t *testing.T) {
+	assert.Empty(t, ScanEnv("x", nil))
+	assert.Empty(t, ScanEnv("x", map[string]string{}))
+}

--- a/cli/src/internal/service/types.go
+++ b/cli/src/internal/service/types.go
@@ -92,6 +92,16 @@ type AzureYaml struct {
 	Dashboard *DashboardConfig    `yaml:"dashboard,omitempty"`
 	Logs      *LogsConfig         `yaml:"logs,omitempty"`      // Project-level logging configuration
 	EnvFilter *EnvFilterConfig    `yaml:"envFilter,omitempty"` // Optional env-var filter configuration
+	Security  *SecurityConfig     `yaml:"security,omitempty"`  // Optional advisory security-check configuration
+}
+
+// SecurityConfig holds opt-out switches for the advisory security checks that
+// run during preflight. The checks are advisory: they warn but never block a
+// run. Set a field to true to silence the matching warning for this project.
+type SecurityConfig struct {
+	// SkipExposureCheck disables the warning shown when a service is configured
+	// to bind to every network interface (for example HOST=0.0.0.0).
+	SkipExposureCheck bool `yaml:"skipExposureCheck,omitempty"`
 }
 
 // EnvFilterConfig controls environment variable filtering at the dashboard-to-child-service


### PR DESCRIPTION
## What I changed

I added an advisory preflight check to `azd app run` that warns when a service is configured to bind to every network interface. On a laptop this is rarely what you want: a service listening on `0.0.0.0` is reachable by anyone on the same Wi-Fi or LAN, so a local-only API can end up exposed at a coffee shop or on a shared office network.

The check runs right after services are resolved and before anything starts. It scans two places:

- each service's declared `environment` in `azure.yaml`
- any `.env` file next to the project or a service directory

It looks for wildcard bind hosts (`0.0.0.0`, `::`, `[::]`, `*`, `+`) in bind-style keys such as `HOST`, `BIND_ADDRESS`, `LISTEN_ADDR`, and any `*_HOST` / `*_ADDR` variant, plus URL keys like `ASPNETCORE_URLS` (including the `http://+:5000` and `http://*:5000` forms). Loopback (`127.0.0.1`, `localhost`, `::1`) and specific IPs are left alone.

When it finds something, it prints a warning that names the source and suggests binding to `127.0.0.1` for local work. It never blocks the run or changes how a service starts.

## Opting out

- `--skip-exposure-check` for a single run
- `security.skipExposureCheck: true` in `azure.yaml` to silence it for the project

## How it works

```mermaid
flowchart TD
    A[azd app run] --> B[Resolve and filter services]
    B --> C{Exposure check enabled?}
    C -->|--skip-exposure-check or security.skipExposureCheck| G[Skip]
    C -->|enabled| D[Scan service environment and .env files]
    D --> E{Wildcard bind host found?}
    E -->|No| F[Continue startup]
    E -->|Yes| H[Print advisory warning, suggest 127.0.0.1]
    H --> F
```

## Why this is safe

- Advisory only. The run continues exactly as before, so no existing workflow breaks.
- Read-only. It inspects configuration and `.env` files that are already read during a run and never edits them.
- Quiet in JSON mode, so scripted output is unchanged.

## Testing

- New table-driven unit tests for the detection package covering IPv4 and IPv6 wildcards, bracketed IPv6, the ASP.NET `+`/`*` forms, multi-URL lists, and safe values (loopback, specific IPs, non-bind keys).
- New wiring tests covering service environment findings, project and per-service `.env` findings, deterministic ordering, and the no-findings case.
- `go build ./...`, `go test`, and `golangci-lint` all pass.

Closes #425
