### PR TITLE
docs: add azd app run no-timing flag

### DIFF
--- a/cli/docs/cli-reference.md
+++ b/cli/docs/cli-reference.md
@@ -354,6 +354,7 @@ azd app run --force
 | `--env-file` | | string | | Load environment variables from .env file |
 | `--verbose` | `-v` | bool | `false` | Enable verbose logging |
 | `--dry-run` | | bool | `false` | Show what would be run without starting services |
+| `--no-timing` | | bool | `false` | Hide the per-service startup timing summary shown after services are ready |
 | `--restart-containers` | | bool | `false` | Restart containers even if they are already running |
 | `--force` | `-f` | bool | `false` | Force clean dependency reinstall (passes --force to deps) |
 | `--web` | `-w` | bool | `false` | Open dashboard in browser |

--- a/cli/docs/commands/run.md
+++ b/cli/docs/commands/run.md
@@ -80,15 +80,6 @@ After starting in the background:
 - Stop the run with `azd app stop`
 - Review logs in `~/.azd/azd-app/{projectHash}/run.log`
 
-## Hide startup timing summary
-
-Use `--no-timing` to skip the per-service startup timing summary after all
-services are ready.
-
-```bash
-azd app run --no-timing
-```
-
 ### Run Multiple Instances
 
 Use `--scale` to run multiple instances of a service:
@@ -101,6 +92,15 @@ This starts:
 - `worker` with `AZD_APP_INSTANCE=1`
 - `worker-2` with a different local port and `AZD_APP_INSTANCE=2`
 - `worker-3` with a different local port and `AZD_APP_INSTANCE=3`
+
+## Hide startup timing summary
+
+Use `--no-timing` to skip the per-service startup timing summary after all
+services are ready.
+
+```bash
+azd app run --no-timing
+```
 
 ## Lifecycle Hooks
 

--- a/cli/docs/commands/run.md
+++ b/cli/docs/commands/run.md
@@ -32,6 +32,7 @@ azd app run [flags]
 | `--verbose` | `-v` | bool | `false` | Enable verbose logging |
 | `--dry-run` | | bool | `false` | Show execution plan without starting services |
 | `--detach` | | bool | `false` | Run the app in the background and return to the shell |
+| `--no-timing` | | bool | `false` | Hide the per-service startup timing summary shown after services are ready |
 | `--restart-containers` | | bool | `false` | Restart containers even if they are already running |
 | `--force` | | bool | `false` | Force clean dependency reinstall (passes --force to deps) |
 | `--trust` | `-y` | bool | `false` | Trust this workspace for code execution and remember the decision |
@@ -78,6 +79,15 @@ After starting in the background:
 - Check status with `azd app status`
 - Stop the run with `azd app stop`
 - Review logs in `~/.azd/azd-app/{projectHash}/run.log`
+
+## Hide startup timing summary
+
+Use `--no-timing` to skip the per-service startup timing summary after all
+services are ready.
+
+```bash
+azd app run --no-timing
+```
 
 ### Run Multiple Instances
 


### PR DESCRIPTION
## Summary
- add the missing `azd app run --no-timing` flag to both CLI reference sources
- add a short usage note for hiding the startup timing summary
- leave generated `run.astro` untouched so the existing generator can refresh it

Refs #423.

## Test
- `git diff --check`
- `rg -n -- "--no-timing|Hide the per-service startup timing summary|parseCommandFromReference|cli-reference.md" cli/docs/cli-reference.md cli/docs/commands/run.md web/scripts/cli-parser.ts web/scripts/generate-cli-reference.ts cli/src/cmd/app/commands/run.go`

## Note
- `pnpm generate:cli` could not complete in this environment because pnpm attempted to fetch web dependencies from npm registry and DNS returned `ENOTFOUND`; no generated file was hand-edited.
