### PR TITLE
deps: upgrade all dependencies to latest

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
-	github.com/dlclark/regexp2/v2 v2.2.2 // indirect
+	github.com/dlclark/regexp2/v2 v2.3.0 // indirect
 	github.com/drone/envsubst v1.0.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -113,8 +113,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
 github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dlclark/regexp2/v2 v2.2.2 h1:MYWvNYw8okuqNhwTYO587EZMiDruVa2vhV6fsGpfya0=
-github.com/dlclark/regexp2/v2 v2.2.2/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
+github.com/dlclark/regexp2/v2 v2.3.0 h1:pHWdu9ZP0TZ9fsXu4mk8709Ssf3C4g3A6BqHlvvkEn8=
+github.com/dlclark/regexp2/v2 v2.3.0/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
 github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
Automated dependency upgrade sweep.

## Changes
- Go (`cli/go.mod`): bump `github.com/dlclark/regexp2/v2` from `v2.2.2` to `v2.3.0` (indirect), via `go get -u ./... && go mod tidy`.

## Intentionally skipped (7-day release-age cooldown)
- `typescript` 6.0.3 -> 7.0.2: published 2026-07-08 (major rewrite, inside cooldown).
- `eslint` 10.6.0 -> 10.7.0: published 2026-07-10 (inside cooldown).

## Already current
- `web/` dependencies: all at latest stable.
- `cli/dashboard` and `cli/package.json` JS deps: latest except the cooldown items above.

## Verification (local)
- `go build ./...`: pass
- `go vet ./src/...`: pass
- `go test -short ./src/...`: pass (portmanager re-run passed in isolation; the one flaky failure was port 8080 contention on the shared dev machine, unrelated to this bump).
- Dashboard `pnpm build`: pass.