### PR TITLE
feat(completion): complete service names for positional args

### DIFF
--- a/cli/src/cmd/app/commands/completion.go
+++ b/cli/src/cmd/app/commands/completion.go
@@ -90,3 +90,32 @@ func splitServiceCompletion(toComplete string) (prefix, last string, chosen map[
 func registerServiceFlagCompletion(cmd *cobra.Command, flagName string) {
 	_ = cmd.RegisterFlagCompletionFunc(flagName, completeServiceNames)
 }
+
+// completeServiceArgs is a cobra ValidArgsFunction for commands that accept one
+// or more service names as positional arguments (for example env, info, and
+// logs). It suggests service names read from azure.yaml, skips names already
+// given earlier on the command line, and always returns
+// ShellCompDirectiveNoFileComp so the shell does not fall back to file-name
+// completion.
+func completeServiceArgs(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	all := serviceNamesFromAzureYaml()
+	if len(all) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	chosen := make(map[string]bool, len(args))
+	for _, a := range args {
+		chosen[a] = true
+	}
+
+	suggestions := make([]string, 0, len(all))
+	for _, name := range all {
+		if chosen[name] {
+			continue
+		}
+		if strings.HasPrefix(name, toComplete) {
+			suggestions = append(suggestions, name)
+		}
+	}
+	return suggestions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cli/src/cmd/app/commands/completion_test.go
+++ b/cli/src/cmd/app/commands/completion_test.go
@@ -109,6 +109,75 @@ func TestCompleteServiceNames_NoAzureYaml(t *testing.T) {
 	}
 }
 
+func TestCompleteServiceArgs(t *testing.T) {
+	dir := t.TempDir()
+	writeAzureYamlForCompletion(t, dir, "api", "web", "worker")
+	t.Chdir(dir)
+
+	tests := []struct {
+		name       string
+		args       []string
+		toComplete string
+		want       []string
+	}{
+		{
+			name:       "empty prefix suggests all",
+			args:       nil,
+			toComplete: "",
+			want:       []string{"api", "web", "worker"},
+		},
+		{
+			name:       "prefix filters",
+			args:       nil,
+			toComplete: "w",
+			want:       []string{"web", "worker"},
+		},
+		{
+			name:       "already chosen names are skipped",
+			args:       []string{"api"},
+			toComplete: "",
+			want:       []string{"web", "worker"},
+		},
+		{
+			name:       "chosen skip combines with prefix",
+			args:       []string{"web"},
+			toComplete: "w",
+			want:       []string{"worker"},
+		},
+		{
+			name:       "no match returns empty",
+			args:       nil,
+			toComplete: "zzz",
+			want:       []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, directive := completeServiceArgs(nil, tt.args, tt.toComplete)
+			if directive != cobra.ShellCompDirectiveNoFileComp {
+				t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+			}
+			if !reflect.DeepEqual(normalizeCompletion(got), normalizeCompletion(tt.want)) {
+				t.Errorf("completeServiceArgs(%v, %q) = %v, want %v", tt.args, tt.toComplete, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompleteServiceArgs_NoAzureYaml(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	got, directive := completeServiceArgs(nil, nil, "")
+	if got != nil {
+		t.Errorf("completeServiceArgs() = %v, want nil when azure.yaml is missing", got)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+	}
+}
+
 func TestRegisterServiceFlagCompletion(t *testing.T) {
 	cmd := &cobra.Command{Use: "demo"}
 	cmd.Flags().String("service", "", "service filter")

--- a/cli/src/cmd/app/commands/env.go
+++ b/cli/src/cmd/app/commands/env.go
@@ -52,9 +52,10 @@ Examples:
 
   # Raw values, no masking
   azd app env api --no-mask`,
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
-		RunE:         runEnv,
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
+		RunE:              runEnv,
+		ValidArgsFunction: completeServiceArgs,
 	}
 
 	cmd.Flags().StringVar(&envFormat, "format", envFormatDotenv, "Output format: dotenv, shell, or json")

--- a/cli/src/cmd/app/commands/info.go
+++ b/cli/src/cmd/app/commands/info.go
@@ -50,8 +50,9 @@ Examples:
 
   # Show information about multiple services
   azd app info --service "api,web"`,
-		SilenceUsage: true,
-		RunE:         runInfo,
+		SilenceUsage:      true,
+		RunE:              runInfo,
+		ValidArgsFunction: completeServiceArgs,
 	}
 
 	cmd.Flags().BoolVar(&infoAll, "all", false, "Show services from all projects on this machine")

--- a/cli/src/cmd/app/commands/logs.go
+++ b/cli/src/cmd/app/commands/logs.go
@@ -277,6 +277,7 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLogsWithOptions(opts, args)
 		},
+		ValidArgsFunction: completeServiceArgs,
 	}
 
 	cmd.Flags().BoolVarP(&opts.follow, "follow", "f", false, "Follow log output (tail -f behavior)")


### PR DESCRIPTION
## What
`azd app env`, `azd app info`, and `azd app logs` take a service name as a positional argument, but pressing tab there completed file names instead of the services from azure.yaml. This adds shell completion for those positional arguments.

## How
- Add `completeServiceArgs`, a cobra `ValidArgsFunction` in `completion.go`. It reads service names from azure.yaml via the existing `serviceNamesFromAzureYaml`, drops names already typed on the line, and returns `ShellCompDirectiveNoFileComp` so the shell does not add file suggestions.
- Set it as `ValidArgsFunction` on the env, info, and logs commands.
- `restart`, `start`, and `stop` target services through `--service` only, and that flag already completes, so they are unchanged.

## Testing
- New table-driven tests for `completeServiceArgs`: empty prefix, prefix filter, already-chosen skip, no match, and missing azure.yaml.
- `go build ./...`, `go vet`, and the completion tests pass locally.

Closes #433
