### PR TITLE
feat(logs): support custom secret redaction patterns in azure.yaml

### DIFF
--- a/cli/docs/commands/logs.md
+++ b/cli/docs/commands/logs.md
@@ -279,6 +279,39 @@ Logs are automatically assigned levels based on content patterns:
 | Contains "debug", "trace" | DEBUG | "Debug: processing..." |
 | Default | INFO | "Server started" |
 
+## Secret Redaction
+
+Log lines are masked for secret-shaped values as they are written, so tokens and
+passwords do not end up in the console, log files, or support bundles. A built-in
+set of patterns covers common formats (key=value pairs for `secret`, `password`,
+`token`, `key`, `credential`, and `auth`, plus JWT tokens).
+
+### Custom redaction rules
+
+Projects often use tokens with their own shape that the built-in patterns do not
+recognize. Declare extra rules under `logs.redaction` in `azure.yaml`:
+
+```yaml
+logs:
+  redaction:
+    patterns:
+      - "acme-[a-z0-9]{16}"      # regular expression, every match is masked
+      - "internal-[A-Z0-9]{8}"
+    literals:
+      - "my-known-shared-secret" # exact string, masked wherever it appears
+```
+
+- `patterns` are regular expressions. Every match is replaced with `***`.
+- `literals` are exact strings, masked wherever they appear.
+
+Rules are compiled once at startup and applied on top of the built-in patterns.
+If a pattern fails to compile, the run prints a warning and skips only that entry
+rather than failing to start. With no `redaction` block present, the built-in
+patterns still apply.
+
+Because log files are masked as they are written, the same rules apply to support
+bundles that include those files.
+
 ## Service Filtering
 
 ### Single Service

--- a/cli/src/cmd/app/commands/run.go
+++ b/cli/src/cmd/app/commands/run.go
@@ -264,6 +264,10 @@ func runAzdMode(ctx context.Context, azureYamlPath, azureYamlDir string) error {
 		return fmt.Errorf("failed to parse azure.yaml: %w", err)
 	}
 
+	// Install any project-specific log redaction rules before services start
+	// streaming, so both the live console and support bundles honor them.
+	registerLogRedaction(azureYaml)
+
 	// REMOVED: initializeAzureLogBuffer call - deprecated v1
 	// Azure logs are now fetched on-demand via /api/azure/logs endpoint
 

--- a/cli/src/cmd/app/commands/run_logredaction.go
+++ b/cli/src/cmd/app/commands/run_logredaction.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-core/cliout"
+)
+
+// registerLogRedaction installs any project-specific log redaction rules
+// declared under logs.redaction in azure.yaml. Invalid regular expressions are
+// skipped with a warning so the run still starts. With no config present, the
+// built-in redaction patterns continue to apply unchanged.
+func registerLogRedaction(azureYaml *service.AzureYaml) {
+	if azureYaml == nil || azureYaml.Logs == nil || azureYaml.Logs.Redaction == nil {
+		return
+	}
+	cfg := azureYaml.Logs.Redaction
+
+	errs := service.RegisterLogRedaction(cfg.Patterns, cfg.Literals)
+	for _, err := range errs {
+		cliout.Warning("Skipping log redaction rule: %v", err)
+	}
+
+	if !cliout.IsJSON() && (len(cfg.Patterns) > 0 || len(cfg.Literals) > 0) {
+		cliout.Info("Applying custom log redaction rules from azure.yaml.")
+	}
+}

--- a/cli/src/cmd/app/commands/run_logredaction_test.go
+++ b/cli/src/cmd/app/commands/run_logredaction_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterLogRedactionFromConfig(t *testing.T) {
+	t.Cleanup(service.ResetLogRedaction)
+
+	azureYaml := &service.AzureYaml{
+		Logs: &service.LogsConfig{
+			Redaction: &service.LogRedactionConfig{
+				Patterns: []string{`tok-[0-9]{4}`},
+				Literals: []string{"literal-secret"},
+			},
+		},
+	}
+
+	registerLogRedaction(azureYaml)
+
+	masked := service.MaskSecretsInLogLine("tok-1234 and literal-secret")
+	assert.NotContains(t, masked, "tok-1234")
+	assert.NotContains(t, masked, "literal-secret")
+}
+
+func TestRegisterLogRedactionNilSafe(t *testing.T) {
+	t.Cleanup(service.ResetLogRedaction)
+
+	// None of these should panic or register anything.
+	registerLogRedaction(nil)
+	registerLogRedaction(&service.AzureYaml{})
+	registerLogRedaction(&service.AzureYaml{Logs: &service.LogsConfig{}})
+
+	assert.Equal(t, "plain line", service.MaskSecretsInLogLine("plain line"))
+}

--- a/cli/src/internal/service/logbuffer.go
+++ b/cli/src/internal/service/logbuffer.go
@@ -131,7 +131,7 @@ var sensitivePatterns = regexp.MustCompile(
 
 // MaskSecretsInLogLine redacts sensitive values from a log message.
 func MaskSecretsInLogLine(message string) string {
-	return sensitivePatterns.ReplaceAllStringFunc(message, func(match string) string {
+	masked := sensitivePatterns.ReplaceAllStringFunc(message, func(match string) string {
 		// For key=value patterns, keep the key and mask the value
 		if idx := strings.IndexAny(match, "=:"); idx >= 0 {
 			return match[:idx+1] + "***"
@@ -139,6 +139,7 @@ func MaskSecretsInLogLine(message string) string {
 		// For standalone tokens (JWT), mask entirely
 		return "***"
 	})
+	return applyCustomRedaction(masked)
 }
 
 // writeToFile writes a log entry to the file (must be called with fileMu locked).

--- a/cli/src/internal/service/logfilter.go
+++ b/cli/src/internal/service/logfilter.go
@@ -150,6 +150,19 @@ type LogsConfig struct {
 	Classifications []LogClassification `yaml:"classifications,omitempty" json:"classifications,omitempty"`
 	// Analytics is the global Azure Log Analytics configuration (workspace, polling, timespan)
 	Analytics *AnalyticsConfigGlobal `yaml:"analytics,omitempty" json:"analytics,omitempty"`
+	// Redaction adds project-specific secret patterns and literals that are
+	// masked in streamed logs and support bundles, alongside the built-in patterns.
+	Redaction *LogRedactionConfig `yaml:"redaction,omitempty" json:"redaction,omitempty"`
+}
+
+// LogRedactionConfig declares project-specific secret redaction rules that are
+// applied to streamed logs (and, because log files are masked as they are
+// written, to support bundles) in addition to the built-in patterns.
+type LogRedactionConfig struct {
+	// Patterns is a list of regular expressions; every match is masked.
+	Patterns []string `yaml:"patterns,omitempty" json:"patterns,omitempty"`
+	// Literals is a list of exact strings to mask wherever they appear.
+	Literals []string `yaml:"literals,omitempty" json:"literals,omitempty"`
 }
 
 // ServiceLogsConfig represents service-level logs configuration in azure.yaml.

--- a/cli/src/internal/service/logredaction.go
+++ b/cli/src/internal/service/logredaction.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// customRedactionMask replaces text matched by a user-supplied redaction rule.
+const customRedactionMask = "***"
+
+var (
+	customRedactionMu       sync.RWMutex
+	customRedactionPatterns []*regexp.Regexp
+	customRedactionLiterals []string
+)
+
+// RegisterLogRedaction installs project-specific redaction rules that
+// MaskSecretsInLogLine applies on top of the built-in patterns. Each entry in
+// patterns is a regular expression whose matches are masked; each entry in
+// literals is masked as an exact substring wherever it appears.
+//
+// Invalid regular expressions are skipped and returned as errors so the caller
+// can warn without aborting the run. Registration replaces any rules installed
+// by a previous call and is meant to run once at startup, before log streaming
+// begins.
+func RegisterLogRedaction(patterns, literals []string) []error {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	var errs []error
+	for _, p := range patterns {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		re, err := regexp.Compile(p)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid redaction pattern %q: %w", p, err))
+			continue
+		}
+		compiled = append(compiled, re)
+	}
+
+	lits := make([]string, 0, len(literals))
+	for _, l := range literals {
+		if l == "" {
+			continue
+		}
+		lits = append(lits, l)
+	}
+
+	customRedactionMu.Lock()
+	customRedactionPatterns = compiled
+	customRedactionLiterals = lits
+	customRedactionMu.Unlock()
+	return errs
+}
+
+// ResetLogRedaction clears all custom redaction rules. It is intended for tests.
+func ResetLogRedaction() {
+	customRedactionMu.Lock()
+	customRedactionPatterns = nil
+	customRedactionLiterals = nil
+	customRedactionMu.Unlock()
+}
+
+// applyCustomRedaction masks custom patterns and literals in message. It reads
+// a snapshot of the registered rules under a read lock; the underlying slices
+// are never mutated in place, so using the snapshot after unlocking is safe.
+func applyCustomRedaction(message string) string {
+	customRedactionMu.RLock()
+	patterns := customRedactionPatterns
+	literals := customRedactionLiterals
+	customRedactionMu.RUnlock()
+
+	for _, re := range patterns {
+		message = re.ReplaceAllString(message, customRedactionMask)
+	}
+	for _, lit := range literals {
+		message = strings.ReplaceAll(message, lit, customRedactionMask)
+	}
+	return message
+}

--- a/cli/src/internal/service/logredaction_test.go
+++ b/cli/src/internal/service/logredaction_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterLogRedactionCustomPattern(t *testing.T) {
+	t.Cleanup(ResetLogRedaction)
+
+	errs := RegisterLogRedaction([]string{`acme-[a-z0-9]{6}`}, nil)
+	require.Empty(t, errs)
+
+	got := MaskSecretsInLogLine("connecting with token acme-ab12cd for user bob")
+	assert.NotContains(t, got, "acme-ab12cd")
+	assert.Contains(t, got, "***")
+	assert.Contains(t, got, "for user bob")
+}
+
+func TestRegisterLogRedactionLiteral(t *testing.T) {
+	t.Cleanup(ResetLogRedaction)
+
+	errs := RegisterLogRedaction(nil, []string{"super-secret-value"})
+	require.Empty(t, errs)
+
+	got := MaskSecretsInLogLine("value is super-secret-value here")
+	assert.NotContains(t, got, "super-secret-value")
+	assert.Contains(t, got, "***")
+}
+
+func TestRegisterLogRedactionInvalidPatternSkipped(t *testing.T) {
+	t.Cleanup(ResetLogRedaction)
+
+	errs := RegisterLogRedaction([]string{`valid-[0-9]+`, `(unclosed`}, nil)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "invalid redaction pattern")
+
+	// The valid pattern is still installed despite the invalid one.
+	got := MaskSecretsInLogLine("id valid-42 done")
+	assert.NotContains(t, got, "valid-42")
+	assert.Contains(t, got, "***")
+}
+
+func TestMaskSecretsInLogLineBuiltInStillAppliesWithNoConfig(t *testing.T) {
+	ResetLogRedaction()
+
+	got := MaskSecretsInLogLine("password=hunter2secret rest")
+	assert.Contains(t, got, "password=***")
+	assert.NotContains(t, got, "hunter2secret")
+}
+
+func TestRegisterLogRedactionEmptyEntriesIgnored(t *testing.T) {
+	t.Cleanup(ResetLogRedaction)
+
+	errs := RegisterLogRedaction([]string{"", "   "}, []string{""})
+	assert.Empty(t, errs)
+
+	got := MaskSecretsInLogLine("nothing to mask here")
+	assert.Equal(t, "nothing to mask here", got)
+}


### PR DESCRIPTION
## What I changed

Streamed logs are already masked for secret-shaped values (key=value pairs for `secret`, `password`, `token`, and friends, plus JWTs). The gap: project-specific tokens with a custom shape, like an internal key with a company prefix, sailed straight through to the console and into support bundles because the built-in patterns did not know about them.

I added an optional `logs.redaction` block to `azure.yaml` so a project can declare its own rules:

```yaml
logs:
  redaction:
    patterns:
      - "acme-[a-z0-9]{16}"      # regex, every match is masked
      - "internal-[A-Z0-9]{8}"
    literals:
      - "my-known-shared-secret" # exact string, masked wherever it appears
```

- `patterns` are regular expressions; every match is replaced with `***`.
- `literals` are exact strings, masked wherever they appear.

Rules are compiled once at startup and applied on top of the built-in patterns in the existing redaction path (`MaskSecretsInLogLine`). Since log files are masked as they are written, support bundles that include those files honor the same rules, so there is no second code path to keep in sync.

I placed the block under the existing `logs:` section alongside `filters`, `classifications`, and `analytics`, which is where the rest of the logging configuration lives.

## How it works

```mermaid
flowchart TD
    A[azure.yaml logs.redaction] --> B[Compile patterns at startup]
    B --> C{Pattern valid?}
    C -->|no| D[Warn and skip that entry]
    C -->|yes| E[Add to custom rule set]
    F[Service log line] --> G[Built-in redaction]
    G --> H[Custom patterns and literals]
    E --> H
    H --> I[Masked line to console, log file, support bundle]
```

## Why this is safe

- Fail-open on startup, fail-closed on secrets: an invalid regex is skipped with a warning so the run still starts, but valid rules are always applied.
- With no `redaction` block, behavior is unchanged: the built-in patterns still apply.
- The custom rule set is read under a lock and never mutated in place, so concurrent log writers see a consistent snapshot.

## Testing

- Unit tests for custom patterns, literals, an invalid regex that is skipped while a valid one still applies, empty entries ignored, and the no-config default where built-in redaction still works.
- Wiring tests that register rules from a parsed `azure.yaml` and confirm nil-safe handling when the block is absent.
- `go build ./...`, `go test`, and `golangci-lint` all pass.

Closes #426
