### PR TITLE
Add service filtering to azd app status

### DIFF
--- a/cli/src/cmd/app/commands/status.go
+++ b/cli/src/cmd/app/commands/status.go
@@ -25,6 +25,7 @@ const minStatusWatchInterval = time.Second
 var (
 	statusWatch    bool
 	statusInterval time.Duration
+	statusService  string
 )
 
 type statusReport struct {
@@ -51,6 +52,9 @@ Examples:
   # One-time snapshot
   azd app status
 
+  # Show one service
+  azd app status --service api
+
   # Live view, refreshed every 2 seconds
   azd app status --watch
 
@@ -61,11 +65,16 @@ Examples:
 	}
 	cmd.Flags().BoolVar(&statusWatch, "watch", false, "Refresh the status on an interval until interrupted")
 	cmd.Flags().DurationVar(&statusInterval, "interval", 2*time.Second, "Refresh interval for --watch (minimum 1s)")
+	cmd.Flags().StringVarP(&statusService, "service", "s", "", "Filter to specific service(s), comma-separated")
 	return cmd
 }
 
 func runStatus(cmd *cobra.Command, _ []string) error {
 	projectDir, err := findProjectDir()
+	if err != nil {
+		return err
+	}
+	requested, err := parseServiceList(statusService)
 	if err != nil {
 		return err
 	}
@@ -78,7 +87,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		}
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
-		return watchStatus(ctx, os.Stdout, projectDir, statusInterval)
+		return watchStatus(ctx, os.Stdout, projectDir, statusInterval, requested)
 	}
 
 	cliout.CommandHeader("status", "Show app status")
@@ -86,6 +95,12 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	report, err := buildStatusReport(projectDir)
 	if err != nil {
 		return err
+	}
+	if len(requested) > 0 {
+		report, err = filterStatusReport(report, requested)
+		if err != nil {
+			return err
+		}
 	}
 
 	if cliout.IsJSON() {
@@ -98,11 +113,17 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 
 // watchStatus renders the status to w immediately and then again on every tick
 // until the context is canceled (for example by Ctrl+C).
-func watchStatus(ctx context.Context, w io.Writer, projectDir string, interval time.Duration) error {
+func watchStatus(ctx context.Context, w io.Writer, projectDir string, interval time.Duration, requested []string) error {
 	render := func() error {
 		report, err := buildStatusReport(projectDir)
 		if err != nil {
 			return err
+		}
+		if len(requested) > 0 {
+			report, err = filterStatusReport(report, requested)
+			if err != nil {
+				return err
+			}
 		}
 		renderStatusReport(w, report, time.Now())
 		return nil
@@ -166,6 +187,32 @@ func buildStatusReport(projectDir string) (statusReport, error) {
 		StartTime:    st.StartTime,
 		Services:     statusServices(projectDir, st.Services),
 	}, nil
+}
+
+func filterStatusReport(report statusReport, requested []string) (statusReport, error) {
+	if len(requested) == 0 || !report.Running {
+		return report, nil
+	}
+
+	available := make([]string, 0, len(report.Services))
+	byName := make(map[string]runstate.ServiceState, len(report.Services))
+	for _, svc := range report.Services {
+		available = append(available, svc.Name)
+		byName[svc.Name] = svc
+	}
+	sort.Strings(available)
+
+	filtered := make([]runstate.ServiceState, 0, len(requested))
+	for _, name := range requested {
+		resolved, err := resolveServiceName(name, available)
+		if err != nil {
+			return statusReport{}, err
+		}
+		filtered = append(filtered, byName[resolved])
+	}
+
+	report.Services = filtered
+	return report, nil
 }
 
 func statusServices(projectDir string, fallback []runstate.ServiceState) []runstate.ServiceState {

--- a/cli/src/cmd/app/commands/status_test.go
+++ b/cli/src/cmd/app/commands/status_test.go
@@ -25,6 +25,7 @@ func TestNewStatusCommand(t *testing.T) {
 	require.NotNil(t, cmd.RunE)
 	assert.NotNil(t, cmd.Flags().Lookup("watch"), "expected --watch flag")
 	assert.NotNil(t, cmd.Flags().Lookup("interval"), "expected --interval flag")
+	assert.NotNil(t, cmd.Flags().Lookup("service"), "expected --service flag")
 }
 
 func TestRenderStatusReport(t *testing.T) {
@@ -45,11 +46,37 @@ func TestWatchStatusStopsOnContextCancel(t *testing.T) {
 	cancel() // already canceled: render one frame, then return via ctx.Done()
 
 	var buf bytes.Buffer
-	err := watchStatus(ctx, &buf, projectDir, time.Second)
+	err := watchStatus(ctx, &buf, projectDir, time.Second, nil)
 	require.NoError(t, err)
 	out := buf.String()
 	assert.Contains(t, out, "App is not running")
 	assert.Contains(t, out, "Stopped watching.")
+}
+
+func TestWatchStatusAppliesServiceFilter(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Cleanup(func() {
+		_ = runstate.Remove(projectDir)
+	})
+
+	require.NoError(t, runstate.Write(projectDir, runstate.RunState{
+		PID:       os.Getpid(),
+		StartTime: time.Now().UTC().Round(time.Second),
+		Services: []runstate.ServiceState{
+			{Name: "api", URL: "http://localhost:8080", Port: 8080},
+			{Name: "web", URL: "http://localhost:3000", Port: 3000},
+		},
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var buf bytes.Buffer
+	err := watchStatus(ctx, &buf, projectDir, time.Second, []string{"api"})
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "api: http://localhost:8080")
+	assert.NotContains(t, out, "web: http://localhost:3000")
 }
 
 func TestRunStatusWatchIntervalTooSmall(t *testing.T) {
@@ -111,6 +138,38 @@ func TestBuildStatusReportRunning(t *testing.T) {
 	assert.Contains(t, string(payload), `"running":true`)
 	assert.Contains(t, string(payload), `"dashboardUrl":"http://localhost:40000"`)
 	assert.Contains(t, string(payload), `"name":"api"`)
+}
+
+func TestFilterStatusReport(t *testing.T) {
+	report := statusReport{
+		Running: true,
+		PID:     123,
+		Services: []runstate.ServiceState{
+			{Name: "api", URL: "http://localhost:8080", Port: 8080},
+			{Name: "worker", Port: 9000},
+			{Name: "web", URL: "http://localhost:3000", Port: 3000},
+		},
+	}
+
+	filtered, err := filterStatusReport(report, []string{"web", "api"})
+	require.NoError(t, err)
+	require.Len(t, filtered.Services, 2)
+	assert.Equal(t, "web", filtered.Services[0].Name)
+	assert.Equal(t, "api", filtered.Services[1].Name)
+
+	_, err = filterStatusReport(report, []string{"webb"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `service "webb" not found`)
+	assert.Contains(t, err.Error(), `Did you mean "web"?`)
+}
+
+func TestFilterStatusReportNotRunning(t *testing.T) {
+	report := statusReport{Running: false}
+
+	filtered, err := filterStatusReport(report, []string{"api"})
+	require.NoError(t, err)
+	assert.False(t, filtered.Running)
+	assert.Empty(t, filtered.Services)
 }
 
 func TestBuildStatusReportStaleStateRemovesFile(t *testing.T) {


### PR DESCRIPTION
Closes #480

## Summary

- add `azd app status --service, -s` for comma-separated service filters
- apply the filter to text, JSON, and watch output
- return the same service name suggestions used by other service commands

## Verification

- `go test .\src\cmd\app\commands -run 'Test.*Status' -count=1`
- `go test .\src\cmd\app\commands -count=1`
