### PR TITLE
feat(info): add service names output

### DIFF
--- a/cli/src/cmd/app/commands/info.go
+++ b/cli/src/cmd/app/commands/info.go
@@ -26,6 +26,7 @@ var (
 	infoService  string
 	infoWatch    bool
 	infoInterval time.Duration
+	infoNames    bool
 )
 
 const (
@@ -59,6 +60,9 @@ Examples:
   # Show information about multiple services
   azd app info --service "api,web"
 
+  # Print service names for scripts
+  azd app info --names
+
   # Live view, refreshed every 2 seconds (CPU and memory update each frame)
   azd app info --watch
 
@@ -73,6 +77,7 @@ Examples:
 	cmd.Flags().StringVarP(&infoService, "service", "s", "", "Show info for specific service(s) (comma-separated)")
 	cmd.Flags().BoolVar(&infoWatch, "watch", false, "Refresh service info on an interval until interrupted")
 	cmd.Flags().DurationVar(&infoInterval, "interval", 2*time.Second, "Refresh interval for --watch (minimum 1s)")
+	cmd.Flags().BoolVar(&infoNames, "names", false, "Print service names only, one per line")
 
 	return cmd
 }
@@ -95,6 +100,10 @@ func runInfo(cmd *cobra.Command, args []string) error {
 		requested = append(requested, parsed...)
 	}
 
+	if infoNames && infoWatch {
+		return fmt.Errorf("--names cannot be used with --watch")
+	}
+
 	// --watch is an interactive text view. The global --json flag always wins and
 	// prints a single snapshot instead.
 	if infoWatch && !cliout.IsJSON() {
@@ -105,8 +114,6 @@ func runInfo(cmd *cobra.Command, args []string) error {
 		defer stop()
 		return watchInfo(ctx, os.Stdout, cwd, requested, infoInterval)
 	}
-
-	cliout.CommandHeader("info", "Show information about services")
 
 	ctx := context.Background()
 
@@ -149,7 +156,12 @@ func runInfo(cmd *cobra.Command, args []string) error {
 		return printInfoJSON(cwd, allServices, azureEnv)
 	}
 
+	if infoNames {
+		return printInfoNames(os.Stdout, allServices)
+	}
+
 	// Default output
+	cliout.CommandHeader("info", "Show information about services")
 	printInfoDefault(cwd, allServices, azureEnv)
 	return nil
 }
@@ -315,6 +327,15 @@ func printInfoJSON(projectDir string, services []*serviceinfo.ServiceInfo, azure
 		"project":  projectDir,
 		"services": outputServices,
 	})
+}
+
+func printInfoNames(w io.Writer, services []*serviceinfo.ServiceInfo) error {
+	for _, svc := range services {
+		if _, err := fmt.Fprintln(w, svc.Name); err != nil {
+			return fmt.Errorf("write service name: %w", err)
+		}
+	}
+	return nil
 }
 
 // printInfoDefault outputs service information in default format.

--- a/cli/src/cmd/app/commands/info_test.go
+++ b/cli/src/cmd/app/commands/info_test.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -336,6 +338,41 @@ func TestRunInfoWithServices(t *testing.T) {
 	err = cmd.Execute()
 	if err != nil {
 		t.Errorf("runInfo() failed with services: %v", err)
+	}
+}
+
+func TestPrintInfoNames(t *testing.T) {
+	services := []*serviceinfo.ServiceInfo{
+		{Name: "api"},
+		{Name: "web"},
+	}
+
+	var buf bytes.Buffer
+	if err := printInfoNames(&buf, services); err != nil {
+		t.Fatalf("printInfoNames failed: %v", err)
+	}
+
+	if got, want := buf.String(), "api\nweb\n"; got != want {
+		t.Fatalf("printInfoNames output = %q, want %q", got, want)
+	}
+}
+
+func TestInfoNamesRejectsWatch(t *testing.T) {
+	infoNames = false
+	infoWatch = false
+	t.Cleanup(func() {
+		infoNames = false
+		infoWatch = false
+	})
+
+	cmd := NewInfoCommand()
+	cmd.SetArgs([]string{"--names", "--watch"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Expected --names with --watch to fail")
+	}
+	if !strings.Contains(err.Error(), "--names cannot be used with --watch") {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #519.

Adds `azd app info --names` for scripts that need service names before calling logs, health, start, stop, or restart. The command prints one service per line after service filters run and rejects `--names --watch`.

Validation:
- `go test .\src\cmd\app\commands -run "TestPrintInfoNames|TestInfoNamesRejectsWatch|TestRunInfoWithServices|TestRunInfoNoServices"`
- `go test .\src\cmd\app\commands`
- `mage build`
- `mage lint`