### PR TITLE
deps: upgrade all dependencies to latest

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20260622092256-25656177ba8e // indirect
-	github.com/charmbracelet/x/exp/slice v0.0.0-20260629091435-9c70f75e26a4 // indirect
+	github.com/charmbracelet/x/exp/slice v0.0.0-20260705004817-2cc9a8fe1146 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/cli/browser v1.3.0 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -93,8 +93,8 @@ github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMx
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
 github.com/charmbracelet/x/exp/golden v0.0.0-20260622092256-25656177ba8e h1:x7pKVbisrybuOyTq7CS0zQoKNrckmfBPXAgKK/Hkg1I=
 github.com/charmbracelet/x/exp/golden v0.0.0-20260622092256-25656177ba8e/go.mod h1:6fMpcW6iwN/kX+xJ52eqVWsDiBTe0UJD24JLoHFe+P0=
-github.com/charmbracelet/x/exp/slice v0.0.0-20260629091435-9c70f75e26a4 h1:3LxYwrbyrdfiPRDtYdJNzkmoozXh/UHjleHvu/w9E+A=
-github.com/charmbracelet/x/exp/slice v0.0.0-20260629091435-9c70f75e26a4/go.mod h1:vqEfX6xzqW1pKKZUUiFOKg0OQ7bCh54Q2vR/tserrRA=
+github.com/charmbracelet/x/exp/slice v0.0.0-20260705004817-2cc9a8fe1146 h1:1KOokKxCor/1b/idDJ67I/7xUYx6lIhcD8aG4OZKQSc=
+github.com/charmbracelet/x/exp/slice v0.0.0-20260705004817-2cc9a8fe1146/go.mod h1:vqEfX6xzqW1pKKZUUiFOKg0OQ7bCh54Q2vR/tserrRA=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=


### PR DESCRIPTION
## Dependency upgrade

Automated upgrade of all real dependency manifests to their latest allowed versions.

### Changes
- **Go (`cli/go.mod`)**: bumped indirect `github.com/charmbracelet/x/exp/slice` to the latest pseudo-version via `go get -u ./... && go mod tidy`. All direct deps were already current; remaining outdated entries are transitive deps pinned upstream by MVS (azd-core / azure-dev) and are intentionally left alone.
- **JS/TS (`cli/dashboard`, `web`, `cli/package.json`)**: already at latest — `npm-check-updates` reports no updates. Packages published within the 7-day `min-release-age` cooldown are intentionally skipped.

### Validation
- `go build ./...` ✅
- `mage test` ✅ (full suite)
- `mage lint` ✅ (golangci-lint, 0 issues)
- dashboard `pnpm build` ✅

Fix-forward only — no dependencies were downgraded.