### PR TITLE
feat(reqs): add only-missing output

### DIFF
--- a/cli/src/cmd/app/commands/core.go
+++ b/cli/src/cmd/app/commands/core.go
@@ -44,7 +44,8 @@ func newCommandOrchestrator() *orchestrator.Orchestrator {
 
 // ExecutionContext holds runtime configuration for command execution.
 type ExecutionContext struct {
-	CacheEnabled bool
+	CacheEnabled    bool
+	ReqsOnlyMissing bool
 }
 
 // ReqsResult represents the JSON output structure for reqs command.
@@ -94,6 +95,11 @@ func SetCacheEnabled(enabled bool) {
 	execContext.CacheEnabled = enabled
 }
 
+// SetReqsOnlyMissing configures whether reqs output should include only failures.
+func SetReqsOnlyMissing(enabled bool) {
+	execContext.ReqsOnlyMissing = enabled
+}
+
 // executeReqs is the core logic for the reqs command.
 func executeReqs() error {
 	cliout.CommandHeader("reqs", "Check required prerequisites")
@@ -132,17 +138,24 @@ func executeReqs() error {
 
 	// Check requirements (with caching)
 	results, allSatisfied := checkRequirementsWithCache(effectiveReqs, azureYamlPath, cacheManager)
+	displayResults := results
+	if execContext.ReqsOnlyMissing {
+		displayResults = filterUnsatisfiedReqResults(results)
+	}
 
 	// JSON output
 	if cliout.IsJSON() {
 		return cliout.PrintJSON(ReqsResult{
 			Satisfied: allSatisfied,
-			Reqs:      results,
+			Reqs:      displayResults,
 		})
 	}
 
 	// Default output
 	cliout.Newline()
+	if execContext.ReqsOnlyMissing {
+		NewResultFormatter().PrintAll(displayResults)
+	}
 	if !allSatisfied {
 		cliout.Info("%s If you recently installed any missing tools, run 'azd app reqs --fix' to refresh PATH", cliout.IconBulb)
 		return fmt.Errorf("requirement check failed")

--- a/cli/src/cmd/app/commands/core_helpers.go
+++ b/cli/src/cmd/app/commands/core_helpers.go
@@ -130,13 +130,13 @@ func checkAllSuccess(results []InstallResult) bool {
 func checkRequirementsWithCache(reqs []Prerequisite, azureYamlPath string, cacheManager *cache.CacheManager) ([]ReqResult, bool) {
 	// Try cache first if enabled
 	if cacheManager.IsEnabled() {
-		if results, allSatisfied, ok := tryGetCachedResults(azureYamlPath, cacheManager); ok {
+		if results, allSatisfied, ok := tryGetCachedResults(azureYamlPath, cacheManager, execContext.ReqsOnlyMissing); ok {
 			return results, allSatisfied
 		}
 	}
 
 	// Perform fresh check (output is shown inline during checks)
-	results, allSatisfied := performReqsCheck(reqs)
+	results, allSatisfied := performReqsCheckWithOptions(reqs, execContext.ReqsOnlyMissing)
 
 	// Save to cache if enabled
 	if cacheManager.IsEnabled() {
@@ -147,7 +147,7 @@ func checkRequirementsWithCache(reqs []Prerequisite, azureYamlPath string, cache
 }
 
 // tryGetCachedResults attempts to retrieve and use cached results.
-func tryGetCachedResults(azureYamlPath string, cacheManager *cache.CacheManager) ([]ReqResult, bool, bool) {
+func tryGetCachedResults(azureYamlPath string, cacheManager *cache.CacheManager, suppressOutput bool) ([]ReqResult, bool, bool) {
 	cachedResults, valid, err := cacheManager.GetCachedResults(azureYamlPath)
 	if err != nil {
 		// Log cache read errors in both JSON and non-JSON modes for visibility
@@ -162,7 +162,7 @@ func tryGetCachedResults(azureYamlPath string, cacheManager *cache.CacheManager)
 	}
 
 	// Cache hit
-	if !cliout.IsJSON() {
+	if !suppressOutput && !cliout.IsJSON() {
 		cliout.Info("Using cached reqs check results...")
 	}
 
@@ -170,7 +170,7 @@ func tryGetCachedResults(azureYamlPath string, cacheManager *cache.CacheManager)
 	results := convertCachedResults(cachedResults.Results)
 
 	// Print cached results
-	if !cliout.IsJSON() {
+	if !suppressOutput && !cliout.IsJSON() {
 		formatter := NewResultFormatter()
 		formatter.PrintAll(results)
 	}
@@ -219,7 +219,12 @@ func saveToCache(azureYamlPath string, results []ReqResult, allSatisfied bool, c
 
 // performReqsCheck performs fresh reqs checking.
 func performReqsCheck(reqs []Prerequisite) ([]ReqResult, bool) {
+	return performReqsCheckWithOptions(reqs, false)
+}
+
+func performReqsCheckWithOptions(reqs []Prerequisite, suppressOutput bool) ([]ReqResult, bool) {
 	checker := NewPrerequisiteChecker()
+	checker.suppressOutput = suppressOutput
 	results := make([]ReqResult, 0, len(reqs))
 	allSatisfied := true
 
@@ -232,6 +237,16 @@ func performReqsCheck(reqs []Prerequisite) ([]ReqResult, bool) {
 	}
 
 	return results, allSatisfied
+}
+
+func filterUnsatisfiedReqResults(results []ReqResult) []ReqResult {
+	filtered := make([]ReqResult, 0)
+	for _, result := range results {
+		if !result.Satisfied {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered
 }
 
 // ResultFormatter handles formatting of requirement check results.

--- a/cli/src/cmd/app/commands/reqs.go
+++ b/cli/src/cmd/app/commands/reqs.go
@@ -210,6 +210,7 @@ func NewReqsCommand() *cobra.Command {
 	var noCache bool
 	var clearCache bool
 	var fixMode bool
+	var onlyMissing bool
 
 	cmd := &cobra.Command{
 		Use:          "reqs",
@@ -247,6 +248,8 @@ Use --no-cache to force a fresh check and bypass cached results.`,
 
 			// Configure cache based on flag
 			SetCacheEnabled(!noCache)
+			SetReqsOnlyMissing(onlyMissing)
+			defer SetReqsOnlyMissing(false)
 
 			if generateMode {
 				// Get current working directory
@@ -277,6 +280,7 @@ Use --no-cache to force a fresh check and bypass cached results.`,
 	cmd.Flags().BoolVar(&noCache, "no-cache", false, "Force fresh reqs check and bypass cached results")
 	cmd.Flags().BoolVar(&clearCache, "clear-cache", false, "Clear cached reqs results")
 	cmd.Flags().BoolVar(&fixMode, "fix", false, "Attempt to fix PATH issues for missing tools")
+	cmd.Flags().BoolVar(&onlyMissing, "only-missing", false, "Show only requirements that are missing, too old, or not running")
 
 	return cmd
 }

--- a/cli/src/cmd/app/commands/reqs_checker.go
+++ b/cli/src/cmd/app/commands/reqs_checker.go
@@ -92,8 +92,9 @@ var installURLRegistry = map[string]string{
 
 // PrerequisiteChecker handles checking of prerequisites.
 type PrerequisiteChecker struct {
-	registry map[string]ToolConfig
-	aliases  map[string]string
+	registry       map[string]ToolConfig
+	aliases        map[string]string
+	suppressOutput bool
 }
 
 // NewPrerequisiteChecker creates a new prerequisite checker.
@@ -102,6 +103,10 @@ func NewPrerequisiteChecker() *PrerequisiteChecker {
 		registry: toolRegistry,
 		aliases:  toolAliases,
 	}
+}
+
+func (pc *PrerequisiteChecker) shouldPrint() bool {
+	return !pc.suppressOutput && !cliout.IsJSON()
 }
 
 // Check checks a prerequisite and returns structured result.
@@ -134,7 +139,7 @@ func (pc *PrerequisiteChecker) Check(prereq Prerequisite) ReqResult {
 
 	if !installed {
 		result.Message = "Not installed"
-		if !cliout.IsJSON() {
+		if pc.shouldPrint() {
 			cliout.ItemError("%s: NOT INSTALLED (required: %s)", prereq.Name, prereq.MinVersion)
 			if installURL != "" {
 				cliout.Item("   Install: %s", installURL)
@@ -147,7 +152,7 @@ func (pc *PrerequisiteChecker) Check(prereq Prerequisite) ReqResult {
 	// Podman uses its own versioning (e.g., 5.7.0) which is not comparable to Docker versions (e.g., 20.10.0).
 	if isPodman && prereq.Name == toolDocker {
 		result.Message = "Podman detected (version check skipped)"
-		if !cliout.IsJSON() {
+		if pc.shouldPrint() {
 			cliout.ItemSuccess("%s: %s via Podman (version check skipped)", prereq.Name, version)
 		}
 		// Continue to check if running if needed, otherwise mark satisfied
@@ -157,7 +162,7 @@ func (pc *PrerequisiteChecker) Check(prereq Prerequisite) ReqResult {
 		}
 	} else if version == "" {
 		result.Message = "Version unknown"
-		if !cliout.IsJSON() {
+		if pc.shouldPrint() {
 			cliout.ItemWarning("%s: INSTALLED (version unknown, required: %s)", prereq.Name, prereq.MinVersion)
 		}
 		// Continue to check if it's running if needed
@@ -165,7 +170,7 @@ func (pc *PrerequisiteChecker) Check(prereq Prerequisite) ReqResult {
 		versionOk := compareVersions(version, prereq.MinVersion)
 		if !versionOk {
 			result.Message = fmt.Sprintf("Version %s does not meet minimum %s", version, prereq.MinVersion)
-			if !cliout.IsJSON() {
+			if pc.shouldPrint() {
 				cliout.ItemError("%s: %s (required: %s)", prereq.Name, version, prereq.MinVersion)
 				if installURL != "" {
 					cliout.Item("   Install: %s", installURL)
@@ -173,7 +178,7 @@ func (pc *PrerequisiteChecker) Check(prereq Prerequisite) ReqResult {
 			}
 			return result
 		}
-		if !cliout.IsJSON() {
+		if pc.shouldPrint() {
 			cliout.ItemSuccess("%s: %s (required: %s)", prereq.Name, version, prereq.MinVersion)
 		}
 	}
@@ -185,14 +190,14 @@ func (pc *PrerequisiteChecker) Check(prereq Prerequisite) ReqResult {
 		result.Running = isRunning
 		if !isRunning {
 			result.Message = "Not running"
-			if !cliout.IsJSON() {
+			if pc.shouldPrint() {
 				cliout.Item("- %s✗%s NOT RUNNING", cliout.Red, cliout.Reset)
 			}
 			return result
 		}
 		result.Satisfied = true
 		result.Message = "Running"
-		if !cliout.IsJSON() {
+		if pc.shouldPrint() {
 			cliout.Item("- %s✓%s RUNNING", cliout.Green, cliout.Reset)
 		}
 		return result

--- a/cli/src/cmd/app/commands/reqs_test.go
+++ b/cli/src/cmd/app/commands/reqs_test.go
@@ -668,6 +668,23 @@ func TestCheckPrerequisite(t *testing.T) {
 	}
 }
 
+func TestFilterUnsatisfiedReqResults(t *testing.T) {
+	results := []ReqResult{
+		{Name: "node", Satisfied: true},
+		{Name: "docker", Satisfied: false, Message: "Not running"},
+		{Name: "python", Satisfied: true},
+		{Name: "pnpm", Satisfied: false, Message: "Not installed"},
+	}
+
+	filtered := filterUnsatisfiedReqResults(results)
+	if len(filtered) != 2 {
+		t.Fatalf("Expected 2 unsatisfied results, got %d", len(filtered))
+	}
+	if filtered[0].Name != "docker" || filtered[1].Name != "pnpm" {
+		t.Fatalf("Unexpected filtered results: %+v", filtered)
+	}
+}
+
 func TestToolRegistryCompleteness(t *testing.T) {
 	requiredTools := []string{"node", "pnpm", "python", "dotnet", "aspire", "azd", "az", "func"}
 


### PR DESCRIPTION
Closes #518.

Adds `azd app reqs --only-missing` so setup and CI output can focus on failed requirement checks. JSON output keeps the same shape with the `reqs` list filtered to failed checks.

Validation:
- `go test .\src\cmd\app\commands -run "TestFilterUnsatisfiedReqResults|TestCheckPrerequisite|TestRunPrereqsWithNoPrereqs"`
- `go test .\src\cmd\app\commands`
- `mage build`
- `mage lint`