### PR TITLE
feat(env): write resolved environment to per-service .env files

### DIFF
--- a/cli/src/cmd/app/commands/env.go
+++ b/cli/src/cmd/app/commands/env.go
@@ -2,8 +2,10 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -25,6 +27,8 @@ var (
 	envFile    string
 	envAll     bool
 	envExplain bool
+	envWrite   bool
+	envOut     string
 )
 
 // NewEnvCommand creates the env command.
@@ -62,6 +66,12 @@ Examples:
   # Explain where each effective value came from
   azd app env api --explain
 
+  # Write the resolved environment to api/.env
+  azd app env api --write
+
+  # Write one .env file per service into the build/env folder
+  azd app env --all --write --out build/env
+
   # Resolved environment for every service
   azd app env --all`,
 		SilenceUsage:      true,
@@ -75,6 +85,8 @@ Examples:
 	cmd.Flags().StringVar(&envFile, "env-file", "", "Path to a .env file to merge, matching azd app run")
 	cmd.Flags().BoolVar(&envAll, "all", false, "Print the resolved environment for every service")
 	cmd.Flags().BoolVar(&envExplain, "explain", false, "Show the source of each effective value and any sources it overrode")
+	cmd.Flags().BoolVar(&envWrite, "write", false, "Write the resolved environment to a .env file instead of printing it")
+	cmd.Flags().StringVar(&envOut, "out", "", "Destination folder for --write files (writes <service>.env); defaults to each service directory")
 
 	return cmd
 }
@@ -99,6 +111,18 @@ func runEnv(_ *cobra.Command, args []string) error {
 	// --all cannot be combined with a specific service name.
 	if envAll && len(args) > 0 {
 		return fmt.Errorf("cannot combine --all with a service name")
+	}
+
+	// --out only makes sense together with --write.
+	if envOut != "" && !envWrite {
+		return fmt.Errorf("--out requires --write")
+	}
+
+	if envWrite {
+		if !envAll && len(args) == 0 {
+			return fmt.Errorf("specify a service name or --all with --write")
+		}
+		return runEnvWrite(azureYaml, names, args)
 	}
 
 	if envAll {
@@ -198,6 +222,116 @@ func renderAllEnv(resolvedByService map[string]map[string]string, names []string
 		}
 		fmt.Printf("# %s\n", name)
 		fmt.Print(formatEnv(resolvedByService[name], format, mask))
+	}
+	return nil
+}
+
+// runEnvWrite resolves the environment for the selected services and writes each
+// one to a .env file. Every service is resolved before any file is written so a
+// resolution or path error is reported without leaving a partial set of files.
+// The default destination is each service's own directory (<service>/.env); when
+// --out is set the files go to <out>/<service>.env instead.
+func runEnvWrite(azureYaml *service.AzureYaml, names []string, args []string) error {
+	format, err := resolveEnvFormat(envFormat)
+	if err != nil {
+		return err
+	}
+	mask := !envNoMask
+
+	var selected []string
+	if envAll {
+		selected = names
+	} else {
+		serviceName := args[0]
+		if _, ok := azureYaml.Services[serviceName]; !ok {
+			if len(names) == 0 {
+				return fmt.Errorf("service %q not found. No services are defined in azure.yaml", serviceName)
+			}
+			return fmt.Errorf("service %q not found. Available services: %s",
+				serviceName, strings.Join(names, ", "))
+		}
+		selected = []string{serviceName}
+	}
+
+	if len(selected) == 0 {
+		cliout.Info("No services are defined in azure.yaml")
+		return nil
+	}
+
+	type envTarget struct {
+		name    string
+		path    string
+		content string
+	}
+
+	targets := make([]envTarget, 0, len(selected))
+	for _, name := range selected {
+		svc := azureYaml.Services[name]
+
+		path, perr := envWriteTargetPath(svc, name, envOut)
+		if perr != nil {
+			return perr
+		}
+
+		resolved, rerr := service.ResolveEnvironment(context.Background(), svc, getAzureEnvironmentValues(), envFile, nil)
+		if rerr != nil {
+			return fmt.Errorf("failed to resolve environment for %q: %w", name, rerr)
+		}
+
+		content, cerr := envFileContent(resolved, format, mask)
+		if cerr != nil {
+			return cerr
+		}
+
+		targets = append(targets, envTarget{name: name, path: path, content: content})
+	}
+
+	for _, t := range targets {
+		if err := writeEnvFile(t.path, t.content); err != nil {
+			return err
+		}
+		cliout.Info("Wrote %s", t.path)
+	}
+	return nil
+}
+
+// envWriteTargetPath returns the file path for a service's --write output. With
+// an explicit outDir the file is <outDir>/<service>.env; otherwise it is
+// <service-project-dir>/.env. A service without a project directory has no
+// natural destination, so the caller must supply --out.
+func envWriteTargetPath(svc service.Service, name, outDir string) (string, error) {
+	if outDir != "" {
+		return filepath.Join(outDir, name+".env"), nil
+	}
+	if svc.Project == "" {
+		return "", fmt.Errorf("service %q has no project directory; use --out to choose a destination", name)
+	}
+	return filepath.Join(svc.Project, ".env"), nil
+}
+
+// envFileContent renders the resolved environment for a --write file. The json
+// format writes an indented object; dotenv and shell reuse the same rendering as
+// the printed output. Secret-shaped values are masked when mask is true.
+func envFileContent(resolved map[string]string, format string, mask bool) (string, error) {
+	if format == envFormatJSON {
+		b, err := json.MarshalIndent(maskEnv(resolved, mask), "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("failed to encode environment as json: %w", err)
+		}
+		return string(b) + "\n", nil
+	}
+	return formatEnv(resolved, format, mask), nil
+}
+
+// writeEnvFile creates the parent directory if needed and writes the file with
+// owner-only permissions, since the content can include secret values.
+func writeEnvFile(path, content string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", dir, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("failed to write %q: %w", path, err)
 	}
 	return nil
 }

--- a/cli/src/cmd/app/commands/env_test.go
+++ b/cli/src/cmd/app/commands/env_test.go
@@ -19,7 +19,7 @@ func TestNewEnvCommand(t *testing.T) {
 	assert.NotEmpty(t, cmd.Short)
 	require.NotNil(t, cmd.RunE)
 
-	for _, name := range []string{"format", "no-mask", "env-file", "all", "explain"} {
+	for _, name := range []string{"format", "no-mask", "env-file", "all", "explain", "write", "out"} {
 		assert.NotNil(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
@@ -220,6 +220,147 @@ func TestRunEnvCommand(t *testing.T) {
 	})
 }
 
+func TestRunEnvWrite(t *testing.T) {
+	originalFormat := cliout.GetFormat()
+	defer func() { _ = cliout.SetFormat(string(originalFormat)) }()
+
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalDir) }()
+
+	// chdirTemp changes into dir and registers a cleanup to restore the original
+	// directory. Because t.TempDir registers its RemoveAll cleanup first, the
+	// LIFO cleanup order restores CWD before the temp dir is removed, which
+	// matters on Windows where an in-use directory cannot be deleted.
+	chdirTemp := func(t *testing.T, dir string) {
+		require.NoError(t, os.Chdir(dir))
+		t.Cleanup(func() { _ = os.Chdir(originalDir) })
+	}
+
+	t.Run("writes a single service .env into its project directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		writeEnvTestAzureYaml(t, tmpDir)
+		chdirTemp(t, tmpDir)
+		resetEnvFlags()
+		t.Setenv("SERVICE_ENV_MARKER", "marker-value")
+
+		_, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api", "--write"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+
+		data, readErr := os.ReadFile(filepath.Join(tmpDir, "api", ".env"))
+		require.NoError(t, readErr)
+		assert.Contains(t, string(data), "SERVICE_ENV_MARKER=marker-value")
+	})
+
+	t.Run("all with out writes one file per service", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		writeEnvTestAzureYaml(t, tmpDir)
+		chdirTemp(t, tmpDir)
+		resetEnvFlags()
+		outDir := filepath.Join(tmpDir, "envout")
+
+		_, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"--all", "--write", "--out", outDir})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+
+		assert.FileExists(t, filepath.Join(outDir, "api.env"))
+		assert.FileExists(t, filepath.Join(outDir, "web.env"))
+	})
+
+	t.Run("json format writes valid json", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		writeEnvTestAzureYaml(t, tmpDir)
+		chdirTemp(t, tmpDir)
+		resetEnvFlags()
+		t.Setenv("SERVICE_ENV_MARKER", "marker-value")
+
+		_, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api", "--write", "--format", "json"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+
+		data, readErr := os.ReadFile(filepath.Join(tmpDir, "api", ".env"))
+		require.NoError(t, readErr)
+		var parsed map[string]string
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		assert.Equal(t, "marker-value", parsed["SERVICE_ENV_MARKER"])
+	})
+
+	t.Run("masks secrets by default and keeps raw with no-mask", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		writeEnvTestAzureYaml(t, tmpDir)
+		chdirTemp(t, tmpDir)
+		t.Setenv("DB_PASSWORD", "supersecret")
+
+		resetEnvFlags()
+		_, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api", "--write"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+		masked, readErr := os.ReadFile(filepath.Join(tmpDir, "api", ".env"))
+		require.NoError(t, readErr)
+		assert.NotContains(t, string(masked), "supersecret")
+
+		resetEnvFlags()
+		_, runErr = captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api", "--write", "--no-mask"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+		raw, readErr := os.ReadFile(filepath.Join(tmpDir, "api", ".env"))
+		require.NoError(t, readErr)
+		assert.Contains(t, string(raw), "DB_PASSWORD=supersecret")
+	})
+
+	t.Run("write without a service or all errors", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		writeEnvTestAzureYaml(t, tmpDir)
+		chdirTemp(t, tmpDir)
+		resetEnvFlags()
+		cmd := NewEnvCommand()
+		cmd.SetArgs([]string{"--write"})
+		runErr := cmd.Execute()
+		require.Error(t, runErr)
+		assert.Contains(t, runErr.Error(), "specify a service name or --all")
+	})
+
+	t.Run("out without write errors", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		writeEnvTestAzureYaml(t, tmpDir)
+		chdirTemp(t, tmpDir)
+		resetEnvFlags()
+		cmd := NewEnvCommand()
+		cmd.SetArgs([]string{"api", "--out", "somewhere"})
+		runErr := cmd.Execute()
+		require.Error(t, runErr)
+		assert.Contains(t, runErr.Error(), "--out requires --write")
+	})
+
+	t.Run("unknown service errors", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		writeEnvTestAzureYaml(t, tmpDir)
+		chdirTemp(t, tmpDir)
+		resetEnvFlags()
+		cmd := NewEnvCommand()
+		cmd.SetArgs([]string{"nope", "--write"})
+		runErr := cmd.Execute()
+		require.Error(t, runErr)
+		assert.Contains(t, runErr.Error(), `service "nope" not found`)
+	})
+}
+
 func TestRenderAllEnv(t *testing.T) {
 	resolved := map[string]map[string]string{
 		"api": {"GREETING": "hello", "DB_PASSWORD": "supersecret"},
@@ -281,6 +422,8 @@ func resetEnvFlags() {
 	envFile = ""
 	envAll = false
 	envExplain = false
+	envWrite = false
+	envOut = ""
 	_ = cliout.SetFormat("default")
 }
 


### PR DESCRIPTION
Closes #447

## Problem

`azd app env` can print the resolved environment for a service, but there is no way to write it to a file. Getting a real `.env` file today means redirecting stdout per service and hand-editing headers, which is easy to get wrong and does not scale to multi-service projects.

## What this adds

Two flags on `azd app env`:

- `--write` writes the resolved environment to a `.env` file instead of printing it. By default each service is written to its own directory (`<service>/.env`).
- `--out DIR` sends the files to `DIR/<service>.env` instead, so you can collect them in one place (handy for CI artifacts or a shared build folder).

Both work with the existing `--all`, `--format`, `--env-file`, and `--no-mask` flags:

```
# Write api/.env
azd app env api --write

# Write one file per service into build/env
azd app env --all --write --out build/env

# JSON file, raw values
azd app env api --write --format json --no-mask
```

## Notes

- All selected services are resolved before any file is written, so a resolution or path error does not leave a partial set of files behind.
- Files are written with owner-only permissions (0600) since the content can include secret values, and secret-shaped values are still masked unless `--no-mask` is passed.
- A service with no project directory (for example an image-only service) has no natural destination, so `--out` is required for it.
- `--out` without `--write` is rejected with a clear error.

## Testing

- Added `TestRunEnvWrite` covering single-service write, `--all --out`, JSON output, masking and `--no-mask`, and the error cases.
- `go build ./...`, `go vet ./...`, and the env command package tests pass.