### PR TITLE
fix(test): rename secretscan test helper runGit to runGitT

### DIFF
--- a/cli/src/cmd/app/commands/run_secretscan_test.go
+++ b/cli/src/cmd/app/commands/run_secretscan_test.go
@@ -49,7 +49,7 @@ func TestCollectSecretFindingsFromTrackedEnv(t *testing.T) {
 	envPath := filepath.Join(dir, ".env")
 	require.NoError(t, os.WriteFile(envPath,
 		[]byte("DB_PASSWORD=hunter2!\nSERVICE_NAME=orders-api\n"), 0o600))
-	runGit(t, dir, "add", ".env")
+	runGitT(t, dir, "add", ".env")
 
 	findings := collectSecretFindings(nil, dir)
 
@@ -73,11 +73,13 @@ func initGitRepo(t *testing.T) string {
 		t.Skip("git not available")
 	}
 	dir := t.TempDir()
-	runGit(t, dir, "init")
+	runGitT(t, dir, "init")
 	return dir
 }
 
-func runGit(t *testing.T, dir string, args ...string) {
+// runGitT runs a git command in dir and fails the test on error. It is a
+// test-only helper; the production git runner lives in test_changed.go.
+func runGitT(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Problem

Merging the idea PRs left `main` with a broken test build:

```
src/cmd/app/commands/run_secretscan_test.go:80:6: runGit redeclared in this block
```

Two independently-green PRs introduced a package-level `runGit` in `package commands`:
- #429 added the **test helper** `func runGit(t *testing.T, dir string, args ...string)` in `run_secretscan_test.go`
- #443 added the **production** `func runGit(dir string, args ...string) (string, error)` in `test_changed.go`

Each PR passed CI on its own branch because the other file did not exist there yet. The redeclaration only appears when both are on `main` together, so `go test ./src/cmd/app/commands/...` (and every downstream PR's Test job) now fails to compile.

## Fix

Rename the **test-only** helper to `runGitT` (production keeps the `runGit` name). Test-only change, no behavior change.

## Verification
- `go vet ./...` clean (no remaining redeclarations)
- `go test ./src/cmd/app/commands/...` passes
- `gofmt` clean