### PR TITLE
feat(test): add --changed to test only affected services

### DIFF
--- a/cli/src/cmd/app/commands/test.go
+++ b/cli/src/cmd/app/commands/test.go
@@ -40,6 +40,8 @@ type TestOptions struct {
 	Save            bool
 	NoSave          bool
 	Environment     string
+	Changed         bool
+	ChangedBase     string
 }
 
 // NewTestCommand creates the test command.
@@ -52,7 +54,7 @@ func NewTestCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: "Run tests for all services with coverage aggregation",
-		Long:  `Automatically detects and runs tests for Node.js (Jest/Vitest/Mocha), Python (pytest/unittest), and .NET (xUnit/NUnit/MSTest) projects with unified coverage reporting`,
+		Long:  "Automatically detects and runs tests for Node.js (Jest/Vitest/Mocha), Python (pytest/unittest), and .NET (xUnit/NUnit/MSTest) projects with unified coverage reporting.\n\nUse --changed to only test services with files changed since --changed-base (default HEAD). It looks at staged, unstaged, and untracked files, maps each one to the service whose project directory contains it, and runs only those services. Combine it with --service to intersect the two filters.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Try to get the output flag from parent or self
 			var formatValue string
@@ -90,6 +92,8 @@ func NewTestCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Save, "save", false, "Save auto-detected test config to azure.yaml without prompting")
 	cmd.Flags().BoolVar(&opts.NoSave, "no-save", false, "Don't prompt to save auto-detected test config")
 	cmd.Flags().StringVarP(&opts.Environment, "environment", "e", "", "Target azd environment name (loads vars from .azure/<env>/.env)")
+	cmd.Flags().BoolVar(&opts.Changed, "changed", false, "Only test services with files changed since --changed-base")
+	cmd.Flags().StringVar(&opts.ChangedBase, "changed-base", "HEAD", "Git ref to compare against for --changed (e.g. HEAD, origin/main)")
 
 	registerServiceFlagCompletion(cmd, "service")
 
@@ -179,6 +183,26 @@ func runTests(commandOrchestrator *orchestrator.Orchestrator, opts *TestOptions)
 		serviceFilter = strings.Split(opts.ServiceFilter, ",")
 		for i := range serviceFilter {
 			serviceFilter[i] = strings.TrimSpace(serviceFilter[i])
+		}
+	}
+
+	// --changed narrows the run to services whose files changed since the base
+	// ref, intersected with any explicit --service filter.
+	if opts.Changed {
+		affected, err := changedServiceFilter(orchestrator.GetServices(), serviceFilter, opts.ChangedBase)
+		if err != nil {
+			return err
+		}
+		if len(affected) == 0 {
+			if cliout.IsJSON() {
+				return cliout.PrintJSON(map[string]any{"affected": []string{}, "tested": false})
+			}
+			cliout.Info("No services affected by changes since %s. Nothing to test.", opts.ChangedBase)
+			return nil
+		}
+		serviceFilter = affected
+		if !cliout.IsJSON() {
+			cliout.Info("Testing services changed since %s: %s", opts.ChangedBase, strings.Join(affected, ", "))
 		}
 	}
 

--- a/cli/src/cmd/app/commands/test_changed.go
+++ b/cli/src/cmd/app/commands/test_changed.go
@@ -1,0 +1,140 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jongio/azd-app/cli/src/internal/testing"
+)
+
+// changedServiceFilter returns the names of services whose project directory
+// contains at least one file changed since base. When requested is non-empty the
+// result is the intersection of the affected services and the requested ones, so
+// --changed and --service compose. Names are returned sorted.
+func changedServiceFilter(services []testing.ServiceInfo, requested []string, base string) ([]string, error) {
+	changed, err := gitChangedFiles(base)
+	if err != nil {
+		return nil, err
+	}
+
+	requestedSet := make(map[string]bool, len(requested))
+	for _, r := range requested {
+		if r != "" {
+			requestedSet[r] = true
+		}
+	}
+
+	affected := make([]string, 0, len(services))
+	for _, svc := range services {
+		if len(requestedSet) > 0 && !requestedSet[svc.Name] {
+			continue
+		}
+
+		dir, err := filepath.Abs(svc.Dir)
+		if err != nil {
+			return nil, fmt.Errorf("resolve directory for service %s: %w", svc.Name, err)
+		}
+		if resolved, symErr := filepath.EvalSymlinks(dir); symErr == nil {
+			dir = resolved
+		}
+
+		if anyPathUnder(changed, dir) {
+			affected = append(affected, svc.Name)
+		}
+	}
+
+	sort.Strings(affected)
+	return affected, nil
+}
+
+// anyPathUnder reports whether any path in paths is dir itself or lives inside dir.
+func anyPathUnder(paths []string, dir string) bool {
+	prefix := dir + string(filepath.Separator)
+	for _, p := range paths {
+		if p == dir || strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// gitChangedFiles returns the absolute paths of files that differ from base,
+// including committed-since-base, staged, unstaged, and untracked files.
+func gitChangedFiles(base string) ([]string, error) {
+	root, err := gitRepoRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	add := func(rel string) {
+		rel = strings.TrimSpace(rel)
+		if rel == "" {
+			return
+		}
+		abs := filepath.Clean(filepath.Join(root, filepath.FromSlash(rel)))
+		seen[abs] = struct{}{}
+	}
+
+	// Tracked changes relative to base (committed-since-base, staged, and unstaged).
+	tracked, err := runGit(root, "diff", "--name-only", base)
+	if err != nil {
+		return nil, err
+	}
+	for _, line := range strings.Split(tracked, "\n") {
+		add(line)
+	}
+
+	// Untracked files that git is not yet ignoring.
+	untracked, err := runGit(root, "ls-files", "--others", "--exclude-standard")
+	if err != nil {
+		return nil, err
+	}
+	for _, line := range strings.Split(untracked, "\n") {
+		add(line)
+	}
+
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// gitRepoRoot returns the absolute, symlink-resolved top level of the git
+// repository that contains the current working directory.
+func gitRepoRoot() (string, error) {
+	out, err := runGit("", "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", fmt.Errorf("--changed requires a git repository: %w", err)
+	}
+	root := strings.TrimSpace(out)
+	if resolved, symErr := filepath.EvalSymlinks(root); symErr == nil {
+		root = resolved
+	}
+	return root, nil
+}
+
+// runGit runs a git command in dir (or the current directory when dir is empty)
+// and returns its stdout. On failure it returns git's stderr as the error text.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), msg)
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return stdout.String(), nil
+}

--- a/cli/src/cmd/app/commands/test_changed_test.go
+++ b/cli/src/cmd/app/commands/test_changed_test.go
@@ -1,0 +1,189 @@
+package commands
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	testrunner "github.com/jongio/azd-app/cli/src/internal/testing"
+)
+
+func runTestGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func gitInitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	// Resolve symlinks so paths match gitRepoRoot's EvalSymlinks output (Windows
+	// t.TempDir returns an 8.3 short path that git expands to the long form).
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	runTestGit(t, dir, "init")
+	runTestGit(t, dir, "config", "user.email", "test@example.com")
+	runTestGit(t, dir, "config", "user.name", "Test User")
+	runTestGit(t, dir, "config", "commit.gpgsign", "false")
+	return dir
+}
+
+func writeChangedTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func setupChangedRepo(t *testing.T) (string, []testrunner.ServiceInfo) {
+	t.Helper()
+	repo := gitInitRepo(t)
+	writeChangedTestFile(t, filepath.Join(repo, "api", "main.go"), "package main\n")
+	writeChangedTestFile(t, filepath.Join(repo, "web", "index.js"), "console.log(1)\n")
+	writeChangedTestFile(t, filepath.Join(repo, "README.md"), "# repo\n")
+	runTestGit(t, repo, "add", ".")
+	runTestGit(t, repo, "commit", "-m", "initial")
+
+	services := []testrunner.ServiceInfo{
+		{Name: "api", Dir: filepath.Join(repo, "api")},
+		{Name: "web", Dir: filepath.Join(repo, "web")},
+	}
+	return repo, services
+}
+
+func assertNames(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("service names = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("service names = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestChangedServiceFilterNoChanges(t *testing.T) {
+	repo, services := setupChangedRepo(t)
+	t.Chdir(repo)
+
+	affected, err := changedServiceFilter(services, nil, "HEAD")
+	if err != nil {
+		t.Fatalf("changedServiceFilter: %v", err)
+	}
+	if len(affected) != 0 {
+		t.Fatalf("expected no affected services, got %v", affected)
+	}
+}
+
+func TestChangedServiceFilterModifiedFile(t *testing.T) {
+	repo, services := setupChangedRepo(t)
+	t.Chdir(repo)
+
+	writeChangedTestFile(t, filepath.Join(repo, "api", "main.go"), "package main\n// edit\n")
+
+	affected, err := changedServiceFilter(services, nil, "HEAD")
+	if err != nil {
+		t.Fatalf("changedServiceFilter: %v", err)
+	}
+	assertNames(t, affected, []string{"api"})
+}
+
+func TestChangedServiceFilterUntrackedFile(t *testing.T) {
+	repo, services := setupChangedRepo(t)
+	t.Chdir(repo)
+
+	// A brand new, unstaged file under web still counts as a change.
+	writeChangedTestFile(t, filepath.Join(repo, "web", "extra.js"), "// new\n")
+
+	affected, err := changedServiceFilter(services, nil, "HEAD")
+	if err != nil {
+		t.Fatalf("changedServiceFilter: %v", err)
+	}
+	assertNames(t, affected, []string{"web"})
+}
+
+func TestChangedServiceFilterIntersectsWithRequested(t *testing.T) {
+	repo, services := setupChangedRepo(t)
+	t.Chdir(repo)
+
+	// Both services change, but only web is requested via --service.
+	writeChangedTestFile(t, filepath.Join(repo, "api", "main.go"), "package main\n// edit\n")
+	writeChangedTestFile(t, filepath.Join(repo, "web", "index.js"), "console.log(2)\n")
+
+	affected, err := changedServiceFilter(services, []string{"web"}, "HEAD")
+	if err != nil {
+		t.Fatalf("changedServiceFilter: %v", err)
+	}
+	assertNames(t, affected, []string{"web"})
+}
+
+func TestChangedServiceFilterAgainstBaseRef(t *testing.T) {
+	repo, services := setupChangedRepo(t)
+	t.Chdir(repo)
+
+	// Capture the initial commit, then commit a change to api.
+	baseCmd := exec.Command("git", "rev-parse", "HEAD")
+	baseCmd.Dir = repo
+	baseOut, err := baseCmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse: %v", err)
+	}
+	base := string(baseOut)
+	base = base[:len(base)-1] // trim trailing newline
+
+	writeChangedTestFile(t, filepath.Join(repo, "api", "main.go"), "package main\n// committed edit\n")
+	runTestGit(t, repo, "add", ".")
+	runTestGit(t, repo, "commit", "-m", "edit api")
+
+	// Compared against the previous commit, only api changed.
+	affected, err := changedServiceFilter(services, nil, base)
+	if err != nil {
+		t.Fatalf("changedServiceFilter: %v", err)
+	}
+	assertNames(t, affected, []string{"api"})
+
+	// Compared against HEAD, nothing changed since we committed everything.
+	affectedHead, err := changedServiceFilter(services, nil, "HEAD")
+	if err != nil {
+		t.Fatalf("changedServiceFilter HEAD: %v", err)
+	}
+	if len(affectedHead) != 0 {
+		t.Fatalf("expected no changes vs HEAD, got %v", affectedHead)
+	}
+}
+
+func TestChangedServiceFilterNotAGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	_, err := changedServiceFilter([]testrunner.ServiceInfo{{Name: "api", Dir: dir}}, nil, "HEAD")
+	if err == nil {
+		t.Fatal("expected an error outside a git repository")
+	}
+}
+
+func TestAnyPathUnder(t *testing.T) {
+	dir := filepath.Join("repo", "api")
+	inside := filepath.Join(dir, "main.go")
+	sibling := filepath.Join("repo", "apiv2", "main.go")
+
+	if !anyPathUnder([]string{inside}, dir) {
+		t.Fatalf("expected %s to be under %s", inside, dir)
+	}
+	if !anyPathUnder([]string{dir}, dir) {
+		t.Fatalf("expected the directory itself to match")
+	}
+	// A sibling directory that merely shares a name prefix must not match.
+	if anyPathUnder([]string{sibling}, dir) {
+		t.Fatalf("did not expect %s to be under %s", sibling, dir)
+	}
+}

--- a/cli/src/cmd/app/commands/test_test.go
+++ b/cli/src/cmd/app/commands/test_test.go
@@ -39,6 +39,8 @@ func TestNewTestCommand(t *testing.T) {
 		"dry-run",
 		"output-format",
 		"output-dir",
+		"changed",
+		"changed-base",
 	}
 
 	for _, flagName := range flags {


### PR DESCRIPTION
## What

Adds a `--changed` flag to `azd app test` so you can run tests only for the services you actually touched, instead of the whole repo.

When `--changed` is set, the command:

- Diffs the working tree against `--changed-base` (default `HEAD`), covering staged, unstaged, and untracked files.
- Maps each changed file to the service whose project directory contains it.
- Runs tests only for the affected services.
- Exits cleanly when nothing changed (prints an info line, or `{"affected":[],"tested":false}` in JSON mode).

It composes with the existing `--service` filter: pass both and you get the intersection of the two.

## Why

On a repo with several services, `azd app test` runs everything even when a change only touched one service. In a pre-commit hook or a fast inner loop you usually only care about what you changed. Affected-only test selection is a common pattern in monorepo tooling, and this brings the same idea to the local dev loop.

## Usage

```
# Test services changed since the last commit
azd app test --changed

# Test services changed relative to main
azd app test --changed --changed-base origin/main

# Intersect with an explicit service list
azd app test --changed --service api,web
```

## How it works

- `changedServiceFilter` resolves the git repo root, collects changed paths (via `git diff --name-only <base>` plus `git ls-files --others --exclude-standard`), and matches each service by its resolved project directory.
- Paths and service directories are symlink-resolved so matching is correct on Windows short paths.
- Git plumbing lives in a new `test_changed.go`; the flag wiring and filter hookup are in `test.go`.

## Tests

New tests in `test_changed_test.go` spin up a real temporary git repo and cover: no changes, a modified file, an untracked file, intersection with `--service`, comparison against an explicit base ref, the not-a-git-repo error, and the path-prefix matching edge case (sibling directory sharing a name prefix). Existing command tests updated to assert the new flags register.

Closes #431
