### PR TITLE
feat(logs): filter log lines to a pattern with --grep

### DIFF
--- a/cli/src/cmd/app/commands/logs.go
+++ b/cli/src/cmd/app/commands/logs.go
@@ -151,6 +151,7 @@ type logsOptions struct {
 	output       string
 	file         string
 	exclude      string
+	grep         string
 	noBuiltins   bool
 	contextLines int    // Number of context lines before/after matching entries (0-10)
 	source       string // Log source: "local", "azure", or "all"
@@ -250,6 +251,12 @@ Examples:
   # Filter by log level
   azd app logs --level error
 
+  # Only show lines matching a pattern
+  azd app logs --grep "timeout|refused"
+
+  # Only show POST requests, hiding health checks
+  azd app logs --grep "POST " --exclude "/health"
+
   # View errors with 3 lines of context before and after
   azd app logs --level error --context 3
 
@@ -294,6 +301,7 @@ Examples:
 	_ = cmd.Flags().MarkHidden("format")
 	cmd.Flags().StringVar(&opts.file, "file", "", "Write logs to file instead of stdout")
 	cmd.Flags().StringVar(&opts.exclude, "exclude", "", "Regex patterns to exclude (comma-separated)")
+	cmd.Flags().StringVar(&opts.grep, "grep", "", "Only show log lines matching this regex (applied after --exclude)")
 	cmd.Flags().BoolVar(&opts.noBuiltins, "no-builtins", false, "Disable built-in filter patterns")
 	cmd.Flags().IntVar(&opts.contextLines, "context", 0, "Number of context lines before/after matching entries (0-10, requires --level)")
 	cmd.Flags().StringVar(&opts.source, "source", "local", "Log source: 'local' (default), 'azure', or 'all'")

--- a/cli/src/cmd/app/commands/logs_executor_test.go
+++ b/cli/src/cmd/app/commands/logs_executor_test.go
@@ -354,6 +354,41 @@ func TestLogsExecutor_BuildLogFilterInternal(t *testing.T) {
 			t.Error("Expected built-in patterns")
 		}
 	})
+
+	t.Run("with grep include pattern", func(t *testing.T) {
+		opts := &logsOptions{
+			grep:       "POST ",
+			noBuiltins: true,
+		}
+		executor := &logsExecutor{opts: opts}
+
+		filter, err := executor.buildLogFilterInternal(tmpDir)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if filter.IncludePatternCount() != 1 {
+			t.Errorf("Expected 1 include pattern, got %d", filter.IncludePatternCount())
+		}
+		if filter.ShouldFilter("GET /health 200") == false {
+			t.Error("Expected non-matching line to be filtered out")
+		}
+		if filter.ShouldFilter("POST /orders 201") == true {
+			t.Error("Expected matching line to pass")
+		}
+	})
+
+	t.Run("invalid grep pattern errors", func(t *testing.T) {
+		opts := &logsOptions{
+			grep:       "(",
+			noBuiltins: true,
+		}
+		executor := &logsExecutor{opts: opts}
+
+		_, err := executor.buildLogFilterInternal(tmpDir)
+		if err == nil {
+			t.Error("Expected an error for an invalid --grep pattern")
+		}
+	})
 }
 
 // ==================== Execute tests ====================

--- a/cli/src/cmd/app/commands/logs_filtering.go
+++ b/cli/src/cmd/app/commands/logs_filtering.go
@@ -140,10 +140,28 @@ func (e *logsExecutor) buildLogFilterInternal(cwd string) (*service.LogFilter, e
 	includeBuiltins := !e.opts.noBuiltins
 
 	// Build the filter
+	var (
+		filter *service.LogFilter
+		filErr error
+	)
 	if includeBuiltins {
-		return service.NewLogFilterWithBuiltins(customPatterns)
+		filter, filErr = service.NewLogFilterWithBuiltins(customPatterns)
+	} else {
+		filter, filErr = service.NewLogFilter(customPatterns)
 	}
-	return service.NewLogFilter(customPatterns)
+	if filErr != nil {
+		return nil, filErr
+	}
+
+	// Apply the positive include pattern from --grep, if any. Exclude patterns
+	// still win, so a line matching both is dropped.
+	if e.opts.grep != "" {
+		if err := filter.AddIncludePattern(e.opts.grep); err != nil {
+			return nil, fmt.Errorf("invalid --grep pattern: %w", err)
+		}
+	}
+
+	return filter, nil
 }
 
 // getOrCreateSignalChan gets or creates a signal channel with proper cleanup.

--- a/cli/src/internal/service/logfilter.go
+++ b/cli/src/internal/service/logfilter.go
@@ -12,7 +12,12 @@ import (
 type LogFilter struct {
 	patterns    []*regexp.Regexp
 	rawPatterns []string
-	mu          sync.RWMutex
+	// includePatterns, when non-empty, restrict output to messages that match at
+	// least one of them. Exclude patterns still win: a message matching both an
+	// exclude and an include pattern is filtered out.
+	includePatterns    []*regexp.Regexp
+	rawIncludePatterns []string
+	mu                 sync.RWMutex
 }
 
 // BuiltInLogFilters contains patterns for common noise that doesn't indicate real problems.
@@ -75,7 +80,10 @@ func NewLogFilterWithBuiltins(customPatterns []string) (*LogFilter, error) {
 	return NewLogFilter(allPatterns)
 }
 
-// ShouldFilter returns true if the message matches any filter pattern.
+// ShouldFilter returns true if the message should be dropped from output. A
+// message is dropped when it matches any exclude pattern, or when include
+// patterns are set and the message matches none of them. Exclude patterns take
+// precedence over include patterns.
 func (lf *LogFilter) ShouldFilter(message string) bool {
 	if lf == nil {
 		return false
@@ -89,7 +97,45 @@ func (lf *LogFilter) ShouldFilter(message string) bool {
 			return true
 		}
 	}
+
+	if len(lf.includePatterns) > 0 {
+		for _, re := range lf.includePatterns {
+			if re.MatchString(message) {
+				return false
+			}
+		}
+		return true
+	}
+
 	return false
+}
+
+// AddIncludePattern adds a pattern that a message must match to be shown. When
+// any include pattern is present, messages that match none of them are filtered
+// out. Patterns are compiled case-insensitively, matching exclude patterns.
+func (lf *LogFilter) AddIncludePattern(pattern string) error {
+	if len(pattern) > maxPatternLength {
+		return fmt.Errorf("log filter pattern exceeds maximum length of %d characters", maxPatternLength)
+	}
+
+	re, err := regexp.Compile("(?i)" + pattern)
+	if err != nil {
+		return err
+	}
+
+	lf.mu.Lock()
+	defer lf.mu.Unlock()
+
+	lf.includePatterns = append(lf.includePatterns, re)
+	lf.rawIncludePatterns = append(lf.rawIncludePatterns, pattern)
+	return nil
+}
+
+// IncludePatternCount returns the number of include patterns in the filter.
+func (lf *LogFilter) IncludePatternCount() int {
+	lf.mu.RLock()
+	defer lf.mu.RUnlock()
+	return len(lf.includePatterns)
 }
 
 // AddPattern adds a new pattern to the filter.

--- a/cli/src/internal/service/logfilter_test.go
+++ b/cli/src/internal/service/logfilter_test.go
@@ -83,6 +83,70 @@ func TestLogFilter_NilFilter(t *testing.T) {
 	}
 }
 
+func TestLogFilter_IncludePatterns(t *testing.T) {
+	t.Run("only matching lines pass when include set", func(t *testing.T) {
+		lf, err := NewLogFilter(nil)
+		if err != nil {
+			t.Fatalf("NewLogFilter() error = %v", err)
+		}
+		if err := lf.AddIncludePattern("POST "); err != nil {
+			t.Fatalf("AddIncludePattern() error = %v", err)
+		}
+
+		if lf.ShouldFilter("GET /healthz 200") == false {
+			t.Error("non-matching line should be filtered out when an include pattern is set")
+		}
+		if lf.ShouldFilter("POST /orders 201") == true {
+			t.Error("matching line should pass when it matches the include pattern")
+		}
+	})
+
+	t.Run("include is case insensitive", func(t *testing.T) {
+		lf, _ := NewLogFilter(nil)
+		if err := lf.AddIncludePattern("error"); err != nil {
+			t.Fatalf("AddIncludePattern() error = %v", err)
+		}
+		if lf.ShouldFilter("Fatal ERROR occurred") == true {
+			t.Error("include pattern should match case-insensitively")
+		}
+	})
+
+	t.Run("exclude wins over include", func(t *testing.T) {
+		lf, err := NewLogFilter([]string{"/health"})
+		if err != nil {
+			t.Fatalf("NewLogFilter() error = %v", err)
+		}
+		if err := lf.AddIncludePattern("GET "); err != nil {
+			t.Fatalf("AddIncludePattern() error = %v", err)
+		}
+
+		// Matches both include ("GET ") and exclude ("/health"): exclude wins.
+		if lf.ShouldFilter("GET /health 200") == false {
+			t.Error("a line matching both include and exclude should be filtered out")
+		}
+		// Matches include, not exclude: passes.
+		if lf.ShouldFilter("GET /orders 200") == true {
+			t.Error("a line matching include but not exclude should pass")
+		}
+	})
+
+	t.Run("invalid include pattern errors", func(t *testing.T) {
+		lf, _ := NewLogFilter(nil)
+		if err := lf.AddIncludePattern("("); err == nil {
+			t.Error("expected an error for an invalid regex include pattern")
+		}
+	})
+
+	t.Run("include count reflects added patterns", func(t *testing.T) {
+		lf, _ := NewLogFilter(nil)
+		_ = lf.AddIncludePattern("a")
+		_ = lf.AddIncludePattern("b")
+		if got := lf.IncludePatternCount(); got != 2 {
+			t.Errorf("IncludePatternCount() = %d, want 2", got)
+		}
+	})
+}
+
 func TestNewLogFilterWithBuiltins(t *testing.T) {
 	lf, err := NewLogFilterWithBuiltins(nil)
 	if err != nil {


### PR DESCRIPTION
## What

Add a `--grep REGEX` flag to `azd app logs` that keeps only log lines matching the pattern. This is a positive include filter that complements the existing `--exclude` drop filter.

## Why

`azd app logs` already supports `--exclude` to drop noisy lines, but there was no way to narrow the stream down to just the lines you care about. When you are chasing a specific request path, status code, or trace id across several services, you had to pipe through an external tool. `--grep` brings that filtering into the command itself and works the same way in both batch and follow (`-f`) modes.

## How

- Extend `service.LogFilter` with include patterns (`AddIncludePattern`, `IncludePatternCount`). `ShouldFilter` now drops a line when include patterns are set and none of them match. Exclude still wins when both an include and an exclude match.
- Patterns compile case-insensitively and are bounded in length, matching the existing exclude handling.
- Wire `--grep` into `logsOptions` and `buildLogFilterInternal` so both the batch and follow paths pick it up automatically.
- The value is treated as a single regular expression (commas are valid regex, so it is not comma-split like `--exclude`).

## Examples

```bash
# Only show lines mentioning POST requests
azd app logs --grep "POST "

# Follow one service and keep only error-ish lines
azd app logs -f --service api --grep "(error|panic|fatal)"

# Combine include and exclude: keep API traffic, drop health checks
azd app logs --grep "/api/" --exclude "/health"
```

## Testing

- `go build ./...`
- `go test ./src/internal/service/ -run TestLogFilter`
- `go test ./src/cmd/app/commands/ -run TestLogsExecutor_BuildLogFilterInternal`

Added include-pattern unit tests plus command-level tests covering match, non-match, and an invalid pattern error.

Closes #448
