### PR TITLE
Add env --keys to list variable names without values

### DIFF
--- a/cli/src/cmd/app/commands/env.go
+++ b/cli/src/cmd/app/commands/env.go
@@ -30,6 +30,7 @@ var (
 	envDiff    bool
 	envWrite   bool
 	envOut     string
+	envKeys    bool
 )
 
 // NewEnvCommand creates the env command.
@@ -70,6 +71,9 @@ Examples:
   # Compare the resolved environment of two services
   azd app env --diff api web
 
+  # List variable names without values
+  azd app env api --keys
+
   # Write the resolved environment to api/.env
   azd app env api --write
 
@@ -92,6 +96,7 @@ Examples:
 	cmd.Flags().BoolVar(&envDiff, "diff", false, "Compare the resolved environment of two services (pass two service names)")
 	cmd.Flags().BoolVar(&envWrite, "write", false, "Write the resolved environment to a .env file instead of printing it")
 	cmd.Flags().StringVar(&envOut, "out", "", "Destination folder for --write files (writes <service>.env); defaults to each service directory")
+	cmd.Flags().BoolVar(&envKeys, "keys", false, "Print variable names only")
 
 	return cmd
 }
@@ -115,6 +120,9 @@ func runEnv(_ *cobra.Command, args []string) error {
 
 	// --diff compares two services and takes exactly two service names.
 	if envDiff {
+		if envKeys {
+			return fmt.Errorf("cannot combine --keys with --diff")
+		}
 		return runEnvDiff(azureYaml, names, args)
 	}
 
@@ -131,6 +139,21 @@ func runEnv(_ *cobra.Command, args []string) error {
 	// --out only makes sense together with --write.
 	if envOut != "" && !envWrite {
 		return fmt.Errorf("--out requires --write")
+	}
+
+	if envKeys {
+		if envExplain {
+			return fmt.Errorf("cannot combine --keys with --explain")
+		}
+		if envWrite {
+			return fmt.Errorf("cannot combine --keys with --write")
+		}
+		if envAll {
+			return runEnvAllKeys(azureYaml, names)
+		}
+		if len(args) == 0 {
+			return fmt.Errorf("specify a service name or --all with --keys")
+		}
 	}
 
 	if envWrite {
@@ -179,6 +202,10 @@ func runEnv(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to resolve environment for %q: %w", serviceName, err)
 	}
 
+	if envKeys {
+		return renderEnvKeys(extractEnvKeys(resolved), format)
+	}
+
 	if format == envFormatJSON {
 		return cliout.PrintJSON(maskEnv(resolved, mask))
 	}
@@ -211,6 +238,66 @@ func runEnvAll(azureYaml *service.AzureYaml, names []string) error {
 	}
 
 	return renderAllEnv(resolvedByService, names, format, !envNoMask)
+}
+
+func runEnvAllKeys(azureYaml *service.AzureYaml, names []string) error {
+	format, err := resolveEnvFormat(envFormat)
+	if err != nil {
+		return err
+	}
+	if cliout.IsJSON() {
+		format = envFormatJSON
+	}
+
+	keysByService := make(map[string][]string, len(names))
+	for _, name := range names {
+		resolved, err := service.ResolveEnvironment(context.Background(), azureYaml.Services[name], getAzureEnvironmentValues(), envFile, nil)
+		if err != nil {
+			return fmt.Errorf("failed to resolve environment for %q: %w", name, err)
+		}
+		keysByService[name] = extractEnvKeys(resolved)
+	}
+
+	return renderAllEnvKeys(keysByService, names, format)
+}
+
+func extractEnvKeys(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func renderEnvKeys(keys []string, format string) error {
+	if format == envFormatJSON {
+		return cliout.PrintJSON(keys)
+	}
+	for _, key := range keys {
+		fmt.Println(key)
+	}
+	return nil
+}
+
+func renderAllEnvKeys(keysByService map[string][]string, names []string, format string) error {
+	if format == envFormatJSON {
+		return cliout.PrintJSON(keysByService)
+	}
+	if len(names) == 0 {
+		fmt.Println("No services are defined")
+		return nil
+	}
+	for i, name := range names {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("# %s\n", name)
+		for _, key := range keysByService[name] {
+			fmt.Println(key)
+		}
+	}
+	return nil
 }
 
 // renderAllEnv writes the resolved environment for every service. The json format

--- a/cli/src/cmd/app/commands/env_test.go
+++ b/cli/src/cmd/app/commands/env_test.go
@@ -19,7 +19,7 @@ func TestNewEnvCommand(t *testing.T) {
 	assert.NotEmpty(t, cmd.Short)
 	require.NotNil(t, cmd.RunE)
 
-	for _, name := range []string{"format", "no-mask", "env-file", "all", "explain", "diff", "write", "out"} {
+	for _, name := range []string{"format", "no-mask", "env-file", "all", "explain", "diff", "write", "out", "keys"} {
 		assert.NotNil(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
@@ -208,6 +208,106 @@ func TestRunEnvCommand(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(out), &parsed))
 		assert.Contains(t, parsed, "api")
 		assert.Contains(t, parsed, "web")
+	})
+
+	t.Run("keys prints sorted variable names for a service", func(t *testing.T) {
+		resetEnvFlags()
+		t.Setenv("Z_SERVICE_ENV_MARKER", "z-value")
+		t.Setenv("A_SERVICE_ENV_MARKER", "a-value")
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api", "--keys"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+
+		lines := splitNonEmpty(out)
+		aIndex := indexOf(lines, "A_SERVICE_ENV_MARKER")
+		zIndex := indexOf(lines, "Z_SERVICE_ENV_MARKER")
+		require.NotEqual(t, -1, aIndex)
+		require.NotEqual(t, -1, zIndex)
+		assert.Less(t, aIndex, zIndex)
+		assert.NotContains(t, out, "a-value")
+		assert.NotContains(t, out, "z-value")
+	})
+
+	t.Run("all keys groups services", func(t *testing.T) {
+		resetEnvFlags()
+		t.Setenv("SERVICE_ENV_MARKER", "marker-value")
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"--all", "--keys"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+
+		assert.Contains(t, out, "# api")
+		assert.Contains(t, out, "# web")
+		assert.Contains(t, out, "SERVICE_ENV_MARKER")
+		assert.NotContains(t, out, "marker-value")
+	})
+
+	t.Run("all keys with json emits key arrays", func(t *testing.T) {
+		resetEnvFlags()
+		t.Setenv("SERVICE_ENV_MARKER", "marker-value")
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"--all", "--keys", "--format", "json"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+
+		var parsed map[string][]string
+		require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+		assert.Contains(t, parsed, "api")
+		assert.Contains(t, parsed["api"], "SERVICE_ENV_MARKER")
+		assert.Contains(t, parsed, "web")
+	})
+
+	t.Run("keys with json emits key array", func(t *testing.T) {
+		resetEnvFlags()
+		t.Setenv("SERVICE_ENV_MARKER", "marker-value")
+		out, runErr := captureStdout(t, func() error {
+			cmd := NewEnvCommand()
+			cmd.SetArgs([]string{"api", "--keys", "--format", "json"})
+			return cmd.Execute()
+		})
+		require.NoError(t, runErr)
+
+		var parsed []string
+		require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+		assert.Contains(t, parsed, "SERVICE_ENV_MARKER")
+	})
+
+	t.Run("keys without service or all errors", func(t *testing.T) {
+		resetEnvFlags()
+		cmd := NewEnvCommand()
+		cmd.SetArgs([]string{"--keys"})
+		runErr := cmd.Execute()
+		require.Error(t, runErr)
+		assert.Contains(t, runErr.Error(), "specify a service name or --all")
+	})
+
+	t.Run("keys rejects incompatible flags", func(t *testing.T) {
+		tests := []struct {
+			name string
+			args []string
+			want string
+		}{
+			{"diff", []string{"--keys", "--diff", "api", "web"}, "cannot combine --keys with --diff"},
+			{"explain", []string{"api", "--keys", "--explain"}, "cannot combine --keys with --explain"},
+			{"write", []string{"api", "--keys", "--write"}, "cannot combine --keys with --write"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				resetEnvFlags()
+				cmd := NewEnvCommand()
+				cmd.SetArgs(tt.args)
+				runErr := cmd.Execute()
+				require.Error(t, runErr)
+				assert.Contains(t, runErr.Error(), tt.want)
+			})
+		}
 	})
 
 	t.Run("all with a service name errors", func(t *testing.T) {
@@ -425,6 +525,7 @@ func resetEnvFlags() {
 	envDiff = false
 	envWrite = false
 	envOut = ""
+	envKeys = false
 	_ = cliout.SetFormat("default")
 }
 
@@ -486,4 +587,13 @@ func splitNonEmpty(s string) []string {
 		}
 	}
 	return out
+}
+
+func indexOf(values []string, target string) int {
+	for i, value := range values {
+		if value == target {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
Closes #479

## Summary

- add `azd app env --keys` for single-service and all-service key listings
- add JSON key output for scripts
- reject `--keys` with flags that need values or comparisons

## Verification

- `go test .\src\cmd\app\commands -run 'Test.*Env' -count=1`
- `go test .\src\cmd\app\commands -count=1`
