### PR TITLE
feat(env): add powershell format to env --format

### DIFF
--- a/cli/src/cmd/app/commands/env.go
+++ b/cli/src/cmd/app/commands/env.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	envFormatDotenv = "dotenv"
-	envFormatShell  = "shell"
-	envFormatJSON   = "json"
+	envFormatDotenv     = "dotenv"
+	envFormatShell      = "shell"
+	envFormatJSON       = "json"
+	envFormatPowerShell = "powershell"
 )
 
 var (
@@ -49,8 +50,8 @@ Secret-shaped values are masked by default. Use --no-mask to print raw values,
 for example when piping the output into another command.
 
 Pass --all to print the resolved environment for every service in one run. The
-dotenv and shell formats group each service under a "# <service>" header; the
-json format emits an object keyed by service name.
+dotenv, shell, and powershell formats group each service under a "# <service>"
+header; the json format emits an object keyed by service name.
 
 Examples:
   # Resolved environment for the api service (KEY=value lines)
@@ -58,6 +59,9 @@ Examples:
 
   # Shell export statements
   azd app env api --format shell
+
+  # PowerShell $env: assignments (load with: azd app env api --format powershell | iex)
+  azd app env api --format powershell
 
   # JSON object (also selected by the global --json flag)
   azd app env api --format json
@@ -88,7 +92,7 @@ Examples:
 		ValidArgsFunction: completeServiceArgs,
 	}
 
-	cmd.Flags().StringVar(&envFormat, "format", envFormatDotenv, "Output format: dotenv, shell, or json")
+	cmd.Flags().StringVar(&envFormat, "format", envFormatDotenv, "Output format: dotenv, shell, powershell, or json")
 	cmd.Flags().BoolVar(&envNoMask, "no-mask", false, "Print raw values instead of masking secret-shaped values")
 	cmd.Flags().StringVar(&envFile, "env-file", "", "Path to a .env file to merge, matching azd app run")
 	cmd.Flags().BoolVar(&envAll, "all", false, "Print the resolved environment for every service")
@@ -301,9 +305,9 @@ func renderAllEnvKeys(keysByService map[string][]string, names []string, format 
 }
 
 // renderAllEnv writes the resolved environment for every service. The json format
-// emits an object keyed by service name; the dotenv and shell formats group each
-// service under a "# <service>" header separated by a blank line. names controls
-// the ordering. Secret-shaped values are masked when mask is true.
+// emits an object keyed by service name; the dotenv, shell, and powershell formats
+// group each service under a "# <service>" header separated by a blank line. names
+// controls the ordering. Secret-shaped values are masked when mask is true.
 func renderAllEnv(resolvedByService map[string]map[string]string, names []string, format string, mask bool) error {
 	if format == envFormatJSON {
 		out := make(map[string]map[string]string, len(resolvedByService))
@@ -516,10 +520,12 @@ func resolveEnvFormat(format string) (string, error) {
 		return envFormatDotenv, nil
 	case envFormatShell:
 		return envFormatShell, nil
+	case envFormatPowerShell:
+		return envFormatPowerShell, nil
 	case envFormatJSON:
 		return envFormatJSON, nil
 	default:
-		return "", fmt.Errorf("invalid --format %q: expected dotenv, shell, or json", format)
+		return "", fmt.Errorf("invalid --format %q: expected dotenv, shell, powershell, or json", format)
 	}
 }
 
@@ -537,8 +543,8 @@ func maskEnv(env map[string]string, mask bool) map[string]string {
 	return out
 }
 
-// formatEnv renders the environment as sorted dotenv or shell lines. Secret
-// masking is applied first when mask is true.
+// formatEnv renders the environment as sorted dotenv, shell, or powershell lines.
+// Secret masking is applied first when mask is true.
 func formatEnv(env map[string]string, format string, mask bool) string {
 	masked := maskEnv(env, mask)
 
@@ -550,13 +556,24 @@ func formatEnv(env map[string]string, format string, mask bool) string {
 
 	var b strings.Builder
 	for _, k := range keys {
-		if format == envFormatShell {
+		switch format {
+		case envFormatShell:
 			fmt.Fprintf(&b, "export %s=%s\n", k, shellQuoteDouble(masked[k]))
-		} else {
+		case envFormatPowerShell:
+			fmt.Fprintf(&b, "$env:%s = %s\n", k, powerShellQuoteSingle(masked[k]))
+		default:
 			fmt.Fprintf(&b, "%s=%s\n", k, masked[k])
 		}
 	}
 	return b.String()
+}
+
+// powerShellQuoteSingle wraps a value in single quotes for a PowerShell string
+// literal, escaping embedded single quotes by doubling them. Single-quoted
+// PowerShell strings are literal, so no other characters need escaping and the
+// result is safe to load with Invoke-Expression.
+func powerShellQuoteSingle(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", "''") + "'"
 }
 
 // shellQuoteDouble wraps a value in double quotes, escaping the characters that

--- a/cli/src/cmd/app/commands/env_test.go
+++ b/cli/src/cmd/app/commands/env_test.go
@@ -34,6 +34,8 @@ func TestResolveEnvFormat(t *testing.T) {
 		{"dotenv", envFormatDotenv, false},
 		{"DOTENV", envFormatDotenv, false},
 		{"shell", envFormatShell, false},
+		{"powershell", envFormatPowerShell, false},
+		{"PowerShell", envFormatPowerShell, false},
 		{"json", envFormatJSON, false},
 		{" json ", envFormatJSON, false},
 		{"yaml", "", true},
@@ -96,11 +98,37 @@ func TestFormatEnv(t *testing.T) {
 		assert.Contains(t, out, `export DB_PASSWORD="supersecret"`)
 	})
 
+	t.Run("powershell emits sorted $env assignments", func(t *testing.T) {
+		out := formatEnv(env, envFormatPowerShell, false)
+		lines := splitNonEmpty(out)
+		require.Len(t, lines, 3)
+		assert.Equal(t, "$env:A_KEY = 'one'", lines[0])
+		assert.Equal(t, "$env:B_KEY = 'two'", lines[1])
+		assert.Equal(t, "$env:DB_PASSWORD = 'supersecret'", lines[2])
+	})
+
 	t.Run("masking applies before formatting", func(t *testing.T) {
 		out := formatEnv(env, envFormatDotenv, true)
 		assert.NotContains(t, out, "supersecret")
 		assert.Contains(t, out, "DB_PASSWORD=su***et")
 	})
+}
+
+func TestPowerShellQuoteSingle(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"plain", `'plain'`},
+		{"", `''`},
+		{"with space", `'with space'`},
+		{"it's", `'it''s'`},
+		{"''", `''''''`},
+		{`dollar$var`, `'dollar$var'`},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, powerShellQuoteSingle(tt.in), "input %q", tt.in)
+	}
 }
 
 func TestShellQuoteDouble(t *testing.T) {


### PR DESCRIPTION
## What

Adds a `powershell` output format to `azd app env --format`.

```powershell
azd app env --format powershell | Invoke-Expression
```

Emits one `$env:KEY = 'value'` line per variable, sorted by key. Values are wrapped in single quotes and embedded single quotes are doubled, so a PowerShell string literal stays literal and there is nothing to interpolate or eval unexpectedly. Works with `--all` (each service still grouped under its `# <service>` header) and with `--json` untouched.

## Why

The existing `shell` format produces `export KEY="value"` lines that only work in bash-like shells. Windows developers running the CLI in PowerShell had no one-liner to load a service's resolved environment into their session. This fills that gap and matches how the other formats already work.

## Changes

- New `powershell` value for `--format`, wired through `resolveEnvFormat` and the `formatEnv` renderer.
- `powerShellQuoteSingle` helper for single-quote escaping.
- Flag help, command examples, and doc comments updated to list the new format.
- Tests: `powershell` cases in `TestResolveEnvFormat` and `TestFormatEnv`, plus a new `TestPowerShellQuoteSingle` covering plain, empty, spaced, quote-bearing, and `$`-bearing values.

Closes #524
