### PR TITLE
Add dry-run preview to support bundles

### DIFF
--- a/cli/src/cmd/app/commands/support_bundle.go
+++ b/cli/src/cmd/app/commands/support_bundle.go
@@ -32,6 +32,15 @@ type supportBundleOptions struct {
 	output  string
 	tail    int
 	service string
+	dryRun  bool
+}
+
+type supportBundlePlan struct {
+	DryRun    bool     `json:"dryRun"`
+	OutputDir string   `json:"outputDir"`
+	Files     []string `json:"files"`
+	Tail      int      `json:"tail"`
+	Service   string   `json:"service,omitempty"`
 }
 
 type supportBundleManifest struct {
@@ -50,9 +59,11 @@ type supportBundleManifest struct {
 func NewSupportBundleCommand() *cobra.Command {
 	opts := &supportBundleOptions{tail: defaultSupportBundleTail}
 	cmd := &cobra.Command{
-		Use:          "support-bundle",
-		Short:        "Collect local diagnostics for support",
-		Long:         "Collect sanitized project, service, health, and log diagnostics into a local folder for issue reports.",
+		Use:   "support-bundle",
+		Short: "Collect local diagnostics for support",
+		Long: `Collect sanitized project, service, health, and log diagnostics into a local folder for issue reports.
+
+Use --dry-run to preview the output folder and file list without writing files.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSupportBundle(cmd.Context(), opts)
@@ -61,6 +72,7 @@ func NewSupportBundleCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "Output folder path")
 	cmd.Flags().IntVar(&opts.tail, "tail", defaultSupportBundleTail, "Recent log lines per service to include")
 	cmd.Flags().StringVarP(&opts.service, "service", "s", "", "Include logs and health for specific service(s), comma-separated")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Show the bundle plan without writing files")
 	return cmd
 }
 
@@ -71,6 +83,9 @@ func runSupportBundle(ctx context.Context, opts *supportBundleOptions) error {
 	if opts.tail < 0 {
 		return fmt.Errorf("--tail must be zero or greater")
 	}
+	if _, err := parseServiceList(opts.service); err != nil {
+		return err
+	}
 
 	azureYamlPath, err := findAzureYaml()
 	if err != nil {
@@ -80,6 +95,15 @@ func runSupportBundle(ctx context.Context, opts *supportBundleOptions) error {
 	outputDir, err := resolveSupportBundleOutput(projectDir, opts.output)
 	if err != nil {
 		return err
+	}
+	if opts.dryRun {
+		return renderSupportBundlePlan(supportBundlePlan{
+			DryRun:    true,
+			OutputDir: outputDir,
+			Files:     plannedSupportBundleFiles(),
+			Tail:      opts.tail,
+			Service:   opts.service,
+		})
 	}
 	if err := os.MkdirAll(outputDir, 0o750); err != nil {
 		return fmt.Errorf("failed to create support bundle folder: %w", err)
@@ -131,6 +155,34 @@ func runSupportBundle(ctx context.Context, opts *supportBundleOptions) error {
 	cliout.Info("Included %d file(s)", len(manifest.Files)+1)
 	if len(manifest.Warnings) > 0 {
 		cliout.Warning("Completed with %d warning(s). See manifest.json.", len(manifest.Warnings))
+	}
+	return nil
+}
+
+func plannedSupportBundleFiles() []string {
+	return []string{
+		"manifest.json",
+		"azure.yaml.redacted",
+		"services.json",
+		"requirements.json",
+		"health.json",
+		"logs.json",
+	}
+}
+
+func renderSupportBundlePlan(plan supportBundlePlan) error {
+	if cliout.IsJSON() {
+		return cliout.PrintJSON(plan)
+	}
+	cliout.Info("Support bundle dry run")
+	cliout.Item("Output: %s", plan.OutputDir)
+	cliout.Item("Tail: %d", plan.Tail)
+	if plan.Service != "" {
+		cliout.Item("Service: %s", plan.Service)
+	}
+	cliout.Info("Files that would be written:")
+	for _, name := range plan.Files {
+		cliout.Item("%s", name)
 	}
 	return nil
 }

--- a/cli/src/cmd/app/commands/support_bundle_test.go
+++ b/cli/src/cmd/app/commands/support_bundle_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jongio/azd-core/cliout"
 )
 
 func TestNewSupportBundleCommand(t *testing.T) {
@@ -16,10 +18,110 @@ func TestNewSupportBundleCommand(t *testing.T) {
 	if cmd.Use != "support-bundle" {
 		t.Fatalf("Use = %q, want support-bundle", cmd.Use)
 	}
-	for _, name := range []string{"output", "tail", "service"} {
+	for _, name := range []string{"output", "tail", "service", "dry-run"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Fatalf("%s flag not found", name)
 		}
+	}
+}
+
+func TestRunSupportBundleDryRunText(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(`
+	name: bundle-test
+	services:
+	  api:
+	    host: local
+	    language: go
+	`), 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+	t.Chdir(dir)
+	outDir := filepath.Join(dir, "bundle")
+
+	if err := cliout.SetFormat("default"); err != nil {
+		t.Fatalf("set output format: %v", err)
+	}
+	out, err := captureStdout(t, func() error {
+		return runSupportBundle(t.Context(), &supportBundleOptions{
+			output:  outDir,
+			tail:    0,
+			service: "api",
+			dryRun:  true,
+		})
+	})
+	if err != nil {
+		t.Fatalf("dry-run failed: %v", err)
+	}
+
+	if _, statErr := os.Stat(outDir); !os.IsNotExist(statErr) {
+		t.Fatalf("dry-run wrote output folder, stat error: %v", statErr)
+	}
+	for _, want := range []string{"Support bundle dry run", outDir, "manifest.json", "azure.yaml.redacted", "logs.json", "Service: api"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSupportBundleDryRunJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte("name: bundle-test\nservices: {}\n"), 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+	t.Chdir(dir)
+	outDir := filepath.Join(dir, "bundle")
+
+	originalFormat := cliout.GetFormat()
+	if err := cliout.SetFormat("json"); err != nil {
+		t.Fatalf("set output format: %v", err)
+	}
+	t.Cleanup(func() { _ = cliout.SetFormat(string(originalFormat)) })
+
+	out, err := captureStdout(t, func() error {
+		return runSupportBundle(t.Context(), &supportBundleOptions{
+			output: outDir,
+			tail:   5,
+			dryRun: true,
+		})
+	})
+	if err != nil {
+		t.Fatalf("dry-run failed: %v", err)
+	}
+
+	var plan supportBundlePlan
+	if err := json.Unmarshal([]byte(out), &plan); err != nil {
+		t.Fatalf("dry-run JSON is invalid: %v\n%s", err, out)
+	}
+	if !plan.DryRun {
+		t.Fatal("dryRun was false")
+	}
+	if plan.OutputDir != outDir {
+		t.Fatalf("outputDir = %q, want %q", plan.OutputDir, outDir)
+	}
+	if plan.Tail != 5 {
+		t.Fatalf("tail = %d, want 5", plan.Tail)
+	}
+	if len(plan.Files) != len(plannedSupportBundleFiles()) {
+		t.Fatalf("files = %#v", plan.Files)
+	}
+	if _, statErr := os.Stat(outDir); !os.IsNotExist(statErr) {
+		t.Fatalf("dry-run wrote output folder, stat error: %v", statErr)
+	}
+}
+
+func TestRunSupportBundleDryRunValidatesInputs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte("name: bundle-test\nservices: {}\n"), 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+	t.Chdir(dir)
+
+	if err := runSupportBundle(t.Context(), &supportBundleOptions{tail: -1, dryRun: true}); err == nil || !strings.Contains(err.Error(), "--tail must be zero or greater") {
+		t.Fatalf("expected tail validation error, got %v", err)
+	}
+	if err := runSupportBundle(t.Context(), &supportBundleOptions{tail: 0, service: "../api", dryRun: true}); err == nil || !strings.Contains(err.Error(), "invalid service name") {
+		t.Fatalf("expected service validation error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #481

## Summary

- add `azd app support-bundle --dry-run`
- print the planned output folder, tail setting, service filter, and file list
- add JSON output for scripts and tests that verify no files are written

## Verification

- `go test .\src\cmd\app\commands -run 'Test.*SupportBundle' -count=1`
- `go test .\src\cmd\app\commands -count=1`
