### PR TITLE
feat(run): warn when a service exceeds CPU or memory thresholds

### DIFF
--- a/cli/docs/schema/azure.yaml.md
+++ b/cli/docs/schema/azure.yaml.md
@@ -463,6 +463,28 @@ services:
 
 See [Service States and Health](../features/service-states.md) for detailed documentation on service types, modes, and health states.
 
+#### `resources` ⭐ NEW
+**Type:** `object` (optional)
+
+Per-service CPU and memory alert thresholds for local monitoring. When a running service exceeds a configured threshold, `azd app run` raises a throttled warning and the service info exposes over-threshold indicators. Omit a field or set it to `0` to skip that check. This is different from the top-level `resources` list of Azure resources.
+
+**Properties:**
+- **`cpuPercent`**: Maximum CPU usage as a percentage of a single core. Values above 100 are allowed for multi-core work. `0` disables the CPU check.
+- **`memoryMB`**: Maximum resident memory in megabytes. `0` disables the memory check.
+
+```yaml
+services:
+  api:
+    language: node
+    project: ./api
+    ports: ["3000"]
+    resources:
+      cpuPercent: 85    # warn when the api uses more than 85% of a core
+      memoryMB: 512     # warn when the api holds more than 512 MB resident
+```
+
+Warnings are debounced per service and per dimension, so a service that hovers just over a limit does not flood the console. Thresholds only affect local `azd app run` monitoring; they do not change how the service is deployed to Azure.
+
 #### `test` ⭐ NEW
 **Type:** `object` (optional)
 

--- a/cli/src/internal/resourcealert/resourcealert.go
+++ b/cli/src/internal/resourcealert/resourcealert.go
@@ -1,0 +1,113 @@
+// Package resourcealert evaluates per-service CPU and memory samples against
+// optional thresholds and reports the ones that are exceeded. It backs the
+// per-service resource warnings raised during a run.
+//
+// Threshold comparison is a pure function (Threshold.Exceeds), so callers can
+// surface an over-threshold indicator without side effects. Engine adds
+// per-service, per-dimension debounce so a service that hovers just over a
+// limit does not flood the console with repeated warnings.
+package resourcealert
+
+import (
+	"sync"
+	"time"
+)
+
+const bytesPerMB = 1024 * 1024
+
+// DefaultDebounce is the minimum time between warnings for the same service and
+// resource dimension.
+const DefaultDebounce = 30 * time.Second
+
+// Kind identifies which resource dimension a breach is about.
+type Kind string
+
+// Resource dimensions that can be exceeded.
+const (
+	KindCPU    Kind = "cpu"
+	KindMemory Kind = "memory"
+)
+
+// Threshold defines optional per-service resource limits. A zero field means
+// that dimension is not checked.
+type Threshold struct {
+	// CPUPercent is the maximum CPU usage as a percentage of a single core.
+	CPUPercent float64
+	// MemoryMB is the maximum resident memory in megabytes.
+	MemoryMB uint64
+}
+
+// Configured reports whether the threshold checks at least one dimension.
+func (t Threshold) Configured() bool {
+	return t.CPUPercent > 0 || t.MemoryMB > 0
+}
+
+// Breach describes a single threshold that was exceeded. Value and Limit use
+// percent for CPU and megabytes for memory.
+type Breach struct {
+	Service string
+	Kind    Kind
+	Value   float64
+	Limit   float64
+	Time    time.Time
+}
+
+// Exceeds returns the breaches for one sample, ignoring debounce. It is a pure
+// comparison suitable for computing an over-threshold indicator.
+func (t Threshold) Exceeds(service string, cpuPercent float64, memoryBytes uint64, now time.Time) []Breach {
+	var breaches []Breach
+	if t.CPUPercent > 0 && cpuPercent > t.CPUPercent {
+		breaches = append(breaches, Breach{Service: service, Kind: KindCPU, Value: cpuPercent, Limit: t.CPUPercent, Time: now})
+	}
+	if t.MemoryMB > 0 {
+		memMB := float64(memoryBytes) / bytesPerMB
+		if memMB > float64(t.MemoryMB) {
+			breaches = append(breaches, Breach{Service: service, Kind: KindMemory, Value: memMB, Limit: float64(t.MemoryMB), Time: now})
+		}
+	}
+	return breaches
+}
+
+// Engine adds per-service, per-dimension debounce on top of Threshold.Exceeds.
+// It is safe for concurrent use.
+type Engine struct {
+	mu        sync.Mutex
+	debounce  time.Duration
+	lastFired map[string]time.Time
+}
+
+// NewEngine creates an engine with the given debounce window. A non-positive
+// debounce falls back to DefaultDebounce.
+func NewEngine(debounce time.Duration) *Engine {
+	if debounce <= 0 {
+		debounce = DefaultDebounce
+	}
+	return &Engine{debounce: debounce, lastFired: make(map[string]time.Time)}
+}
+
+// Evaluate returns the breaches that should fire at time now, suppressing
+// repeats within the debounce window for the same service and dimension. It
+// returns nil when the threshold is unconfigured or nothing is exceeded.
+func (e *Engine) Evaluate(service string, cpuPercent float64, memoryBytes uint64, threshold Threshold, now time.Time) []Breach {
+	if e == nil || !threshold.Configured() {
+		return nil
+	}
+	candidate := threshold.Exceeds(service, cpuPercent, memoryBytes, now)
+	if len(candidate) == 0 {
+		return nil
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var fired []Breach
+	for _, b := range candidate {
+		key := string(b.Kind) + "\x00" + b.Service
+		if last, ok := e.lastFired[key]; ok && now.Sub(last) < e.debounce {
+			continue
+		}
+		e.lastFired[key] = now
+		fired = append(fired, b)
+	}
+	return fired
+}

--- a/cli/src/internal/resourcealert/resourcealert_test.go
+++ b/cli/src/internal/resourcealert/resourcealert_test.go
@@ -1,0 +1,99 @@
+package resourcealert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThresholdConfigured(t *testing.T) {
+	assert.False(t, Threshold{}.Configured())
+	assert.True(t, Threshold{CPUPercent: 80}.Configured())
+	assert.True(t, Threshold{MemoryMB: 512}.Configured())
+}
+
+func TestThresholdExceeds(t *testing.T) {
+	now := time.Now()
+	const mb = 1024 * 1024
+
+	tests := []struct {
+		name      string
+		threshold Threshold
+		cpu       float64
+		memBytes  uint64
+		wantKinds []Kind
+	}{
+		{"nothing configured", Threshold{}, 999, 999 * mb, nil},
+		{"cpu under", Threshold{CPUPercent: 80}, 50, 0, nil},
+		{"cpu over", Threshold{CPUPercent: 80}, 90, 0, []Kind{KindCPU}},
+		{"cpu exactly at limit not over", Threshold{CPUPercent: 80}, 80, 0, nil},
+		{"memory under", Threshold{MemoryMB: 512}, 0, 400 * mb, nil},
+		{"memory over", Threshold{MemoryMB: 512}, 0, 600 * mb, []Kind{KindMemory}},
+		{"both over", Threshold{CPUPercent: 80, MemoryMB: 512}, 95, 600 * mb, []Kind{KindCPU, KindMemory}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			breaches := tt.threshold.Exceeds("api", tt.cpu, tt.memBytes, now)
+			var kinds []Kind
+			for _, b := range breaches {
+				kinds = append(kinds, b.Kind)
+				assert.Equal(t, "api", b.Service)
+			}
+			assert.Equal(t, tt.wantKinds, kinds)
+		})
+	}
+}
+
+func TestThresholdExceedsReportsValues(t *testing.T) {
+	now := time.Now()
+	breaches := Threshold{CPUPercent: 80, MemoryMB: 100}.Exceeds("api", 90, 200*1024*1024, now)
+	assert.Len(t, breaches, 2)
+	for _, b := range breaches {
+		switch b.Kind {
+		case KindCPU:
+			assert.Equal(t, 90.0, b.Value)
+			assert.Equal(t, 80.0, b.Limit)
+		case KindMemory:
+			assert.Equal(t, 200.0, b.Value)
+			assert.Equal(t, 100.0, b.Limit)
+		}
+	}
+}
+
+func TestEngineEvaluateThrottles(t *testing.T) {
+	e := NewEngine(30 * time.Second)
+	threshold := Threshold{CPUPercent: 80}
+	base := time.Now()
+
+	first := e.Evaluate("api", 90, 0, threshold, base)
+	assert.Len(t, first, 1, "first breach should fire")
+
+	within := e.Evaluate("api", 95, 0, threshold, base.Add(10*time.Second))
+	assert.Empty(t, within, "repeat within debounce should be suppressed")
+
+	after := e.Evaluate("api", 95, 0, threshold, base.Add(31*time.Second))
+	assert.Len(t, after, 1, "breach after debounce window should fire again")
+}
+
+func TestEngineEvaluateSeparateServicesAndKinds(t *testing.T) {
+	e := NewEngine(30 * time.Second)
+	threshold := Threshold{CPUPercent: 80, MemoryMB: 100}
+	now := time.Now()
+
+	api := e.Evaluate("api", 90, 200*1024*1024, threshold, now)
+	assert.Len(t, api, 2, "cpu and memory are throttled independently")
+
+	worker := e.Evaluate("worker", 90, 0, threshold, now)
+	assert.Len(t, worker, 1, "a different service has its own throttle state")
+}
+
+func TestEngineEvaluateUnconfigured(t *testing.T) {
+	e := NewEngine(0)
+	assert.Empty(t, e.Evaluate("api", 9999, 9999, Threshold{}, time.Now()))
+}
+
+func TestNilEngineSafe(t *testing.T) {
+	var e *Engine
+	assert.Empty(t, e.Evaluate("api", 90, 0, Threshold{CPUPercent: 80}, time.Now()))
+}

--- a/cli/src/internal/service/resource_thresholds_test.go
+++ b/cli/src/internal/service/resource_thresholds_test.go
@@ -1,0 +1,43 @@
+package service_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAzureYaml_ResourceThresholds(t *testing.T) {
+	yamlContent := `name: resource-test
+services:
+  api:
+    host: containerapp
+    image: nginx:latest
+    ports: ["8080"]
+    resources:
+      cpuPercent: 85
+      memoryMB: 1024
+  worker:
+    host: containerapp
+    image: worker:latest
+`
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "azure.yaml"), []byte(yamlContent), 0o600))
+
+	parsed, err := service.ParseAzureYaml(tmpDir)
+	require.NoError(t, err)
+
+	api, ok := parsed.Services["api"]
+	require.True(t, ok)
+	require.NotNil(t, api.Resources)
+	assert.Equal(t, 85.0, api.Resources.CPUPercent)
+	assert.Equal(t, uint64(1024), api.Resources.MemoryMB)
+
+	// A service without a resources block leaves it nil.
+	worker, ok := parsed.Services["worker"]
+	require.True(t, ok)
+	assert.Nil(t, worker.Resources)
+}

--- a/cli/src/internal/service/types.go
+++ b/cli/src/internal/service/types.go
@@ -140,9 +140,22 @@ type Service struct {
 	Type               string              `yaml:"type,omitempty"`        // Service type: "http", "tcp", "process". Default: "http" if ports defined, "process" otherwise.
 	Mode               string              `yaml:"mode,omitempty"`        // Run mode (for type=process): "watch", "build", "daemon", "task". Default: "daemon".
 	Restart            *RestartConfig      `yaml:"restart,omitempty"`     // Optional auto-restart policy for unexpected service exits.
+	Resources          *ResourceThresholds `yaml:"resources,omitempty"`   // Optional per-service CPU/memory alert thresholds.
 	Local              *LocalServiceConfig `yaml:"local,omitempty"`       // Local development configuration
 	Azure              *AzureServiceConfig `yaml:"azure,omitempty"`       // Azure deployment configuration
 	URL                string              `yaml:"url,omitempty"`         // DEPRECATED: Use azure.customUrl instead. Custom URL for accessing the service.
+}
+
+// ResourceThresholds sets optional per-service resource limits that raise a
+// throttled warning during a run when a service exceeds them. A zero field is
+// not checked.
+type ResourceThresholds struct {
+	// CPUPercent is the maximum CPU usage as a percentage of a single core; it
+	// can exceed 100 for multi-core work. Zero disables the CPU check.
+	CPUPercent float64 `yaml:"cpuPercent,omitempty" json:"cpuPercent,omitempty"`
+	// MemoryMB is the maximum resident memory in megabytes. Zero disables the
+	// memory check.
+	MemoryMB uint64 `yaml:"memoryMB,omitempty" json:"memoryMB,omitempty"`
 }
 
 // RestartConfig represents the user-configurable restart behavior in azure.yaml.
@@ -194,6 +207,7 @@ type serviceRaw struct {
 	Type        string              `yaml:"type,omitempty"`
 	Mode        string              `yaml:"mode,omitempty"`
 	Restart     *RestartConfig      `yaml:"restart,omitempty"`
+	Resources   *ResourceThresholds `yaml:"resources,omitempty"`
 	Local       *LocalServiceConfig `yaml:"local,omitempty"`
 	Azure       *AzureServiceConfig `yaml:"azure,omitempty"`
 	URL         string              `yaml:"url,omitempty"`
@@ -221,6 +235,7 @@ func (s *Service) UnmarshalYAML(unmarshal func(any) error) error {
 	s.Type = raw.Type
 	s.Mode = raw.Mode
 	s.Restart = raw.Restart
+	s.Resources = raw.Resources
 	s.Local = raw.Local
 	s.Azure = raw.Azure
 	s.URL = raw.URL

--- a/cli/src/internal/serviceinfo/serviceinfo.go
+++ b/cli/src/internal/serviceinfo/serviceinfo.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jongio/azd-app/cli/src/internal/resourcealert"
 	"github.com/jongio/azd-app/cli/src/internal/resourcesampler"
 	"github.com/jongio/azd-app/cli/src/internal/service"
 	"github.com/jongio/azd-core/registry"
@@ -25,6 +26,10 @@ var (
 	// as a package var so tests can exercise the merge path deterministically
 	// without depending on live process sampling.
 	sampleResourceUsage = resourcesampler.Sample
+
+	// resourceAlertEngine debounces per-service resource threshold warnings so a
+	// service hovering over a limit does not flood the console across refreshes.
+	resourceAlertEngine = resourcealert.NewEngine(0)
 )
 
 func init() {
@@ -108,6 +113,14 @@ type LocalServiceInfo struct {
 	// MemoryBytes is the running process tree's resident memory in bytes. Zero
 	// when the service is not running or sampling failed.
 	MemoryBytes uint64 `json:"memoryBytes,omitempty"`
+	// CPUThresholdPercent is the configured CPU alert threshold, if any.
+	CPUThresholdPercent float64 `json:"cpuThresholdPercent,omitempty"`
+	// MemoryThresholdMB is the configured memory alert threshold in MB, if any.
+	MemoryThresholdMB uint64 `json:"memoryThresholdMB,omitempty"`
+	// CPUOverThreshold is true when live CPU usage exceeds CPUThresholdPercent.
+	CPUOverThreshold bool `json:"cpuOverThreshold,omitempty"`
+	// MemoryOverThreshold is true when live memory usage exceeds MemoryThresholdMB.
+	MemoryOverThreshold bool `json:"memoryOverThreshold,omitempty"`
 }
 
 // AzureServiceInfo contains Azure-specific service information.
@@ -293,6 +306,7 @@ func extractAzureServiceInfo(envVars map[string]string) map[string]AzureServiceI
 // mergeServiceInfo combines azure.yaml services with running services and Azure info.
 func mergeServiceInfo(azureYaml *service.AzureYaml, runningServices []*registry.ServiceRegistryEntry, azureServices map[string]AzureServiceInfo, envVars map[string]string) []*ServiceInfo {
 	serviceMap := make(map[string]*ServiceInfo)
+	thresholds := make(map[string]resourcealert.Threshold)
 
 	// First, add all services from azure.yaml
 	if azureYaml != nil && azureYaml.Services != nil {
@@ -345,6 +359,13 @@ func mergeServiceInfo(azureYaml *service.AzureYaml, runningServices []*registry.
 				}
 			}
 
+			if svc.Resources != nil {
+				thresholds[normalizedName] = resourcealert.Threshold{
+					CPUPercent: svc.Resources.CPUPercent,
+					MemoryMB:   svc.Resources.MemoryMB,
+				}
+			}
+
 			serviceMap[normalizedName] = serviceInfo
 		}
 	}
@@ -381,6 +402,9 @@ func mergeServiceInfo(azureYaml *service.AzureYaml, runningServices []*registry.
 				usage := sampleResourceUsage(runningSvc.PID)
 				existing.Local.CPUPercent = usage.CPUPercent
 				existing.Local.MemoryBytes = usage.MemoryBytes
+				if threshold, ok := thresholds[normalizedName]; ok {
+					applyResourceThresholds(existing.Local, runningSvc.Name, usage, threshold)
+				}
 			}
 		}
 	}
@@ -425,6 +449,47 @@ func mergeServiceInfo(azureYaml *service.AzureYaml, runningServices []*registry.
 	}
 
 	return result
+}
+
+// applyResourceThresholds records the configured thresholds on the local info,
+// sets the over-threshold indicators from the current sample, and raises a
+// throttled warning for each dimension that is exceeded.
+func applyResourceThresholds(local *LocalServiceInfo, serviceName string, usage resourcesampler.Usage, threshold resourcealert.Threshold) {
+	if local == nil || !threshold.Configured() {
+		return
+	}
+
+	local.CPUThresholdPercent = threshold.CPUPercent
+	local.MemoryThresholdMB = threshold.MemoryMB
+
+	now := time.Now()
+
+	// Indicator state is a pure comparison, always reflecting the latest sample.
+	for _, breach := range threshold.Exceeds(serviceName, usage.CPUPercent, usage.MemoryBytes, now) {
+		switch breach.Kind {
+		case resourcealert.KindCPU:
+			local.CPUOverThreshold = true
+		case resourcealert.KindMemory:
+			local.MemoryOverThreshold = true
+		}
+	}
+
+	// Warnings are debounced so a service hovering over a limit does not flood
+	// the console across refreshes.
+	for _, breach := range resourceAlertEngine.Evaluate(serviceName, usage.CPUPercent, usage.MemoryBytes, threshold, now) {
+		switch breach.Kind {
+		case resourcealert.KindCPU:
+			slog.Warn("Service over CPU threshold",
+				"service", serviceName,
+				"cpuPercent", breach.Value,
+				"thresholdPercent", breach.Limit)
+		case resourcealert.KindMemory:
+			slog.Warn("Service over memory threshold",
+				"service", serviceName,
+				"memoryMB", breach.Value,
+				"thresholdMB", breach.Limit)
+		}
+	}
 }
 
 // detectFramework attempts to detect framework from service definition.

--- a/cli/src/internal/serviceinfo/serviceinfo_resource_test.go
+++ b/cli/src/internal/serviceinfo/serviceinfo_resource_test.go
@@ -1,0 +1,110 @@
+package serviceinfo
+
+import (
+	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/resourcesampler"
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-core/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withStubbedSampler(t *testing.T, usage resourcesampler.Usage) {
+	t.Helper()
+	original := sampleResourceUsage
+	sampleResourceUsage = func(int) resourcesampler.Usage { return usage }
+	t.Cleanup(func() { sampleResourceUsage = original })
+}
+
+func findService(result []*ServiceInfo, name string) *ServiceInfo {
+	for _, svc := range result {
+		if svc.Name == name {
+			return svc
+		}
+	}
+	return nil
+}
+
+func TestMergeServiceInfoResourceOverThreshold(t *testing.T) {
+	const mb = 1024 * 1024
+	withStubbedSampler(t, resourcesampler.Usage{CPUPercent: 150, MemoryBytes: 800 * mb})
+
+	azureYaml := &service.AzureYaml{
+		Services: map[string]service.Service{
+			"api": {
+				Host: "local",
+				Resources: &service.ResourceThresholds{
+					CPUPercent: 90,
+					MemoryMB:   512,
+				},
+			},
+		},
+	}
+	running := []*registry.ServiceRegistryEntry{
+		{Name: "api", Status: "running", PID: 4321},
+	}
+
+	result := mergeServiceInfo(azureYaml, running, nil, nil)
+	api := findService(result, "api")
+	require.NotNil(t, api)
+	require.NotNil(t, api.Local)
+
+	assert.Equal(t, 90.0, api.Local.CPUThresholdPercent)
+	assert.Equal(t, uint64(512), api.Local.MemoryThresholdMB)
+	assert.True(t, api.Local.CPUOverThreshold, "cpu 150 over 90 should flag")
+	assert.True(t, api.Local.MemoryOverThreshold, "memory 800MB over 512 should flag")
+}
+
+func TestMergeServiceInfoResourceUnderThreshold(t *testing.T) {
+	const mb = 1024 * 1024
+	withStubbedSampler(t, resourcesampler.Usage{CPUPercent: 20, MemoryBytes: 100 * mb})
+
+	azureYaml := &service.AzureYaml{
+		Services: map[string]service.Service{
+			"api": {
+				Host: "local",
+				Resources: &service.ResourceThresholds{
+					CPUPercent: 90,
+					MemoryMB:   512,
+				},
+			},
+		},
+	}
+	running := []*registry.ServiceRegistryEntry{
+		{Name: "api", Status: "running", PID: 4321},
+	}
+
+	api := findService(mergeServiceInfo(azureYaml, running, nil, nil), "api")
+	require.NotNil(t, api)
+	require.NotNil(t, api.Local)
+
+	assert.False(t, api.Local.CPUOverThreshold)
+	assert.False(t, api.Local.MemoryOverThreshold)
+	// Thresholds are still echoed so the dashboard can show the configured limits.
+	assert.Equal(t, 90.0, api.Local.CPUThresholdPercent)
+	assert.Equal(t, uint64(512), api.Local.MemoryThresholdMB)
+}
+
+func TestMergeServiceInfoNoThresholdsConfigured(t *testing.T) {
+	const mb = 1024 * 1024
+	withStubbedSampler(t, resourcesampler.Usage{CPUPercent: 999, MemoryBytes: 9999 * mb})
+
+	azureYaml := &service.AzureYaml{
+		Services: map[string]service.Service{
+			"api": {Host: "local"},
+		},
+	}
+	running := []*registry.ServiceRegistryEntry{
+		{Name: "api", Status: "running", PID: 4321},
+	}
+
+	api := findService(mergeServiceInfo(azureYaml, running, nil, nil), "api")
+	require.NotNil(t, api)
+	require.NotNil(t, api.Local)
+
+	assert.False(t, api.Local.CPUOverThreshold)
+	assert.False(t, api.Local.MemoryOverThreshold)
+	assert.Zero(t, api.Local.CPUThresholdPercent)
+	assert.Zero(t, api.Local.MemoryThresholdMB)
+}


### PR DESCRIPTION
## Summary

I added optional per-service CPU and memory alert thresholds so I can catch a runaway service during local development before it starves the rest of my stack. When a running service crosses a limit I set in `azure.yaml`, `azd app run` prints a throttled warning and the service info now carries over-threshold indicators the dashboard can pick up.

Closes #428

## Why

When I run several services locally, one of them can quietly spike CPU or leak memory and drag the whole machine down. Today nothing tells me which service is the culprit until I go digging in Task Manager. A small threshold I opt into per service turns that into an immediate, targeted warning.

## What I changed

- New `resourcealert` package that compares a live sample against a `Threshold`. The comparison (`Threshold.Exceeds`) is a pure function so the over-threshold indicator has no side effects, and an `Engine` adds per-service, per-dimension debounce so a service that hovers over a limit does not flood the console.
- `azure.yaml` gains an optional per-service `resources` block with `cpuPercent` and `memoryMB`. A zero or omitted field skips that dimension.
- Service info now records the configured thresholds and two indicators (`cpuOverThreshold`, `memoryOverThreshold`) on the local service info, so the dashboard and JSON output can show which services are over their limits.
- Warnings are emitted through structured logging during a run, debounced to once per 30s per service and dimension.

## Configuration

```yaml
services:
  api:
    language: node
    project: ./api
    ports: ["3000"]
    resources:
      cpuPercent: 85    # warn when the api uses more than 85% of a core
      memoryMB: 512     # warn when the api holds more than 512 MB resident
```

## How it works

```mermaid
flowchart TD
    A[Sample running service] --> B{resources block set?}
    B -- no --> Z[No check]
    B -- yes --> C[Threshold.Exceeds compares sample]
    C --> D{Over a limit?}
    D -- no --> E[Clear indicators]
    D -- yes --> F[Set over-threshold indicator]
    F --> G[Engine debounce per service and dimension]
    G --> H{Outside debounce window?}
    H -- yes --> I[Emit throttled warning]
    H -- no --> J[Suppress repeat warning]
```

## Testing

- `go test ./src/internal/resourcealert/... ./src/internal/service/... ./src/internal/serviceinfo/...` (pass)
- `go build ./...` (pass)
- `golangci-lint run` on the touched packages (0 issues)

Unit tests cover the pure comparison, the debounce window, separate services and dimensions, the unconfigured case, `azure.yaml` parsing of the new block, and the merge path that sets the indicators from a stubbed sample.

## Follow-up

The over-threshold indicators are exposed on the service info now. Wiring them into the dashboard as a visual badge is a small follow-up that consumes these existing fields; it needs a proto and UI change I kept out of this PR to keep the surface area focused.
