### PR TITLE
feat(outdated): filter checks by package manager

### DIFF
--- a/cli/src/cmd/app/commands/outdated.go
+++ b/cli/src/cmd/app/commands/outdated.go
@@ -74,6 +74,7 @@ type outdatedTarget struct {
 // outdatedOptions holds the options for the outdated command.
 type outdatedOptions struct {
 	services []string
+	managers []string
 	format   string
 	exitCode bool
 	writer   io.Writer
@@ -105,6 +106,9 @@ Examples:
   # Limit to one service
   azd app outdated --service api
 
+  # Limit to selected package managers
+  azd app outdated --manager npm,pip
+
   # Machine-readable output
   azd app outdated --format json
 
@@ -128,6 +132,7 @@ Examples:
 	}
 
 	cmd.Flags().StringSliceVarP(&opts.services, "service", "s", nil, "Limit to specific services (can be specified multiple times)")
+	cmd.Flags().StringSliceVar(&opts.managers, "manager", nil, "Limit to package managers: npm, pnpm, yarn, pip, dotnet, or go (comma-separated)")
 	cmd.Flags().StringVar(&opts.format, "format", "", "Output format: text (default) or json")
 	cmd.Flags().BoolVar(&opts.exitCode, "exit-code", false, "Return a non-zero exit code when any dependency is outdated")
 
@@ -147,10 +152,16 @@ func runOutdated(opts *outdatedOptions) error {
 		return fmt.Errorf("failed to determine project root: %w", err)
 	}
 
+	managerFilter, err := normalizeOutdatedManagerFilter(opts.managers)
+	if err != nil {
+		return err
+	}
+
 	targets, err := resolveOutdatedTargets(searchRoot, opts.services)
 	if err != nil {
 		return err
 	}
+	targets = filterOutdatedTargetsByManager(targets, managerFilter)
 
 	result := outdatedResult{}
 	for _, t := range targets {
@@ -195,6 +206,51 @@ func runOutdated(opts *outdatedOptions) error {
 		return fmt.Errorf("%d outdated dependenc%s found", result.TotalOutdated, pluralDeps(result.TotalOutdated))
 	}
 	return nil
+}
+
+func normalizeOutdatedManagerFilter(values []string) (map[string]bool, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	valid := map[string]bool{
+		managerNpm:    true,
+		managerPnpm:   true,
+		managerYarn:   true,
+		managerPip:    true,
+		managerDotnet: true,
+		managerGo:     true,
+	}
+	filter := make(map[string]bool)
+	for _, value := range values {
+		for _, raw := range strings.Split(value, ",") {
+			manager := strings.ToLower(strings.TrimSpace(raw))
+			if manager == "" {
+				continue
+			}
+			if !valid[manager] {
+				return nil, fmt.Errorf("invalid --manager %q: expected npm, pnpm, yarn, pip, dotnet, or go", raw)
+			}
+			filter[manager] = true
+		}
+	}
+	if len(filter) == 0 {
+		return nil, fmt.Errorf("--manager requires at least one package manager")
+	}
+	return filter, nil
+}
+
+func filterOutdatedTargetsByManager(targets []outdatedTarget, managers map[string]bool) []outdatedTarget {
+	if len(managers) == 0 {
+		return targets
+	}
+	filtered := make([]outdatedTarget, 0, len(targets))
+	for _, target := range targets {
+		if managers[target.Manager] {
+			filtered = append(filtered, target)
+		}
+	}
+	return filtered
 }
 
 // resolveOutdatedTargets parses azure.yaml, optionally filters to the requested

--- a/cli/src/cmd/app/commands/outdated_test.go
+++ b/cli/src/cmd/app/commands/outdated_test.go
@@ -36,7 +36,7 @@ func TestNewOutdatedCommand(t *testing.T) {
 	if cmd.Use != "outdated" {
 		t.Fatalf("Use = %q, want outdated", cmd.Use)
 	}
-	for _, name := range []string{"service", "format", "exit-code"} {
+	for _, name := range []string{"service", "manager", "format", "exit-code"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("flag %q not found", name)
 		}
@@ -335,6 +335,47 @@ func TestResolveOutdatedTargets(t *testing.T) {
 	}
 	if targets[0].Service != "web" || targets[0].Manager != managerNpm || !targets[0].Supported {
 		t.Errorf("unexpected target: %+v", targets[0])
+	}
+}
+
+func TestNormalizeOutdatedManagerFilter(t *testing.T) {
+	filter, err := normalizeOutdatedManagerFilter([]string{"npm,pip", " Go "})
+	if err != nil {
+		t.Fatalf("normalizeOutdatedManagerFilter: %v", err)
+	}
+	for _, want := range []string{managerNpm, managerPip, managerGo} {
+		if !filter[want] {
+			t.Fatalf("manager %q missing from filter %#v", want, filter)
+		}
+	}
+	if filter[managerYarn] {
+		t.Fatalf("unexpected yarn in filter %#v", filter)
+	}
+
+	if _, err := normalizeOutdatedManagerFilter([]string{"brew"}); err == nil || !strings.Contains(err.Error(), "invalid --manager") {
+		t.Fatalf("expected invalid manager error, got %v", err)
+	}
+	if _, err := normalizeOutdatedManagerFilter([]string{","}); err == nil || !strings.Contains(err.Error(), "requires at least one") {
+		t.Fatalf("expected empty manager error, got %v", err)
+	}
+}
+
+func TestFilterOutdatedTargetsByManager(t *testing.T) {
+	targets := []outdatedTarget{
+		{Service: "web", Manager: managerNpm},
+		{Service: "api", Manager: managerPip},
+		{Service: "worker", Manager: managerGo},
+		{Service: "legacy", Manager: ""},
+	}
+	filtered := filterOutdatedTargetsByManager(targets, map[string]bool{managerNpm: true, managerGo: true})
+	if len(filtered) != 2 {
+		t.Fatalf("got %d filtered targets, want 2: %+v", len(filtered), filtered)
+	}
+	if filtered[0].Service != "web" || filtered[1].Service != "worker" {
+		t.Fatalf("unexpected filtered targets: %+v", filtered)
+	}
+	if got := filterOutdatedTargetsByManager(targets, nil); len(got) != len(targets) {
+		t.Fatalf("nil filter returned %d targets, want %d", len(got), len(targets))
 	}
 }
 


### PR DESCRIPTION
Adds `azd app outdated --manager` so polyglot projects can limit dependency checks to selected package managers.

Validation:
- `go test .\src\cmd\app\commands`

Closes #532