### PR TITLE
feat(deps): verify installed dependencies with deps --check

### DIFF
--- a/cli/src/cmd/app/commands/deps.go
+++ b/cli/src/cmd/app/commands/deps.go
@@ -20,6 +20,7 @@ type DepsOptions struct {
 	NoCache  bool
 	Force    bool
 	DryRun   bool     // Show what would be installed without installing
+	Check    bool     // Verify dependencies are installed without installing (non-zero exit if missing)
 	Services []string // Filter to specific services by name
 }
 
@@ -218,9 +219,23 @@ func NewDepsCommand() *cobra.Command {
 	commandOrchestrator := newCommandOrchestrator()
 
 	cmd := &cobra.Command{
-		Use:          "deps",
-		Short:        "Install dependencies for services defined in azure.yaml",
-		Long:         `Installs dependencies for services defined in azure.yaml. Only service project paths are checked (Node.js, Python, .NET). Requires azure.yaml with a 'services' section.`,
+		Use:   "deps",
+		Short: "Install dependencies for services defined in azure.yaml",
+		Long: `Installs dependencies for services defined in azure.yaml. Only service project paths are checked (Node.js, Python, .NET). Requires azure.yaml with a 'services' section.
+
+Examples:
+  # Install dependencies for every service
+  azd app deps
+
+  # Show what would be installed without installing
+  azd app deps --dry-run
+
+  # Verify dependencies are installed without installing anything.
+  # Exits non-zero if any service is missing its dependencies, for CI gating.
+  azd app deps --check
+
+  # Check a single service
+  azd app deps --check --service api`,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Try to get the output flag from parent or self
@@ -236,6 +251,11 @@ func NewDepsCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check mode: verify dependencies are installed without installing anything.
+			if opts.Check {
+				return runDepsCheck(opts, os.Stdout)
+			}
+
 			// Handle --force flag (combines --clean and --no-cache)
 			if opts.Force {
 				opts.Clean = true
@@ -259,6 +279,7 @@ func NewDepsCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.NoCache, "no-cache", false, "Force fresh dependency installation and bypass cached results")
 	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force clean reinstall (combines --clean and --no-cache)")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be installed without actually installing")
+	cmd.Flags().BoolVar(&opts.Check, "check", false, "Verify dependencies are installed without installing; exits non-zero if any are missing")
 	cmd.Flags().StringSliceVarP(&opts.Services, "service", "s", nil, "Install dependencies only for specific services (can be specified multiple times)")
 
 	return cmd

--- a/cli/src/cmd/app/commands/deps_check.go
+++ b/cli/src/cmd/app/commands/deps_check.go
@@ -1,0 +1,202 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/jongio/azd-core/cliout"
+	types "github.com/jongio/azd-core/projecttype"
+)
+
+// depsCheckStatus reports whether one detected project has its dependencies installed.
+type depsCheckStatus struct {
+	Type      string `json:"type"`
+	Dir       string `json:"dir,omitempty"`
+	Path      string `json:"path,omitempty"`
+	Manager   string `json:"manager,omitempty"`
+	Marker    string `json:"marker"`
+	Installed bool   `json:"installed"`
+}
+
+// depsCheckResult is the machine-readable summary for deps --check.
+type depsCheckResult struct {
+	Projects     []depsCheckStatus `json:"projects"`
+	TotalChecked int               `json:"totalChecked"`
+	Missing      int               `json:"missing"`
+	AllInstalled bool              `json:"allInstalled"`
+}
+
+// depsPathIsDir reports whether path exists and is a directory.
+func depsPathIsDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// depsPathIsFile reports whether path exists and is a regular file.
+func depsPathIsFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// nodeDepsMarker returns the path checked for installed Node dependencies and whether it exists.
+// Workspace children may share a node_modules at the workspace root, so that is checked too.
+func nodeDepsMarker(p types.NodeProject) (string, bool) {
+	primary := filepath.Join(p.Dir, "node_modules")
+	if depsPathIsDir(primary) {
+		return primary, true
+	}
+	if p.WorkspaceRoot != "" {
+		shared := filepath.Join(p.WorkspaceRoot, "node_modules")
+		if depsPathIsDir(shared) {
+			return shared, true
+		}
+	}
+	return primary, false
+}
+
+// pythonDepsMarker returns the path checked for an installed Python environment and whether it exists.
+func pythonDepsMarker(p types.PythonProject) (string, bool) {
+	venv := filepath.Join(p.Dir, ".venv")
+	if depsPathIsDir(venv) {
+		return venv, true
+	}
+	if alt := filepath.Join(p.Dir, "venv"); depsPathIsDir(alt) {
+		return alt, true
+	}
+	return venv, false
+}
+
+// dotnetDepsMarker returns the restore marker checked for a .NET project and whether it exists.
+// A successful restore writes obj/project.assets.json next to the project file.
+func dotnetDepsMarker(p types.DotnetProject) (string, bool) {
+	marker := filepath.Join(filepath.Dir(p.Path), "obj", "project.assets.json")
+	return marker, depsPathIsFile(marker)
+}
+
+// buildDepsCheckResult inspects each detected project for its installed dependency marker.
+func buildDepsCheckResult(projects DetectedProjects) depsCheckResult {
+	result := depsCheckResult{}
+
+	for _, p := range projects.Node {
+		marker, installed := nodeDepsMarker(p)
+		result.Projects = append(result.Projects, depsCheckStatus{
+			Type:      "node",
+			Dir:       p.Dir,
+			Manager:   p.PackageManager,
+			Marker:    marker,
+			Installed: installed,
+		})
+	}
+	for _, p := range projects.Python {
+		marker, installed := pythonDepsMarker(p)
+		result.Projects = append(result.Projects, depsCheckStatus{
+			Type:      "python",
+			Dir:       p.Dir,
+			Manager:   p.PackageManager,
+			Marker:    marker,
+			Installed: installed,
+		})
+	}
+	for _, p := range projects.Dotnet {
+		marker, installed := dotnetDepsMarker(p)
+		result.Projects = append(result.Projects, depsCheckStatus{
+			Type:      "dotnet",
+			Path:      p.Path,
+			Marker:    marker,
+			Installed: installed,
+		})
+	}
+
+	result.TotalChecked = len(result.Projects)
+	for _, s := range result.Projects {
+		if !s.Installed {
+			result.Missing++
+		}
+	}
+	result.AllInstalled = result.Missing == 0
+	return result
+}
+
+// runDepsCheck verifies that dependencies are installed for each detected service
+// without installing anything. It returns an error when any service is missing its
+// dependencies, which surfaces as a non-zero exit code for CI gating.
+func runDepsCheck(opts *DepsOptions, w io.Writer) error {
+	if opts == nil {
+		opts = &DepsOptions{}
+	}
+	if w == nil {
+		w = os.Stdout
+	}
+
+	searchRoot, err := getSearchRoot()
+	if err != nil {
+		return handleDepsError(err, "failed to determine search root")
+	}
+
+	nodeProjects, pythonProjects, dotnetProjects, err := detectProjectsFromAzureYaml(searchRoot)
+	if err != nil {
+		return handleDepsError(err, "failed to detect projects from azure.yaml")
+	}
+
+	projects := DetectedProjects{Node: nodeProjects, Python: pythonProjects, Dotnet: dotnetProjects}
+	if len(opts.Services) > 0 {
+		projects = filterDetectedProjectsByService(projects, opts.Services, searchRoot)
+	}
+
+	if projects.Total() == 0 {
+		if cliout.IsJSON() {
+			return cliout.PrintJSON(depsCheckResult{Projects: []depsCheckStatus{}, AllInstalled: true})
+		}
+		if len(opts.Services) > 0 {
+			fmt.Fprintf(w, "No projects found matching services: %v\n", opts.Services)
+		} else {
+			fmt.Fprintln(w, msgNoProjectsDetected)
+		}
+		return nil
+	}
+
+	result := buildDepsCheckResult(projects)
+
+	if cliout.IsJSON() {
+		if err := cliout.PrintJSON(result); err != nil {
+			return err
+		}
+	} else {
+		renderDepsCheckText(w, result, searchRoot)
+	}
+
+	if result.Missing > 0 {
+		return fmt.Errorf("%d of %d service(s) missing dependencies; run 'azd app deps' to install", result.Missing, result.TotalChecked)
+	}
+	return nil
+}
+
+// renderDepsCheckText prints a human-readable dependency check report.
+func renderDepsCheckText(w io.Writer, result depsCheckResult, searchRoot string) {
+	fmt.Fprintln(w, "Dependency check")
+	for _, s := range result.Projects {
+		location := s.Dir
+		if location == "" {
+			location = s.Path
+		}
+		if rel, err := filepath.Rel(searchRoot, location); err == nil && rel != "." {
+			location = rel
+		}
+		label := s.Type
+		if s.Manager != "" {
+			label = fmt.Sprintf("%s/%s", s.Type, s.Manager)
+		}
+		status := "installed"
+		if !s.Installed {
+			status = "missing"
+		}
+		fmt.Fprintf(w, "  [%s] %s (%s)\n", status, location, label)
+	}
+	if result.Missing > 0 {
+		fmt.Fprintf(w, "%d of %d service(s) missing dependencies. Run 'azd app deps' to install.\n", result.Missing, result.TotalChecked)
+	} else {
+		fmt.Fprintf(w, "All %d service(s) have dependencies installed.\n", result.TotalChecked)
+	}
+}

--- a/cli/src/cmd/app/commands/deps_check.go
+++ b/cli/src/cmd/app/commands/deps_check.go
@@ -150,9 +150,9 @@ func runDepsCheck(opts *DepsOptions, w io.Writer) error {
 			return cliout.PrintJSON(depsCheckResult{Projects: []depsCheckStatus{}, AllInstalled: true})
 		}
 		if len(opts.Services) > 0 {
-			fmt.Fprintf(w, "No projects found matching services: %v\n", opts.Services)
+			_, _ = fmt.Fprintf(w, "No projects found matching services: %v\n", opts.Services)
 		} else {
-			fmt.Fprintln(w, msgNoProjectsDetected)
+			_, _ = fmt.Fprintln(w, msgNoProjectsDetected)
 		}
 		return nil
 	}
@@ -175,7 +175,7 @@ func runDepsCheck(opts *DepsOptions, w io.Writer) error {
 
 // renderDepsCheckText prints a human-readable dependency check report.
 func renderDepsCheckText(w io.Writer, result depsCheckResult, searchRoot string) {
-	fmt.Fprintln(w, "Dependency check")
+	_, _ = fmt.Fprintln(w, "Dependency check")
 	for _, s := range result.Projects {
 		location := s.Dir
 		if location == "" {
@@ -192,11 +192,11 @@ func renderDepsCheckText(w io.Writer, result depsCheckResult, searchRoot string)
 		if !s.Installed {
 			status = "missing"
 		}
-		fmt.Fprintf(w, "  [%s] %s (%s)\n", status, location, label)
+		_, _ = fmt.Fprintf(w, "  [%s] %s (%s)\n", status, location, label)
 	}
 	if result.Missing > 0 {
-		fmt.Fprintf(w, "%d of %d service(s) missing dependencies. Run 'azd app deps' to install.\n", result.Missing, result.TotalChecked)
+		_, _ = fmt.Fprintf(w, "%d of %d service(s) missing dependencies. Run 'azd app deps' to install.\n", result.Missing, result.TotalChecked)
 	} else {
-		fmt.Fprintf(w, "All %d service(s) have dependencies installed.\n", result.TotalChecked)
+		_, _ = fmt.Fprintf(w, "All %d service(s) have dependencies installed.\n", result.TotalChecked)
 	}
 }

--- a/cli/src/cmd/app/commands/deps_check_test.go
+++ b/cli/src/cmd/app/commands/deps_check_test.go
@@ -1,0 +1,248 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jongio/azd-core/cliout"
+	types "github.com/jongio/azd-core/projecttype"
+)
+
+func TestNodeDepsMarker(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dir := filepath.Join(tmpDir, "installed")
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if marker, ok := nodeDepsMarker(types.NodeProject{Dir: dir}); !ok {
+		t.Errorf("expected installed=true for %s", marker)
+	}
+
+	missing := filepath.Join(tmpDir, "missing")
+	if err := os.MkdirAll(missing, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, ok := nodeDepsMarker(types.NodeProject{Dir: missing}); ok {
+		t.Error("expected installed=false when node_modules is absent")
+	}
+
+	// Workspace child resolves node_modules at the workspace root.
+	wsRoot := filepath.Join(tmpDir, "ws")
+	child := filepath.Join(wsRoot, "packages", "child")
+	if err := os.MkdirAll(child, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(wsRoot, "node_modules"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, ok := nodeDepsMarker(types.NodeProject{Dir: child, WorkspaceRoot: wsRoot}); !ok {
+		t.Error("expected installed=true via workspace root node_modules")
+	}
+}
+
+func TestPythonDepsMarker(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	venvDir := filepath.Join(tmpDir, "venv-style")
+	if err := os.MkdirAll(filepath.Join(venvDir, ".venv"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, ok := pythonDepsMarker(types.PythonProject{Dir: venvDir}); !ok {
+		t.Error("expected installed=true for .venv")
+	}
+
+	altDir := filepath.Join(tmpDir, "alt")
+	if err := os.MkdirAll(filepath.Join(altDir, "venv"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, ok := pythonDepsMarker(types.PythonProject{Dir: altDir}); !ok {
+		t.Error("expected installed=true for venv")
+	}
+
+	missing := filepath.Join(tmpDir, "missing")
+	if err := os.MkdirAll(missing, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, ok := pythonDepsMarker(types.PythonProject{Dir: missing}); ok {
+		t.Error("expected installed=false when no environment exists")
+	}
+}
+
+func TestDotnetDepsMarker(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	proj := filepath.Join(tmpDir, "api", "api.csproj")
+	objDir := filepath.Join(tmpDir, "api", "obj")
+	if err := os.MkdirAll(objDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(objDir, "project.assets.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, ok := dotnetDepsMarker(types.DotnetProject{Path: proj}); !ok {
+		t.Error("expected installed=true when project.assets.json exists")
+	}
+
+	missing := filepath.Join(tmpDir, "web", "web.csproj")
+	if err := os.MkdirAll(filepath.Dir(missing), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, ok := dotnetDepsMarker(types.DotnetProject{Path: missing}); ok {
+		t.Error("expected installed=false without a restore marker")
+	}
+}
+
+func TestBuildDepsCheckResult(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	installedNode := filepath.Join(tmpDir, "web")
+	if err := os.MkdirAll(filepath.Join(installedNode, "node_modules"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	missingNode := filepath.Join(tmpDir, "api")
+	if err := os.MkdirAll(missingNode, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	projects := DetectedProjects{
+		Node: []types.NodeProject{
+			{Dir: installedNode, PackageManager: "npm"},
+			{Dir: missingNode, PackageManager: "npm"},
+		},
+	}
+
+	result := buildDepsCheckResult(projects)
+	if result.TotalChecked != 2 {
+		t.Errorf("TotalChecked = %d, want 2", result.TotalChecked)
+	}
+	if result.Missing != 1 {
+		t.Errorf("Missing = %d, want 1", result.Missing)
+	}
+	if result.AllInstalled {
+		t.Error("AllInstalled should be false with one missing project")
+	}
+
+	// All installed case.
+	if err := os.MkdirAll(filepath.Join(missingNode, "node_modules"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	result = buildDepsCheckResult(projects)
+	if result.Missing != 0 || !result.AllInstalled {
+		t.Errorf("expected all installed, got Missing=%d AllInstalled=%v", result.Missing, result.AllInstalled)
+	}
+}
+
+func TestRenderDepsCheckText(t *testing.T) {
+	result := depsCheckResult{
+		Projects: []depsCheckStatus{
+			{Type: "node", Dir: "/root/web", Manager: "npm", Installed: true},
+			{Type: "python", Dir: "/root/api", Manager: "pip", Installed: false},
+		},
+		TotalChecked: 2,
+		Missing:      1,
+	}
+
+	var buf bytes.Buffer
+	renderDepsCheckText(&buf, result, "/root")
+	out := buf.String()
+
+	for _, want := range []string{"[installed]", "[missing]", "node/npm", "python/pip", "missing dependencies"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunDepsCheck(t *testing.T) {
+	_ = cliout.SetFormat("default")
+	t.Cleanup(func() { _ = cliout.SetFormat("default") })
+
+	tmpDir := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(tmpDir); err == nil {
+		tmpDir = resolved
+	}
+
+	azureYaml := `name: test-app
+services:
+  api:
+    project: ./api
+    language: nodejs
+  web:
+    project: ./web
+    language: nodejs
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "azure.yaml"), []byte(azureYaml), 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+
+	for _, name := range []string{"api", "web"} {
+		dir := filepath.Join(tmpDir, name)
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"`+name+`"}`), 0o600); err != nil {
+			t.Fatalf("write package.json: %v", err)
+		}
+	}
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	// Registered after t.TempDir() so it runs first (LIFO), restoring the
+	// working directory before TempDir's RemoveAll on Windows.
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	t.Run("missing dependencies returns error", func(t *testing.T) {
+		// Only api has node_modules installed.
+		if err := os.MkdirAll(filepath.Join(tmpDir, "api", "node_modules"), 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		_ = os.RemoveAll(filepath.Join(tmpDir, "web", "node_modules"))
+
+		var buf bytes.Buffer
+		err := runDepsCheck(&DepsOptions{}, &buf)
+		if err == nil {
+			t.Fatal("expected a non-nil error when a service is missing dependencies")
+		}
+		if !strings.Contains(buf.String(), "[missing]") {
+			t.Errorf("expected report to flag a missing service, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("all installed returns nil", func(t *testing.T) {
+		for _, name := range []string{"api", "web"} {
+			if err := os.MkdirAll(filepath.Join(tmpDir, name, "node_modules"), 0o750); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+		}
+
+		var buf bytes.Buffer
+		if err := runDepsCheck(&DepsOptions{}, &buf); err != nil {
+			t.Fatalf("expected nil error when all installed, got %v", err)
+		}
+		if !strings.Contains(buf.String(), "installed") {
+			t.Errorf("expected success report, got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("service filter narrows the check", func(t *testing.T) {
+		// web is missing, but limiting to api (installed) should pass.
+		_ = os.RemoveAll(filepath.Join(tmpDir, "web", "node_modules"))
+		if err := os.MkdirAll(filepath.Join(tmpDir, "api", "node_modules"), 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		var buf bytes.Buffer
+		if err := runDepsCheck(&DepsOptions{Services: []string{"api"}}, &buf); err != nil {
+			t.Fatalf("expected nil error when only checking an installed service, got %v", err)
+		}
+	})
+}

--- a/cli/src/cmd/app/commands/deps_test.go
+++ b/cli/src/cmd/app/commands/deps_test.go
@@ -83,7 +83,7 @@ func TestDepsCommand_Flags(t *testing.T) {
 	}
 
 	// Verify flags exist
-	flags := []string{"verbose", "clean", "no-cache", "force", "dry-run", "service"}
+	flags := []string{"verbose", "clean", "no-cache", "force", "dry-run", "check", "service"}
 	for _, flagName := range flags {
 		if cmd.Flags().Lookup(flagName) == nil {
 			t.Errorf("Flag %q not found", flagName)


### PR DESCRIPTION
## What

Add a `--check` flag to `azd app deps` that verifies each service already has its dependencies installed, without installing anything. It exits non-zero when a service is missing dependencies, so you can use it as a CI gate.

## Why

`azd app deps` installs dependencies and `--dry-run` shows what would be installed, but there was no fast way to answer "are all services ready to run?" without actually installing. In CI you often want to fail early with a clear message when someone forgot to commit a lockfile change or a fresh checkout has not installed yet. `--check` gives you that as a single command with a non-zero exit code.

## How

- New `--check` flag on the deps command. When set, `RunE` short-circuits to `runDepsCheck` before any install path runs.
- Detection reuses the existing azure.yaml service discovery (`detectProjectsFromAzureYaml`) and the `--service` filter.
- Installed markers per language:
  - Node: `node_modules` in the project dir, or a shared `node_modules` at the workspace root for workspace children.
  - Python: a `.venv` or `venv` directory.
  - .NET: `obj/project.assets.json` (written by a successful restore) next to the project file.
- Prints a per-service report in text mode and honors JSON output via the global `-o json` flag.
- Returns an error (non-zero exit) listing how many services are missing dependencies.

## Examples

```bash
# Verify every service is installed; exit non-zero if any are missing
azd app deps --check

# Check a single service
azd app deps --check --service api

# Machine-readable output
azd app deps --check -o json
```

## Testing

- `go build ./...`
- `go test ./src/cmd/app/commands/ -run 'TestNodeDepsMarker|TestPythonDepsMarker|TestDotnetDepsMarker|TestBuildDepsCheckResult|TestRenderDepsCheckText|TestRunDepsCheck|TestNewDepsCommand'`

Added unit tests for each language marker, the aggregation logic, the text report, and an end-to-end check covering the missing, all-installed, and service-filter cases.

Closes #450
