### PR TITLE
feat(add): preview well-known services with dry run

### DIFF
--- a/cli/src/cmd/app/commands/add.go
+++ b/cli/src/cmd/app/commands/add.go
@@ -54,6 +54,7 @@ Examples:
 
 	cmd.Flags().Bool("list", false, "List all available services")
 	cmd.Flags().Bool("show-connection", false, "Show connection string after adding")
+	cmd.Flags().Bool("dry-run", false, "Show the azure.yaml service block without modifying the file")
 
 	return cmd
 }
@@ -63,12 +64,14 @@ type AddResult struct {
 	Service           string            `json:"service"`
 	Added             bool              `json:"added"`
 	Message           string            `json:"message,omitempty"`
+	Preview           string            `json:"preview,omitempty"`
 	ConnectionStrings map[string]string `json:"connectionStrings,omitempty"`
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {
 	listServices, _ := cmd.Flags().GetBool("list")
 	showConnection, _ := cmd.Flags().GetBool("show-connection")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 	// Handle --list flag
 	if listServices {
@@ -110,6 +113,28 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			})
 		}
 		cliout.Warning("Service %q already exists in azure.yaml", serviceName)
+		return nil
+	}
+
+	if dryRun {
+		preview, previewErr := buildServicePreview(serviceName, def)
+		if previewErr != nil {
+			return fmt.Errorf("failed to build service preview: %w", previewErr)
+		}
+		if cliout.IsJSON() {
+			return cliout.PrintJSON(AddResult{
+				Service: serviceName,
+				Added:   false,
+				Message: fmt.Sprintf("Would add %s to azure.yaml", def.DisplayName),
+				Preview: preview,
+			})
+		}
+		cliout.Info("Dry run: would add %s to azure.yaml", def.DisplayName)
+		cliout.Newline()
+		fmt.Print(preview)
+		if !strings.HasSuffix(preview, "\n") {
+			cliout.Newline()
+		}
 		return nil
 	}
 
@@ -385,4 +410,26 @@ func buildServiceNode(def *wellknown.ServiceDefinition) *yaml.Node {
 	}
 
 	return node
+}
+
+func buildServicePreview(serviceName string, def *wellknown.ServiceDefinition) (string, error) {
+	servicesNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: serviceName, Tag: "!!str"},
+			buildServiceNode(def),
+		},
+	}
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "services", Tag: "!!str"},
+			servicesNode,
+		},
+	}
+	out, err := yaml.Marshal(root)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }

--- a/cli/src/cmd/app/commands/add_test.go
+++ b/cli/src/cmd/app/commands/add_test.go
@@ -212,3 +212,62 @@ func TestBuildServiceNode(t *testing.T) {
 		t.Error("buildServiceNode() did not include environment (postgres has env vars)")
 	}
 }
+
+func TestBuildServicePreview(t *testing.T) {
+	def := wellknown.Get("redis")
+	if def == nil {
+		t.Fatal("redis service not found in wellknown registry")
+	}
+
+	preview, err := buildServicePreview("redis", def)
+	if err != nil {
+		t.Fatalf("buildServicePreview() error: %v", err)
+	}
+
+	for _, want := range []string{"services:", "redis:", "image: redis:7-alpine", "6379:6379"} {
+		if !strings.Contains(preview, want) {
+			t.Errorf("preview missing %q:\n%s", want, preview)
+		}
+	}
+}
+
+func TestRunAddDryRunDoesNotModifyAzureYaml(t *testing.T) {
+	tempDir := t.TempDir()
+	content := `name: test-app
+services:
+  api:
+    language: python
+    project: ./api
+`
+	azureYamlPath := filepath.Join(tempDir, "azure.yaml")
+	if err := os.WriteFile(azureYamlPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to create azure.yaml: %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if chdirErr := os.Chdir(originalWD); chdirErr != nil {
+			t.Fatalf("failed to restore cwd: %v", chdirErr)
+		}
+	})
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	cmd := NewAddCommand()
+	cmd.SetArgs([]string{"redis", "--dry-run"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("add --dry-run failed: %v", err)
+	}
+
+	after, err := os.ReadFile(azureYamlPath)
+	if err != nil {
+		t.Fatalf("failed to read azure.yaml: %v", err)
+	}
+	if string(after) != content {
+		t.Fatalf("dry-run modified azure.yaml:\n%s", string(after))
+	}
+}


### PR DESCRIPTION
Closes #486

## Summary
- add `azd app add <service> --dry-run`
- print the generated azure.yaml service block without writing the file
- include the preview in JSON output

## Verification
- `go test .\src\cmd\app\commands -run "Test(BuildServicePreview|RunAddDryRunDoesNotModifyAzureYaml|AddServiceToYaml|ServiceExistsInYaml)"`
- `mage test`
- `mage build`