### PR TITLE
feat(env): add --all to print every service's resolved environment

### DIFF
--- a/cli/src/cmd/app/commands/env.go
+++ b/cli/src/cmd/app/commands/env.go
@@ -23,6 +23,7 @@ var (
 	envFormat string
 	envNoMask bool
 	envFile   string
+	envAll    bool
 )
 
 // NewEnvCommand creates the env command.
@@ -40,6 +41,10 @@ list the available services.
 Secret-shaped values are masked by default. Use --no-mask to print raw values,
 for example when piping the output into another command.
 
+Pass --all to print the resolved environment for every service in one run. The
+dotenv and shell formats group each service under a "# <service>" header; the
+json format emits an object keyed by service name.
+
 Examples:
   # Resolved environment for the api service (KEY=value lines)
   azd app env api
@@ -51,7 +56,10 @@ Examples:
   azd app env api --format json
 
   # Raw values, no masking
-  azd app env api --no-mask`,
+  azd app env api --no-mask
+
+  # Resolved environment for every service
+  azd app env --all`,
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
 		RunE:         runEnv,
@@ -60,6 +68,7 @@ Examples:
 	cmd.Flags().StringVar(&envFormat, "format", envFormatDotenv, "Output format: dotenv, shell, or json")
 	cmd.Flags().BoolVar(&envNoMask, "no-mask", false, "Print raw values instead of masking secret-shaped values")
 	cmd.Flags().StringVar(&envFile, "env-file", "", "Path to a .env file to merge, matching azd app run")
+	cmd.Flags().BoolVar(&envAll, "all", false, "Print the resolved environment for every service")
 
 	return cmd
 }
@@ -80,6 +89,15 @@ func runEnv(_ *cobra.Command, args []string) error {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+
+	// --all cannot be combined with a specific service name.
+	if envAll && len(args) > 0 {
+		return fmt.Errorf("cannot combine --all with a service name")
+	}
+
+	if envAll {
+		return runEnvAll(azureYaml, names)
+	}
 
 	// No service name: list the available services and exit.
 	if len(args) == 0 {
@@ -116,6 +134,60 @@ func runEnv(_ *cobra.Command, args []string) error {
 	}
 
 	fmt.Print(formatEnv(resolved, format, mask))
+	return nil
+}
+
+// runEnvAll resolves and prints the environment for every service. Every service
+// is resolved before any output is written so a resolution failure is reported
+// without emitting a partial dump.
+func runEnvAll(azureYaml *service.AzureYaml, names []string) error {
+	format, err := resolveEnvFormat(envFormat)
+	if err != nil {
+		return err
+	}
+	// The global --json flag takes precedence over --format.
+	if cliout.IsJSON() {
+		format = envFormatJSON
+	}
+
+	resolvedByService := make(map[string]map[string]string, len(names))
+	for _, name := range names {
+		svc := azureYaml.Services[name]
+		resolved, err := service.ResolveEnvironment(context.Background(), svc, getAzureEnvironmentValues(), envFile, nil)
+		if err != nil {
+			return fmt.Errorf("failed to resolve environment for %q: %w", name, err)
+		}
+		resolvedByService[name] = resolved
+	}
+
+	return renderAllEnv(resolvedByService, names, format, !envNoMask)
+}
+
+// renderAllEnv writes the resolved environment for every service. The json format
+// emits an object keyed by service name; the dotenv and shell formats group each
+// service under a "# <service>" header separated by a blank line. names controls
+// the ordering. Secret-shaped values are masked when mask is true.
+func renderAllEnv(resolvedByService map[string]map[string]string, names []string, format string, mask bool) error {
+	if format == envFormatJSON {
+		out := make(map[string]map[string]string, len(resolvedByService))
+		for name, resolved := range resolvedByService {
+			out[name] = maskEnv(resolved, mask)
+		}
+		return cliout.PrintJSON(out)
+	}
+
+	if len(names) == 0 {
+		cliout.Info("No services are defined in azure.yaml")
+		return nil
+	}
+
+	for i, name := range names {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("# %s\n", name)
+		fmt.Print(formatEnv(resolvedByService[name], format, mask))
+	}
 	return nil
 }
 

--- a/cli/src/cmd/app/commands/env_test.go
+++ b/cli/src/cmd/app/commands/env_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,7 +19,7 @@ func TestNewEnvCommand(t *testing.T) {
 	assert.NotEmpty(t, cmd.Short)
 	require.NotNil(t, cmd.RunE)
 
-	for _, name := range []string{"format", "no-mask", "env-file"} {
+	for _, name := range []string{"format", "no-mask", "env-file", "all"} {
 		assert.NotNil(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
@@ -178,6 +179,96 @@ func TestRunEnvCommand(t *testing.T) {
 		require.Error(t, runErr)
 		assert.Contains(t, runErr.Error(), "invalid --format")
 	})
+
+	t.Run("all prints every service grouped by header", func(t *testing.T) {
+		resetEnvFlags()
+		t.Setenv("SERVICE_ENV_MARKER", "marker-value")
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"--all"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+		assert.Contains(t, out, "# api")
+		assert.Contains(t, out, "# web")
+		// The api header must come before the web header (services are sorted).
+		assert.Less(t, strings.Index(out, "# api"), strings.Index(out, "# web"))
+		assert.Contains(t, out, "SERVICE_ENV_MARKER=marker-value")
+	})
+
+	t.Run("all with json emits an object keyed by service", func(t *testing.T) {
+		resetEnvFlags()
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"--all", "--format", "json"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+		var parsed map[string]map[string]string
+		require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+		assert.Contains(t, parsed, "api")
+		assert.Contains(t, parsed, "web")
+	})
+
+	t.Run("all with a service name errors", func(t *testing.T) {
+		resetEnvFlags()
+		cmd := NewEnvCommand()
+		cmd.SetArgs([]string{"api", "--all"})
+		runErr := cmd.Execute()
+		require.Error(t, runErr)
+		assert.Contains(t, runErr.Error(), "cannot combine --all with a service name")
+	})
+}
+
+func TestRenderAllEnv(t *testing.T) {
+	resolved := map[string]map[string]string{
+		"api": {"GREETING": "hello", "DB_PASSWORD": "supersecret"},
+		"web": {"REGION": "westus"},
+	}
+	names := []string{"api", "web"}
+
+	t.Run("dotenv groups services under headers and masks secrets", func(t *testing.T) {
+		resetEnvFlags()
+		out, runErr := captureStdout(t, func() error {
+			return renderAllEnv(resolved, names, envFormatDotenv, true)
+		})
+		require.NoError(t, runErr)
+		assert.Contains(t, out, "# api")
+		assert.Contains(t, out, "GREETING=hello")
+		assert.Contains(t, out, "# web")
+		assert.Contains(t, out, "REGION=westus")
+		assert.NotContains(t, out, "supersecret")
+	})
+
+	t.Run("no-mask keeps raw secret values", func(t *testing.T) {
+		resetEnvFlags()
+		out, runErr := captureStdout(t, func() error {
+			return renderAllEnv(resolved, names, envFormatDotenv, false)
+		})
+		require.NoError(t, runErr)
+		assert.Contains(t, out, "DB_PASSWORD=supersecret")
+	})
+
+	t.Run("json emits object keyed by service", func(t *testing.T) {
+		resetEnvFlags()
+		out, runErr := captureStdout(t, func() error {
+			return renderAllEnv(resolved, names, envFormatJSON, false)
+		})
+		require.NoError(t, runErr)
+		var parsed map[string]map[string]string
+		require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+		assert.Equal(t, "hello", parsed["api"]["GREETING"])
+		assert.Equal(t, "westus", parsed["web"]["REGION"])
+	})
+
+	t.Run("no services reports an empty message", func(t *testing.T) {
+		resetEnvFlags()
+		out, runErr := captureStdout(t, func() error {
+			return renderAllEnv(map[string]map[string]string{}, nil, envFormatDotenv, true)
+		})
+		require.NoError(t, runErr)
+		assert.Contains(t, out, "No services are defined")
+	})
 }
 
 // resetEnvFlags clears the package-level env command flag state between runs so
@@ -188,6 +279,7 @@ func resetEnvFlags() {
 	envFormat = envFormatDotenv
 	envNoMask = false
 	envFile = ""
+	envAll = false
 	_ = cliout.SetFormat("default")
 }
 


### PR DESCRIPTION
## What

Adds an `--all` flag to `azd app env` that prints the resolved environment for every service defined in azure.yaml in a single run, instead of running the command once per service.

## Why

`azd app env <service>` prints one service at a time. When you want to eyeball the full picture (or diff two services), you have to run it repeatedly and stitch the output together yourself. `--all` does it in one pass.

## Behavior

- `azd app env --all` resolves and prints every service, sorted by name.
- dotenv and shell formats group each service under a `# <service>` header, separated by a blank line.
- json format (or the global `--json` flag) emits an object keyed by service name.
- Masking, `--no-mask`, and `--env-file` apply per service, same as the single-service path.
- `--all` combined with a positional service name is rejected with a clear error.
- Every service is resolved before any output is written, so a resolution failure never leaves a partial dump on screen.

## Testing

- `go build ./...`
- `go test ./src/cmd/app/commands/` (env command + renderer unit tests, all passing)

Closes #435
