### PR TITLE
feat(clean): add older-than artifact filter

### DIFF
--- a/cli/src/cmd/app/commands/clean.go
+++ b/cli/src/cmd/app/commands/clean.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/jongio/azd-core/cliout"
 	"github.com/spf13/cobra"
@@ -43,10 +44,11 @@ var dotnetBuildArtifacts = []string{"bin", "obj"}
 
 // cleanOptions holds the options for the clean command.
 type cleanOptions struct {
-	deps     bool
-	dryRun   bool
-	services []string
-	writer   io.Writer
+	deps      bool
+	dryRun    bool
+	olderThan time.Duration
+	services  []string
+	writer    io.Writer
 }
 
 // cleanTarget is a single directory clean will remove (or would remove in dry-run).
@@ -91,6 +93,9 @@ Examples:
   # Also remove dependency directories
   azd app clean --deps
 
+  # Only remove artifacts untouched for at least 24 hours
+  azd app clean --older-than 24h
+
   # Limit to one service
   azd app clean --service api`,
 		SilenceUsage: true,
@@ -107,6 +112,7 @@ Examples:
 
 	cmd.Flags().BoolVar(&opts.deps, "deps", false, "Also remove dependency directories (node_modules, .venv)")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "List what would be removed and the reclaimable size without deleting")
+	cmd.Flags().DurationVar(&opts.olderThan, "older-than", 0, "Only remove artifacts older than this duration (for example, 24h)")
 	cmd.Flags().StringSliceVarP(&opts.services, "service", "s", nil, "Limit to specific services (can be specified multiple times)")
 
 	return cmd
@@ -118,6 +124,9 @@ func runClean(opts *cleanOptions) error {
 	}
 	if opts.writer == nil {
 		opts.writer = os.Stdout
+	}
+	if opts.olderThan < 0 {
+		return fmt.Errorf("--older-than must be zero or greater")
 	}
 
 	searchRoot, err := getSearchRoot()
@@ -139,6 +148,9 @@ func runClean(opts *cleanOptions) error {
 	}
 
 	targets := collectCleanTargets(projects, opts.deps)
+	if opts.olderThan > 0 {
+		targets = filterCleanTargetsByAge(targets, opts.olderThan, time.Now())
+	}
 
 	// Compute sizes for reporting.
 	var total int64
@@ -249,6 +261,24 @@ func collectCleanTargets(projects DetectedProjects, includeDeps bool) []cleanTar
 
 	sort.Slice(targets, func(i, j int) bool { return targets[i].Path < targets[j].Path })
 	return targets
+}
+
+func filterCleanTargetsByAge(targets []cleanTarget, olderThan time.Duration, now time.Time) []cleanTarget {
+	if olderThan <= 0 {
+		return targets
+	}
+	cutoff := now.Add(-olderThan)
+	filtered := make([]cleanTarget, 0, len(targets))
+	for _, target := range targets {
+		info, err := os.Stat(target.Path)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		if info.ModTime().Before(cutoff) || info.ModTime().Equal(cutoff) {
+			filtered = append(filtered, target)
+		}
+	}
+	return filtered
 }
 
 // safeToRemove verifies a path is a known artifact directory that lives inside the

--- a/cli/src/cmd/app/commands/clean_test.go
+++ b/cli/src/cmd/app/commands/clean_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	types "github.com/jongio/azd-core/projecttype"
 )
@@ -18,7 +19,7 @@ func TestNewCleanCommand(t *testing.T) {
 	if cmd.Use != "clean" {
 		t.Fatalf("Use = %q, want clean", cmd.Use)
 	}
-	for _, name := range []string{"deps", "dry-run", "service"} {
+	for _, name := range []string{"deps", "dry-run", "older-than", "service"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("flag %q not found", name)
 		}
@@ -72,6 +73,7 @@ func TestCollectCleanTargets(t *testing.T) {
 			t.Errorf("expected build target %s to be collected", want)
 		}
 	}
+
 	if paths[filepath.Join(nodeDir, "node_modules")] {
 		t.Error("node_modules should not be collected without --deps")
 	}
@@ -95,6 +97,36 @@ func TestCollectCleanTargets(t *testing.T) {
 		if filepath.Base(tgt.Path) == "dist" && tgt.Category != cleanCategoryBuild {
 			t.Errorf("dist category = %q, want %q", tgt.Category, cleanCategoryBuild)
 		}
+	}
+}
+
+func TestFilterCleanTargetsByAge(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, "stale", "dist")
+	recent := filepath.Join(root, "recent", "dist")
+	mkdirAll(t, stale)
+	mkdirAll(t, recent)
+
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(stale, now.Add(-48*time.Hour), now.Add(-48*time.Hour)); err != nil {
+		t.Fatalf("chtimes stale: %v", err)
+	}
+	if err := os.Chtimes(recent, now.Add(-2*time.Hour), now.Add(-2*time.Hour)); err != nil {
+		t.Fatalf("chtimes recent: %v", err)
+	}
+
+	targets := []cleanTarget{
+		{Path: stale, Category: cleanCategoryBuild},
+		{Path: recent, Category: cleanCategoryBuild},
+	}
+	got := filterCleanTargetsByAge(targets, 24*time.Hour, now)
+	if len(got) != 1 || got[0].Path != stale {
+		t.Fatalf("filterCleanTargetsByAge returned %+v, want only %s", got, stale)
+	}
+
+	got = filterCleanTargetsByAge(targets, 0, now)
+	if len(got) != 2 {
+		t.Fatalf("disabled age filter returned %d targets, want 2", len(got))
 	}
 }
 
@@ -239,7 +271,18 @@ func TestRunCleanWithDepsRemovesNodeModules(t *testing.T) {
 	if err := runClean(&cleanOptions{deps: true, writer: &buf}); err != nil {
 		t.Fatalf("runClean --deps failed: %v", err)
 	}
+
 	if _, err := os.Stat(filepath.Join(serviceDir, "node_modules")); !os.IsNotExist(err) {
 		t.Errorf("node_modules should be removed with --deps, stat err = %v", err)
+	}
+}
+
+func TestRunCleanRejectsNegativeOlderThan(t *testing.T) {
+	root, _ := setupCleanProject(t)
+	t.Chdir(root)
+
+	err := runClean(&cleanOptions{olderThan: -time.Second, writer: &bytes.Buffer{}})
+	if err == nil || !strings.Contains(err.Error(), "--older-than must be zero or greater") {
+		t.Fatalf("runClean error = %v, want --older-than validation", err)
 	}
 }


### PR DESCRIPTION
Adds `azd app clean --older-than <duration>` so cleanup can skip fresh build output and only target stale artifacts.

Validation:
- `go test .\src\cmd\app\commands`

Closes #530