### PR TITLE
feat(notifications): add scriptable output

### DIFF
--- a/cli/src/cmd/app/commands/notifications.go
+++ b/cli/src/cmd/app/commands/notifications.go
@@ -45,7 +45,9 @@ func newNotificationsListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List notification history",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliout.CommandHeader("notifications list", "List notification history")
+			if !cliout.IsJSON() {
+				cliout.CommandHeader("notifications list", "List notification history")
+			}
 			ctx := cmd.Context()
 			dbPath := getNotificationDBPath()
 
@@ -68,6 +70,9 @@ func newNotificationsListCmd() *cobra.Command {
 				return fmt.Errorf("failed to query notifications: %w", err)
 			}
 
+			if cliout.IsJSON() {
+				return cliout.PrintJSON(records)
+			}
 			printNotifications(records)
 			return nil
 		},
@@ -135,7 +140,10 @@ func newNotificationsMarkReadCmd() *cobra.Command {
 }
 
 func newNotificationsClearCmd() *cobra.Command {
-	var olderThan string
+	var (
+		olderThan string
+		yes       bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "clear",
@@ -164,30 +172,32 @@ func newNotificationsClearCmd() *cobra.Command {
 				return nil
 			}
 
-			// Interactive confirmation with context-aware input
-			fmt.Print("Clear all notification history? (y/N): ")
+			if !yes {
+				// Interactive confirmation with context-aware input
+				fmt.Print("Clear all notification history? (y/N): ")
 
-			// Create a channel to read user input
-			responseChan := make(chan string, 1)
-			go func() {
+				// Create a channel to read user input
+				responseChan := make(chan string, 1)
+				go func() {
+					var response string
+					_, _ = fmt.Scanln(&response)
+					responseChan <- response
+				}()
+
+				// Wait for user input or context cancellation
 				var response string
-				_, _ = fmt.Scanln(&response)
-				responseChan <- response
-			}()
+				select {
+				case response = <-responseChan:
+					// User provided input
+				case <-ctx.Done():
+					fmt.Println("\nCanceled by context")
+					return ctx.Err()
+				}
 
-			// Wait for user input or context cancellation
-			var response string
-			select {
-			case response = <-responseChan:
-				// User provided input
-			case <-ctx.Done():
-				fmt.Println("\nCanceled by context")
-				return ctx.Err()
-			}
-
-			if response != "y" && response != "Y" {
-				fmt.Println("Canceled")
-				return nil
+				if response != "y" && response != "Y" {
+					fmt.Println("Canceled")
+					return nil
+				}
 			}
 
 			if err := db.ClearAll(ctx); err != nil {
@@ -200,8 +210,15 @@ func newNotificationsClearCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&olderThan, "older-than", "", "Clear notifications older than duration (e.g., 24h, 7d)")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Clear all notification history without prompting")
 
 	return cmd
+}
+
+type notificationStatsResult struct {
+	Total    int `json:"total"`
+	Unread   int `json:"unread"`
+	Critical int `json:"critical"`
 }
 
 func newNotificationsStatsCmd() *cobra.Command {
@@ -209,7 +226,9 @@ func newNotificationsStatsCmd() *cobra.Command {
 		Use:   "stats",
 		Short: "Show notification statistics",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliout.CommandHeader("notifications stats", "Show notification statistics")
+			if !cliout.IsJSON() {
+				cliout.CommandHeader("notifications stats", "Show notification statistics")
+			}
 			ctx := cmd.Context()
 			dbPath := getNotificationDBPath()
 
@@ -222,6 +241,14 @@ func newNotificationsStatsCmd() *cobra.Command {
 			stats, err := db.GetStats(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to get stats: %w", err)
+			}
+
+			if cliout.IsJSON() {
+				return cliout.PrintJSON(notificationStatsResult{
+					Total:    stats["total"],
+					Unread:   stats["unread"],
+					Critical: stats["critical"],
+				})
 			}
 
 			fmt.Println("Notification Statistics:")

--- a/cli/src/cmd/app/commands/notifications_test.go
+++ b/cli/src/cmd/app/commands/notifications_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jongio/azd-app/cli/src/internal/notifications"
+	"github.com/jongio/azd-core/cliout"
 )
 
 func TestGetNotificationDBPath(t *testing.T) {
@@ -271,6 +273,144 @@ func TestPrintNotifications(t *testing.T) {
 			printNotifications(tt.records)
 		})
 	}
+}
+
+func TestNotificationsListJSONOutput(t *testing.T) {
+	db, ctx := openTestNotificationDB(t)
+	defer func() { _ = db.Close() }()
+
+	err := db.Save(ctx, notifications.Event{
+		Type:        "service.status",
+		ServiceName: "api",
+		Message:     "Service started",
+		Severity:    "info",
+		Timestamp:   time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	_ = db.Close()
+
+	originalFormat := cliout.GetFormat()
+	t.Cleanup(func() { _ = cliout.SetFormat(string(originalFormat)) })
+	if err := cliout.SetFormat("json"); err != nil {
+		t.Fatalf("SetFormat(json) error = %v", err)
+	}
+
+	out, runErr := captureStdout(t, func() error {
+		cmd := newNotificationsListCmd()
+		cmd.SetArgs([]string{"--limit", "10"})
+		return cmd.Execute()
+	})
+	if runErr != nil {
+		t.Fatalf("notifications list error = %v", runErr)
+	}
+
+	var records []notifications.NotificationRecord
+	if err := json.Unmarshal([]byte(out), &records); err != nil {
+		t.Fatalf("invalid JSON output %q: %v", out, err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records length = %d, want 1", len(records))
+	}
+	if records[0].ServiceName != "api" {
+		t.Fatalf("serviceName = %q, want api", records[0].ServiceName)
+	}
+}
+
+func TestNotificationsStatsJSONOutput(t *testing.T) {
+	db, ctx := openTestNotificationDB(t)
+	defer func() { _ = db.Close() }()
+
+	events := []notifications.Event{
+		{Type: "service.status", ServiceName: "api", Message: "started", Severity: "info", Timestamp: time.Now()},
+		{Type: "service.status", ServiceName: "worker", Message: "failed", Severity: "critical", Timestamp: time.Now()},
+	}
+	for _, event := range events {
+		if err := db.Save(ctx, event); err != nil {
+			t.Fatalf("Save() error = %v", err)
+		}
+	}
+	_ = db.Close()
+
+	originalFormat := cliout.GetFormat()
+	t.Cleanup(func() { _ = cliout.SetFormat(string(originalFormat)) })
+	if err := cliout.SetFormat("json"); err != nil {
+		t.Fatalf("SetFormat(json) error = %v", err)
+	}
+
+	out, runErr := captureStdout(t, func() error {
+		cmd := newNotificationsStatsCmd()
+		cmd.SetArgs([]string{})
+		return cmd.Execute()
+	})
+	if runErr != nil {
+		t.Fatalf("notifications stats error = %v", runErr)
+	}
+
+	var stats notificationStatsResult
+	if err := json.Unmarshal([]byte(out), &stats); err != nil {
+		t.Fatalf("invalid JSON output %q: %v", out, err)
+	}
+	if stats.Total != 2 || stats.Unread != 2 || stats.Critical != 1 {
+		t.Fatalf("stats = %+v, want total=2 unread=2 critical=1", stats)
+	}
+}
+
+func TestNotificationsClearYesSkipsPrompt(t *testing.T) {
+	db, ctx := openTestNotificationDB(t)
+	defer func() { _ = db.Close() }()
+
+	for _, service := range []string{"api", "web"} {
+		if err := db.Save(ctx, notifications.Event{
+			Type:        "service.status",
+			ServiceName: service,
+			Message:     "started",
+			Severity:    "info",
+			Timestamp:   time.Now(),
+		}); err != nil {
+			t.Fatalf("Save() error = %v", err)
+		}
+	}
+	_ = db.Close()
+
+	originalFormat := cliout.GetFormat()
+	t.Cleanup(func() { _ = cliout.SetFormat(string(originalFormat)) })
+	if err := cliout.SetFormat("default"); err != nil {
+		t.Fatalf("SetFormat(default) error = %v", err)
+	}
+
+	cmd := newNotificationsClearCmd()
+	cmd.SetArgs([]string{"--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("notifications clear --yes error = %v", err)
+	}
+
+	db, err := notifications.NewDatabase(getNotificationDBPath())
+	if err != nil {
+		t.Fatalf("NewDatabase() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	records, err := db.GetRecent(ctx, 10)
+	if err != nil {
+		t.Fatalf("GetRecent() error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("records length = %d, want 0", len(records))
+	}
+}
+
+func openTestNotificationDB(t *testing.T) (*notifications.Database, context.Context) {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("LOCALAPPDATA", "")
+
+	db, err := notifications.NewDatabase(getNotificationDBPath())
+	if err != nil {
+		t.Fatalf("NewDatabase() error = %v", err)
+	}
+	return db, context.Background()
 }
 
 func TestNotificationIDValidation(t *testing.T) {


### PR DESCRIPTION
Adds scriptable notification output and cleanup:

- `notifications list` prints records when global JSON output is selected
- `notifications stats` prints total, unread, and critical counts as JSON
- `notifications clear --yes` clears all notification history without prompting

Validation:
- `go test .\src\cmd\app\commands -run "TestNotifications|TestGetNotificationDBPath|TestFormatRelativeTime|TestTruncateUTF8" -count=1`

Closes #541