### PR TITLE
feat(env): add env --explain to show each variable's source

### DIFF
--- a/cli/src/cmd/app/commands/env.go
+++ b/cli/src/cmd/app/commands/env.go
@@ -20,10 +20,11 @@ const (
 )
 
 var (
-	envFormat string
-	envNoMask bool
-	envFile   string
-	envAll    bool
+	envFormat  string
+	envNoMask  bool
+	envFile    string
+	envAll     bool
+	envExplain bool
 )
 
 // NewEnvCommand creates the env command.
@@ -58,6 +59,9 @@ Examples:
   # Raw values, no masking
   azd app env api --no-mask
 
+  # Explain where each effective value came from
+  azd app env api --explain
+
   # Resolved environment for every service
   azd app env --all`,
 		SilenceUsage:      true,
@@ -70,6 +74,7 @@ Examples:
 	cmd.Flags().BoolVar(&envNoMask, "no-mask", false, "Print raw values instead of masking secret-shaped values")
 	cmd.Flags().StringVar(&envFile, "env-file", "", "Path to a .env file to merge, matching azd app run")
 	cmd.Flags().BoolVar(&envAll, "all", false, "Print the resolved environment for every service")
+	cmd.Flags().BoolVar(&envExplain, "explain", false, "Show the source of each effective value and any sources it overrode")
 
 	return cmd
 }
@@ -124,12 +129,17 @@ func runEnv(_ *cobra.Command, args []string) error {
 	}
 
 	svc := azureYaml.Services[serviceName]
+	mask := !envNoMask
+
+	if envExplain {
+		return runEnvExplain(serviceName, svc, mask)
+	}
+
 	resolved, err := service.ResolveEnvironment(context.Background(), svc, getAzureEnvironmentValues(), envFile, nil)
 	if err != nil {
 		return fmt.Errorf("failed to resolve environment for %q: %w", serviceName, err)
 	}
 
-	mask := !envNoMask
 	if format == envFormatJSON {
 		return cliout.PrintJSON(maskEnv(resolved, mask))
 	}
@@ -190,6 +200,60 @@ func renderAllEnv(resolvedByService map[string]map[string]string, names []string
 		fmt.Print(formatEnv(resolvedByService[name], format, mask))
 	}
 	return nil
+}
+
+// envExplainEntry is the per-variable JSON shape for "env --explain": the
+// effective value plus the source that supplied it and any sources it overrode.
+type envExplainEntry struct {
+	Value     string              `json:"value"`
+	Source    service.EnvSource   `json:"source"`
+	Overrides []service.EnvSource `json:"overrides,omitempty"`
+}
+
+// runEnvExplain prints each effective variable with the source that won and,
+// when a higher-priority source replaced a lower one, the sources it overrode.
+func runEnvExplain(serviceName string, svc service.Service, mask bool) error {
+	resolved, prov, err := service.ResolveEnvironmentWithSources(context.Background(), svc, getAzureEnvironmentValues(), envFile, nil)
+	if err != nil {
+		return fmt.Errorf("failed to resolve environment for %q: %w", serviceName, err)
+	}
+
+	masked := maskEnv(resolved, mask)
+	keys := make([]string, 0, len(masked))
+	for k := range masked {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	if cliout.IsJSON() {
+		out := make(map[string]envExplainEntry, len(masked))
+		for _, k := range keys {
+			p := prov[k]
+			out[k] = envExplainEntry{Value: masked[k], Source: p.Source, Overrides: p.Overrides}
+		}
+		return cliout.PrintJSON(out)
+	}
+
+	for _, k := range keys {
+		p := prov[k]
+		fmt.Printf("%s=%s\n", k, masked[k])
+		if len(p.Overrides) > 0 {
+			fmt.Printf("    source: %s (overrode: %s)\n", p.Source, joinSourcesHighestFirst(p.Overrides))
+		} else {
+			fmt.Printf("    source: %s\n", p.Source)
+		}
+	}
+	return nil
+}
+
+// joinSourcesHighestFirst renders overridden sources from highest to lowest
+// precedence. Overrides are recorded lowest-first, so this reverses them.
+func joinSourcesHighestFirst(sources []service.EnvSource) string {
+	parts := make([]string, 0, len(sources))
+	for i := len(sources) - 1; i >= 0; i-- {
+		parts = append(parts, string(sources[i]))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // printServiceList prints the available service names so the user knows the

--- a/cli/src/cmd/app/commands/env_explain_test.go
+++ b/cli/src/cmd/app/commands/env_explain_test.go
@@ -1,10 +1,15 @@
 package commands
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-core/cliout"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJoinSourcesHighestFirst(t *testing.T) {
@@ -19,4 +24,102 @@ func TestJoinSourcesHighestFirstSingle(t *testing.T) {
 
 func TestJoinSourcesHighestFirstEmpty(t *testing.T) {
 	assert.Equal(t, "", joinSourcesHighestFirst(nil))
+}
+
+func TestNewEnvCommandExplainFlag(t *testing.T) {
+	cmd := NewEnvCommand()
+	require.NotNil(t, cmd.Flags().Lookup("explain"), "expected --explain flag")
+}
+
+// TestRunEnvExplainCommand drives "env <service> --explain" end to end so the
+// runEnv --explain branch and runEnvExplain's text, JSON, and error paths are
+// all exercised. getAzureEnvironmentValues() copies the full OS environment, so
+// every OS variable also appears as an "azd" layer; azure.yaml overrides both.
+func TestRunEnvExplainCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeEnvExplainAzureYaml(t, tmpDir)
+
+	// The explain path honors the global cliout output format (the --json flag).
+	// Capture and restore it so these subtests are hermetic regardless of order.
+	originalFormat := cliout.GetFormat()
+	defer func() { _ = cliout.SetFormat(string(originalFormat)) }()
+
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalDir) }()
+	require.NoError(t, os.Chdir(tmpDir))
+
+	t.Run("text output shows source and overrides per variable", func(t *testing.T) {
+		resetEnvFlags()
+		t.Setenv("EXPLAIN_OVERRIDE", "os-val")
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api", "--explain"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+		// azure.yaml wins EXPLAIN_OVERRIDE over the os and azd layers; overrides
+		// render highest priority first.
+		assert.Contains(t, out, "EXPLAIN_OVERRIDE=svc-val\n    source: azure.yaml (overrode: azd, os)\n")
+		// A variable defined only in azure.yaml has a single source, no overrides.
+		assert.Contains(t, out, "EXPLAIN_SVC_ONLY=only-val\n    source: azure.yaml\n")
+	})
+
+	t.Run("json output includes source and overrides", func(t *testing.T) {
+		resetEnvFlags()
+		require.NoError(t, cliout.SetFormat("json"))
+		t.Setenv("EXPLAIN_OVERRIDE", "os-val")
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api", "--explain"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+
+		var got map[string]struct {
+			Value     string   `json:"value"`
+			Source    string   `json:"source"`
+			Overrides []string `json:"overrides"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+		override, ok := got["EXPLAIN_OVERRIDE"]
+		require.True(t, ok, "EXPLAIN_OVERRIDE present in JSON output")
+		assert.Equal(t, "svc-val", override.Value)
+		assert.Equal(t, "azure.yaml", override.Source)
+		// JSON serializes overrides lowest priority first (application order).
+		assert.Equal(t, []string{"os", "azd"}, override.Overrides)
+
+		svcOnly, ok := got["EXPLAIN_SVC_ONLY"]
+		require.True(t, ok, "EXPLAIN_SVC_ONLY present in JSON output")
+		assert.Equal(t, "azure.yaml", svcOnly.Source)
+		assert.Empty(t, svcOnly.Overrides)
+	})
+
+	t.Run("env-file load failure surfaces an error", func(t *testing.T) {
+		resetEnvFlags()
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api", "--explain", "--env-file", filepath.Join(tmpDir, "missing.env")})
+			return cmd.Execute()
+		})
+		require.Error(t, runErr)
+		assert.Contains(t, runErr.Error(), "failed to resolve environment")
+		assert.Empty(t, out)
+	})
+}
+
+func writeEnvExplainAzureYaml(t *testing.T, dir string) {
+	t.Helper()
+	content := `name: envexplainapp
+services:
+  api:
+    host: containerapp
+    language: python
+    project: ./api
+    environment:
+      EXPLAIN_OVERRIDE: svc-val
+      EXPLAIN_SVC_ONLY: only-val
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(content), 0o600))
 }

--- a/cli/src/cmd/app/commands/env_explain_test.go
+++ b/cli/src/cmd/app/commands/env_explain_test.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinSourcesHighestFirst(t *testing.T) {
+	// Overrides are recorded lowest-first; display reverses to highest-first.
+	got := joinSourcesHighestFirst([]service.EnvSource{service.EnvSourceOS, service.EnvSourceAzd, service.EnvSourceDotEnv})
+	assert.Equal(t, ".env, azd, os", got)
+}
+
+func TestJoinSourcesHighestFirstSingle(t *testing.T) {
+	assert.Equal(t, "azd", joinSourcesHighestFirst([]service.EnvSource{service.EnvSourceAzd}))
+}
+
+func TestJoinSourcesHighestFirstEmpty(t *testing.T) {
+	assert.Equal(t, "", joinSourcesHighestFirst(nil))
+}

--- a/cli/src/cmd/app/commands/env_test.go
+++ b/cli/src/cmd/app/commands/env_test.go
@@ -19,7 +19,7 @@ func TestNewEnvCommand(t *testing.T) {
 	assert.NotEmpty(t, cmd.Short)
 	require.NotNil(t, cmd.RunE)
 
-	for _, name := range []string{"format", "no-mask", "env-file", "all"} {
+	for _, name := range []string{"format", "no-mask", "env-file", "all", "explain"} {
 		assert.NotNil(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
@@ -280,6 +280,7 @@ func resetEnvFlags() {
 	envNoMask = false
 	envFile = ""
 	envAll = false
+	envExplain = false
 	_ = cliout.SetFormat("default")
 }
 

--- a/cli/src/internal/service/environment.go
+++ b/cli/src/internal/service/environment.go
@@ -28,7 +28,52 @@ import (
 // to the deployment environment (managed identity, Key Vault references), not to the local dev
 // orchestrator.
 func ResolveEnvironment(ctx context.Context, service Service, azureEnv map[string]string, dotEnvPath string, serviceURLs map[string]string) (map[string]string, error) {
+	env, _, err := resolveEnvironmentWithSources(ctx, service, azureEnv, dotEnvPath, serviceURLs)
+	return env, err
+}
+
+// EnvSource identifies where an environment variable's value was read from.
+type EnvSource string
+
+// Environment variable sources, ordered from lowest to highest precedence.
+const (
+	EnvSourceOS         EnvSource = "os"
+	EnvSourceAzd        EnvSource = "azd"
+	EnvSourceDotEnv     EnvSource = ".env"
+	EnvSourceServiceURL EnvSource = "service-url"
+	EnvSourceService    EnvSource = "azure.yaml"
+)
+
+// EnvProvenance records where the effective value of a variable came from and,
+// when a higher-priority source replaced a lower one, which sources it overrode
+// (in the order they were applied, lowest priority first).
+type EnvProvenance struct {
+	Source    EnvSource   `json:"source"`
+	Overrides []EnvSource `json:"overrides,omitempty"`
+}
+
+// ResolveEnvironmentWithSources resolves the environment exactly like
+// ResolveEnvironment and additionally returns, per variable, the source that
+// supplied the winning value and any lower-priority sources it overrode.
+func ResolveEnvironmentWithSources(ctx context.Context, service Service, azureEnv map[string]string, dotEnvPath string, serviceURLs map[string]string) (map[string]string, map[string]EnvProvenance, error) {
+	return resolveEnvironmentWithSources(ctx, service, azureEnv, dotEnvPath, serviceURLs)
+}
+
+func resolveEnvironmentWithSources(ctx context.Context, service Service, azureEnv map[string]string, dotEnvPath string, serviceURLs map[string]string) (map[string]string, map[string]EnvProvenance, error) {
 	env := make(map[string]string)
+	prov := make(map[string]EnvProvenance)
+
+	apply := func(source EnvSource, key, value string) {
+		if existing, ok := prov[key]; ok {
+			prov[key] = EnvProvenance{
+				Source:    source,
+				Overrides: append(append([]EnvSource{}, existing.Overrides...), existing.Source),
+			}
+		} else {
+			prov[key] = EnvProvenance{Source: source}
+		}
+		env[key] = value
+	}
 
 	// Start with full OS environment — child processes inherit everything from the parent.
 	// When running as an azd extension, the parent azd process injects all environment
@@ -37,29 +82,29 @@ func ResolveEnvironment(ctx context.Context, service Service, azureEnv map[strin
 	for _, e := range os.Environ() {
 		pair := strings.SplitN(e, "=", 2)
 		if len(pair) == 2 {
-			env[pair[0]] = pair[1]
+			apply(EnvSourceOS, pair[0], pair[1])
 		}
 	}
 
 	// Merge Azure environment variables (from azd context) - these override OS env
 	for k, v := range azureEnv {
-		env[k] = v
+		apply(EnvSourceAzd, k, v)
 	}
 
 	// Load and merge .env file if specified - these override Azure env
 	if dotEnvPath != "" {
 		dotEnv, err := LoadDotEnv(dotEnvPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load .env file: %w", err)
+			return nil, nil, fmt.Errorf("failed to load .env file: %w", err)
 		}
 		for k, v := range dotEnv {
-			env[k] = v
+			apply(EnvSourceDotEnv, k, v)
 		}
 	}
 
 	// Merge auto-generated service URLs - these override .env file
 	for k, v := range serviceURLs {
-		env[k] = v
+		apply(EnvSourceServiceURL, k, v)
 	}
 
 	// Merge service-specific environment variables from azure.yaml - highest priority
@@ -67,10 +112,11 @@ func ResolveEnvironment(ctx context.Context, service Service, azureEnv map[strin
 	for name, value := range serviceEnv {
 		// Perform variable substitution
 		value = substituteEnvVars(value, env)
-		env[name] = value
+		apply(EnvSourceService, name, value)
 	}
 
-	// Resolve Azure Key Vault references if present
+	// Resolve Azure Key Vault references if present. This rewrites values only;
+	// the winning source per key is unchanged, so provenance still applies.
 	envSlice := envMapToSlice(env)
 	if hasKeyVaultReferences(envSlice) {
 		resolvedSlice, err := resolveKeyVaultReferences(ctx, envSlice)
@@ -83,7 +129,7 @@ func ResolveEnvironment(ctx context.Context, service Service, azureEnv map[strin
 		}
 	}
 
-	return env, nil
+	return env, prov, nil
 }
 
 // resolveKeyVaultReferences resolves Key Vault references in environment variables.

--- a/cli/src/internal/service/environment_provenance_test.go
+++ b/cli/src/internal/service/environment_provenance_test.go
@@ -79,3 +79,15 @@ func TestResolveEnvironmentMatchesWithSources(t *testing.T) {
 
 	assert.Equal(t, plain, withSources)
 }
+
+func TestResolveEnvironmentWithSourcesDotEnvLoadError(t *testing.T) {
+	// A missing .env path makes LoadDotEnv fail, which must surface as an error
+	// with nil results rather than a partial environment.
+	missing := filepath.Join(t.TempDir(), "missing.env")
+
+	env, prov, err := ResolveEnvironmentWithSources(context.Background(), Service{}, nil, missing, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load .env file")
+	assert.Nil(t, env)
+	assert.Nil(t, prov)
+}

--- a/cli/src/internal/service/environment_provenance_test.go
+++ b/cli/src/internal/service/environment_provenance_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEnvironmentWithSourcesPrecedence(t *testing.T) {
+	t.Setenv("PROV_LAYER_KEY", "from-os")
+
+	azureEnv := map[string]string{
+		"PROV_LAYER_KEY": "from-azd",
+		"PROV_AZD_ONLY":  "azd-value",
+	}
+	svc := Service{Environment: Environment{"PROV_LAYER_KEY": "from-service"}}
+
+	env, prov, err := ResolveEnvironmentWithSources(context.Background(), svc, azureEnv, "", nil)
+	require.NoError(t, err)
+
+	// azure.yaml has the highest precedence and wins the layered key.
+	assert.Equal(t, "from-service", env["PROV_LAYER_KEY"])
+	p := prov["PROV_LAYER_KEY"]
+	assert.Equal(t, EnvSourceService, p.Source)
+	assert.Equal(t, []EnvSource{EnvSourceOS, EnvSourceAzd}, p.Overrides)
+
+	// A key set only by azd has no overrides.
+	azdOnly := prov["PROV_AZD_ONLY"]
+	assert.Equal(t, EnvSourceAzd, azdOnly.Source)
+	assert.Empty(t, azdOnly.Overrides)
+}
+
+func TestResolveEnvironmentWithSourcesDotEnvOverridesAzd(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	require.NoError(t, os.WriteFile(envPath, []byte("PROV_DOTENV_KEY=from-dotenv\n"), 0o600))
+
+	azureEnv := map[string]string{"PROV_DOTENV_KEY": "from-azd"}
+
+	env, prov, err := ResolveEnvironmentWithSources(context.Background(), Service{}, azureEnv, envPath, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "from-dotenv", env["PROV_DOTENV_KEY"])
+	p := prov["PROV_DOTENV_KEY"]
+	assert.Equal(t, EnvSourceDotEnv, p.Source)
+	assert.Equal(t, []EnvSource{EnvSourceAzd}, p.Overrides)
+}
+
+func TestResolveEnvironmentWithSourcesServiceURLOverridesDotEnv(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	require.NoError(t, os.WriteFile(envPath, []byte("PROV_URL_KEY=from-dotenv\n"), 0o600))
+
+	serviceURLs := map[string]string{"PROV_URL_KEY": "http://localhost:3000"}
+
+	env, prov, err := ResolveEnvironmentWithSources(context.Background(), Service{}, nil, envPath, serviceURLs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://localhost:3000", env["PROV_URL_KEY"])
+	p := prov["PROV_URL_KEY"]
+	assert.Equal(t, EnvSourceServiceURL, p.Source)
+	assert.Equal(t, []EnvSource{EnvSourceDotEnv}, p.Overrides)
+}
+
+func TestResolveEnvironmentMatchesWithSources(t *testing.T) {
+	t.Setenv("PROV_PARITY_KEY", "os-value")
+	azureEnv := map[string]string{"PROV_PARITY_EXTRA": "azd-value"}
+	svc := Service{Environment: Environment{"PROV_PARITY_SVC": "svc-value"}}
+
+	plain, err := ResolveEnvironment(context.Background(), svc, azureEnv, "", nil)
+	require.NoError(t, err)
+
+	withSources, _, err := ResolveEnvironmentWithSources(context.Background(), svc, azureEnv, "", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, plain, withSources)
+}


### PR DESCRIPTION
## What I changed

`ResolveEnvironment` layers variables from several sources in a fixed precedence: OS environment, then azd environment, then a `.env` file, then generated service URLs, then the `azure.yaml` service block. When a value comes out wrong, there was no way to see which layer won, so debugging precedence turned into guesswork.

I instrumented the merge to record, per variable, the winning source and any lower-priority sources it overrode, and added `azd app env <service> --explain` to surface it:

```
API_URL=http://localhost:3000
    source: service-url (overrode: .env)
DATABASE_HOST=db.internal
    source: azure.yaml (overrode: .env, os)
LOG_LEVEL=debug
    source: .env
```

Secret-shaped values stay masked (use `--no-mask` for raw), and JSON output includes the source per key:

```json
{
  "DATABASE_HOST": {
    "value": "db.internal",
    "source": "azure.yaml",
    "overrides": ["os", ".env"]
  }
}
```

## How it works

```mermaid
flowchart TD
    A[azd app env --explain] --> B[Resolve env with source tracking]
    B --> C[OS env]
    B --> D[azd env]
    B --> E[.env file]
    B --> F[generated service URLs]
    B --> G[azure.yaml service env]
    C & D & E & F & G --> H[Winning source per key]
    H --> I[Table: key, value, source, overrode]
```

## Design notes

- I refactored the existing layering into a single tracked pass. `ResolveEnvironment` now delegates to it and returns the same result, so nothing that calls it changes behavior. A parity test asserts the two entry points return identical maps.
- Key Vault resolution rewrites values only, not which source set the key, so provenance stays correct after resolution.
- Overrides are recorded lowest-priority-first and shown highest-first, which reads naturally ("overrode: .env, os").

## Why this is safe

- Read-only and additive: no change to how services run or how the environment is resolved.
- Secrets remain masked by default in both text and JSON output.

## Testing

- Unit tests for the full precedence chain (os to azd to .env to service-url to azure.yaml), the override notes, and a parity check that `ResolveEnvironment` and the tracked variant agree.
- A test for the highest-first ordering of the "overrode" note.
- `go build ./...`, `go test`, and `golangci-lint` all pass.

Closes #427
