### PR TITLE
deps: upgrade all dependencies to latest

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
-	github.com/dlclark/regexp2/v2 v2.5.1 // indirect
+	github.com/dlclark/regexp2/v2 v2.5.2 // indirect
 	github.com/drone/envsubst v1.0.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -113,8 +113,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
 github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dlclark/regexp2/v2 v2.5.1 h1:E5Ug7Dh264W1ymdySmiHNcDG7fmsR307APCE5R07a20=
-github.com/dlclark/regexp2/v2 v2.5.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
+github.com/dlclark/regexp2/v2 v2.5.2 h1:HAsucWRhsqcDzl6Ua9aR8JwYOTzrZyPrF0/FNxJVAI0=
+github.com/dlclark/regexp2/v2 v2.5.2/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
 github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
## Dependency upgrade sweep

Automated daily dependency sweep for jongio/azd-app.

### Upgraded
- **Go (cli/go.mod)**: `github.com/dlclark/regexp2/v2` v2.5.1 to v2.5.2 (indirect), via `go get -u ./...` + `go mod tidy`.

### No change (already current or intentionally held)
- **cli/go.mod direct deps + cli/dashboard**: upgraded ~90 min earlier in #516; nothing newer available.
- **web/ and cli/package.json npm deps**: every available upgrade (astro 7.1.1, tailwind 4.3.3, vite 8.1.5, typescript-eslint 8.64.0, lucide-react 1.25.0, postcss 8.5.20, etc.) was published within the last 7 days and is skipped under the 7-day release-age cooldown.
- **TypeScript**: held at latest 6.0.x (6.0.3). 7.x is blocked by typescript-eslint (peer caps typescript <6.1.0).
- **@jongio/azd-web-core**: already at latest (2.4.1).

### Verification
- `go build ./...` clean
- `go vet ./...` clean
- `go test -short ./src/...` all packages pass