### PR TITLE
feat(graph): add --focus to show one service and its connected nodes

### DIFF
--- a/cli/src/cmd/app/commands/graph.go
+++ b/cli/src/cmd/app/commands/graph.go
@@ -24,6 +24,7 @@ const (
 type graphOptions struct {
 	output     string
 	outputFile string
+	focus      string
 	writer     io.Writer
 }
 
@@ -60,6 +61,9 @@ Use --format to change the output. text and json print to stdout. mermaid and do
 emit a diagram you can drop into a README or an architecture doc. Combine with
 --output-file to write the result to a file instead of stdout.
 
+Pass --focus <service> to narrow the graph to one service, everything it depends
+on, and everything that depends on it. This works with every output format.
+
 Examples:
   # Human-readable text (default)
   azd app graph
@@ -68,7 +72,10 @@ Examples:
   azd app graph --format mermaid --output-file docs/services.mmd
 
   # Graphviz DOT to stdout
-  azd app graph --format dot`,
+  azd app graph --format dot
+
+  # Just the api service and its connected nodes
+  azd app graph --focus api`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGraph(opts)
@@ -76,6 +83,7 @@ Examples:
 	}
 	cmd.Flags().StringVarP(&opts.output, "output", "o", graphOutputText, "Output format: text, json, mermaid, or dot")
 	cmd.Flags().StringVar(&opts.outputFile, "output-file", "", "Write output to this file instead of stdout")
+	cmd.Flags().StringVar(&opts.focus, "focus", "", "Limit the graph to a service, its dependencies, and its dependents")
 	return cmd
 }
 
@@ -114,6 +122,13 @@ func runGraph(opts *graphOptions) error {
 	}
 	result := buildGraphResult(projectDir, graph)
 
+	if opts.focus != "" {
+		result, err = focusGraphResult(result, opts.focus)
+		if err != nil {
+			return err
+		}
+	}
+
 	// When --output-file is set, buffer the rendered output and write it to disk.
 	writer := opts.writer
 	var buf *bytes.Buffer
@@ -149,6 +164,87 @@ func renderGraph(w io.Writer, format string, result graphResult) error {
 		printGraphText(w, result)
 	}
 	return nil
+}
+
+// focusGraphResult reduces the graph to the focused node, everything it depends
+// on (transitively), and everything that depends on it (transitively). Node
+// metadata is preserved; startup levels are filtered to the focused nodes with
+// empty levels removed. It returns an error if the focus name is not a node.
+func focusGraphResult(result graphResult, focus string) (graphResult, error) {
+	known := make(map[string]struct{}, len(result.Nodes))
+	for _, n := range result.Nodes {
+		known[n.Name] = struct{}{}
+	}
+	if _, ok := known[focus]; !ok {
+		names := make([]string, 0, len(result.Nodes))
+		for _, n := range result.Nodes {
+			names = append(names, n.Name)
+		}
+		sort.Strings(names)
+		return graphResult{}, fmt.Errorf("service %q not found in the graph. Available: %s",
+			focus, strings.Join(names, ", "))
+	}
+
+	// deps maps a node to the nodes it depends on; dependents is the reverse.
+	deps := make(map[string][]string)
+	dependents := make(map[string][]string)
+	for _, e := range result.Edges {
+		deps[e.From] = append(deps[e.From], e.To)
+		dependents[e.To] = append(dependents[e.To], e.From)
+	}
+
+	keep := map[string]struct{}{focus: {}}
+	collectReachable(focus, deps, keep)
+	collectReachable(focus, dependents, keep)
+
+	nodes := make([]graphNode, 0, len(keep))
+	for _, n := range result.Nodes {
+		if _, ok := keep[n.Name]; ok {
+			nodes = append(nodes, n)
+		}
+	}
+
+	edges := make([]graphEdge, 0, len(result.Edges))
+	for _, e := range result.Edges {
+		_, okFrom := keep[e.From]
+		_, okTo := keep[e.To]
+		if okFrom && okTo {
+			edges = append(edges, e)
+		}
+	}
+
+	levels := make([][]string, 0, len(result.Levels))
+	for _, level := range result.Levels {
+		filtered := make([]string, 0, len(level))
+		for _, name := range level {
+			if _, ok := keep[name]; ok {
+				filtered = append(filtered, name)
+			}
+		}
+		if len(filtered) > 0 {
+			levels = append(levels, filtered)
+		}
+	}
+
+	return graphResult{
+		Project: result.Project,
+		Nodes:   nodes,
+		Edges:   edges,
+		Levels:  levels,
+	}, nil
+}
+
+// collectReachable does a depth-first walk over adj starting at start, adding
+// every reachable node to keep. Nodes already in keep are skipped, so cycles
+// terminate.
+func collectReachable(start string, adj map[string][]string, keep map[string]struct{}) {
+	for _, next := range adj[start] {
+		if _, ok := keep[next]; ok {
+			continue
+		}
+		keep[next] = struct{}{}
+		collectReachable(next, adj, keep)
+	}
 }
 
 func buildGraphResult(projectDir string, graph *service.DependencyGraph) graphResult {

--- a/cli/src/cmd/app/commands/graph_test.go
+++ b/cli/src/cmd/app/commands/graph_test.go
@@ -22,6 +22,178 @@ func TestNewGraphCommand(t *testing.T) {
 	if cmd.Flags().Lookup("output") == nil {
 		t.Fatal("output flag not found")
 	}
+	if cmd.Flags().Lookup("focus") == nil {
+		t.Fatal("focus flag not found")
+	}
+}
+
+func focusSampleGraph() graphResult {
+	return graphResult{
+		Project: "project",
+		Nodes: []graphNode{
+			{Name: "api", Type: "service", Level: 1},
+			{Name: "db", Type: "resource", Level: 0},
+			{Name: "web", Type: "service", Level: 2},
+			{Name: "worker", Type: "service", Level: 1},
+		},
+		Edges: []graphEdge{
+			{From: "api", To: "db"},
+			{From: "web", To: "api"},
+			{From: "worker", To: "db"},
+		},
+		Levels: [][]string{{"db"}, {"api", "worker"}, {"web"}},
+	}
+}
+
+func nodeNameSet(nodes []graphNode) map[string]bool {
+	set := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		set[n.Name] = true
+	}
+	return set
+}
+
+func TestFocusGraphResult(t *testing.T) {
+	t.Run("focus keeps dependencies and dependents", func(t *testing.T) {
+		got, err := focusGraphResult(focusSampleGraph(), "api")
+		if err != nil {
+			t.Fatalf("focusGraphResult failed: %v", err)
+		}
+		names := nodeNameSet(got.Nodes)
+		for _, want := range []string{"api", "db", "web"} {
+			if !names[want] {
+				t.Fatalf("expected %q in focused nodes, got %#v", want, got.Nodes)
+			}
+		}
+		if names["worker"] {
+			t.Fatalf("worker should be excluded when focusing api, got %#v", got.Nodes)
+		}
+		// Only edges between kept nodes survive: api->db and web->api.
+		if len(got.Edges) != 2 {
+			t.Fatalf("edges = %d, want 2: %#v", len(got.Edges), got.Edges)
+		}
+		for _, e := range got.Edges {
+			if e.From == "worker" || e.To == "worker" {
+				t.Fatalf("worker edge should be dropped: %#v", e)
+			}
+		}
+	})
+
+	t.Run("focus on a leaf resource pulls in every dependent", func(t *testing.T) {
+		got, err := focusGraphResult(focusSampleGraph(), "db")
+		if err != nil {
+			t.Fatalf("focusGraphResult failed: %v", err)
+		}
+		if len(got.Nodes) != 4 {
+			t.Fatalf("nodes = %d, want 4 (db reaches every dependent): %#v", len(got.Nodes), got.Nodes)
+		}
+	})
+
+	t.Run("empty levels are dropped", func(t *testing.T) {
+		got, err := focusGraphResult(focusSampleGraph(), "worker")
+		if err != nil {
+			t.Fatalf("focusGraphResult failed: %v", err)
+		}
+		for _, level := range got.Levels {
+			if len(level) == 0 {
+				t.Fatalf("focused levels should not contain empty entries: %#v", got.Levels)
+			}
+		}
+	})
+
+	t.Run("unknown focus errors and lists available", func(t *testing.T) {
+		_, err := focusGraphResult(focusSampleGraph(), "nope")
+		if err == nil {
+			t.Fatal("expected error for unknown focus")
+		}
+		if !strings.Contains(err.Error(), "not found in the graph") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(err.Error(), "api") {
+			t.Fatalf("error should list available nodes: %v", err)
+		}
+	})
+}
+
+func TestRunGraphFocus(t *testing.T) {
+	dir := t.TempDir()
+	azureYaml := []byte(`
+name: graph-test
+services:
+  api:
+    host: local
+    language: go
+    project: ./api
+    uses:
+      - db
+  web:
+    host: local
+    language: node
+    project: ./web
+    uses:
+      - api
+  lonely:
+    host: local
+    language: go
+    project: ./lonely
+resources:
+  db:
+    type: postgres
+`)
+	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), azureYaml, 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+	for _, sub := range []string{"api", "web", "lonely"} {
+		if err := os.Mkdir(filepath.Join(dir, sub), 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+	err := runGraph(&graphOptions{output: graphOutputJSON, focus: "api", writer: &buf})
+	if err != nil {
+		t.Fatalf("runGraph failed: %v", err)
+	}
+	var got graphResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	names := nodeNameSet(got.Nodes)
+	if !names["api"] || !names["db"] || !names["web"] {
+		t.Fatalf("focused graph should contain api, db, web: %#v", got.Nodes)
+	}
+	if names["lonely"] {
+		t.Fatalf("lonely service should be excluded when focusing api: %#v", got.Nodes)
+	}
+}
+
+func TestRunGraphFocusUnknown(t *testing.T) {
+	dir := t.TempDir()
+	azureYaml := []byte(`
+name: graph-test
+services:
+  api:
+    host: local
+    language: go
+    project: ./api
+`)
+	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), azureYaml, 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "api"), 0o750); err != nil {
+		t.Fatalf("mkdir api: %v", err)
+	}
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+	err := runGraph(&graphOptions{output: graphOutputText, focus: "missing", writer: &buf})
+	if err == nil {
+		t.Fatal("expected error for unknown focus service")
+	}
+	if !strings.Contains(err.Error(), "not found in the graph") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestBuildGraphResult(t *testing.T) {


### PR DESCRIPTION
## What

Adds a `--focus <service>` flag to `azd app graph` that narrows the graph to one service, everything it depends on, and everything that depends on it.

## Why

On a project with more than a handful of services, the full graph gets noisy. When you are working on one service you usually only care about its neighborhood: what it needs to come up, and what breaks if it goes down. `--focus` gives you exactly that slice.

## Behavior

- `azd app graph --focus api` keeps `api`, its transitive dependencies, and its transitive dependents.
- Edges are kept only when both endpoints are in the focused set.
- Startup levels are filtered to the focused nodes, and empty levels are dropped.
- An unknown focus name returns an error that lists the valid node names.
- Works with every output format: text, json, mermaid, and dot.

Example:

```
azd app graph --focus api --format mermaid
```

## Testing

- `go build ./...`
- `go test ./src/cmd/app/commands/ -run Graph` (focus unit tests + runGraph integration, all passing)

Closes #434
