### PR TITLE
feat(run): add no-deps repeat start option

### DIFF
--- a/cli/src/cmd/app/commands/run.go
+++ b/cli/src/cmd/app/commands/run.go
@@ -38,6 +38,7 @@ var (
 	runWeb               bool
 	runRestartContainers bool
 	runForce             bool
+	runNoDeps            bool
 	runTrust             bool
 	runNoTiming          bool
 	runSkipSecretScan    bool
@@ -68,6 +69,7 @@ func NewRunCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&runWeb, "web", "w", false, "Open dashboard in browser")
 	cmd.Flags().BoolVar(&runRestartContainers, "restart-containers", false, "Restart containers even if they are already running")
 	cmd.Flags().BoolVar(&runForce, "force", false, "Force clean dependency reinstall and auto-resolve port conflicts without prompting")
+	cmd.Flags().BoolVar(&runNoDeps, "no-deps", false, "Skip reqs and dependency installation before starting services")
 	cmd.Flags().BoolVarP(&runTrust, "trust", "y", false, "Trust this workspace for code execution and remember the decision")
 	cmd.Flags().BoolVar(&runDetach, "detach", false, "Run the app in the background and return to the shell")
 	cmd.Flags().BoolVar(&runNoTiming, "no-timing", false, "Hide the per-service startup timing summary shown after services are ready")
@@ -82,7 +84,7 @@ func NewRunCommand() *cobra.Command {
 // runWithServices runs services from azure.yaml.
 func runWithServices(ctx context.Context, commandOrchestrator *orchestrator.Orchestrator, _ *cobra.Command, _ []string) error {
 	cliout.CommandHeader("run", "Run the development environment")
-	if err := validateRuntimeMode(runRuntime); err != nil {
+	if err := validateRunOptions(); err != nil {
 		return err
 	}
 
@@ -115,13 +117,37 @@ func runWithServices(ctx context.Context, commandOrchestrator *orchestrator.Orch
 		setDepsOptions(opts)
 	}
 
-	// Execute dependencies first (reqs -> deps -> run)
-	// The orchestrator automatically sets orchestrated mode for dependencies
-	if err := commandOrchestrator.Run("run"); err != nil {
-		return fmt.Errorf("failed to execute command dependencies: %w", err)
+	if err := runRunDependencies(commandOrchestrator); err != nil {
+		return err
 	}
 
 	return runServicesFromAzureYaml(ctx, azureYamlPath, runRuntime)
+}
+
+func validateRunOptions() error {
+	if err := validateRuntimeMode(runRuntime); err != nil {
+		return err
+	}
+	if runNoDeps && runForce {
+		return fmt.Errorf("--no-deps cannot be combined with --force")
+	}
+	return nil
+}
+
+func runRunDependencies(commandOrchestrator *orchestrator.Orchestrator) error {
+	if runNoDeps {
+		if !cliout.IsJSON() {
+			cliout.Info("Skipping reqs and dependency installation (--no-deps)")
+		}
+		return nil
+	}
+
+	// Execute dependencies first (reqs -> deps -> run). The orchestrator
+	// automatically sets orchestrated mode for dependencies.
+	if err := commandOrchestrator.Run("run"); err != nil {
+		return fmt.Errorf("failed to execute command dependencies: %w", err)
+	}
+	return nil
 }
 
 // ensureWorkspaceTrusted enforces the workspace trust gate before any

--- a/cli/src/cmd/app/commands/run_test.go
+++ b/cli/src/cmd/app/commands/run_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jongio/azd-app/cli/src/internal/detector"
+	"github.com/jongio/azd-app/cli/src/internal/orchestrator"
 	"github.com/jongio/azd-app/cli/src/internal/service"
 	"github.com/jongio/azd-core/browser"
 	"github.com/spf13/cobra"
@@ -50,6 +51,8 @@ func TestRunCommandFlags(t *testing.T) {
 			// Reset flags for each test
 			cmd = NewRunCommand()
 			runRuntime = "azd" // reset to default
+			runNoDeps = false
+			runForce = false
 
 			// Parse flags
 			if err := cmd.ParseFlags(tt.args); err != nil {
@@ -167,6 +170,92 @@ func TestRunCommandFlagDefaults(t *testing.T) {
 	envFileFlag := cmd.Flags().Lookup("env-file")
 	if envFileFlag == nil {
 		t.Fatal("--env-file flag not found")
+	}
+
+	noDepsFlag := cmd.Flags().Lookup("no-deps")
+	if noDepsFlag == nil {
+		t.Fatal("--no-deps flag not found")
+	}
+	if noDepsFlag.DefValue != "false" {
+		t.Errorf("Expected default no-deps to be 'false', got %q", noDepsFlag.DefValue)
+	}
+}
+
+func TestRunCommandNoDepsFlagParsing(t *testing.T) {
+	cmd := NewRunCommand()
+	runNoDeps = false
+	t.Cleanup(func() { runNoDeps = false })
+
+	if err := cmd.ParseFlags([]string{"--no-deps"}); err != nil {
+		t.Fatalf("ParseFlags failed: %v", err)
+	}
+	if !runNoDeps {
+		t.Fatal("Expected --no-deps to set runNoDeps")
+	}
+}
+
+func TestValidateRunOptionsRejectsNoDepsWithForce(t *testing.T) {
+	runRuntime = runtimeModeAzd
+	runNoDeps = true
+	runForce = true
+	t.Cleanup(func() {
+		runRuntime = runtimeModeAzd
+		runNoDeps = false
+		runForce = false
+	})
+
+	err := validateRunOptions()
+	if err == nil {
+		t.Fatal("Expected --no-deps and --force conflict error")
+	}
+	if !strings.Contains(err.Error(), "--no-deps cannot be combined with --force") {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestRunRunDependenciesSkipsWhenNoDeps(t *testing.T) {
+	executed := 0
+	orch := orchestrator.NewOrchestrator()
+	if err := orch.Register(&orchestrator.Command{
+		Name: "run",
+		Execute: func() error {
+			executed++
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	runNoDeps = true
+	t.Cleanup(func() { runNoDeps = false })
+
+	if err := runRunDependencies(orch); err != nil {
+		t.Fatalf("runRunDependencies() error = %v", err)
+	}
+	if executed != 0 {
+		t.Fatalf("dependency command executed %d time(s), want 0", executed)
+	}
+}
+
+func TestRunRunDependenciesExecutesByDefault(t *testing.T) {
+	executed := 0
+	orch := orchestrator.NewOrchestrator()
+	if err := orch.Register(&orchestrator.Command{
+		Name: "run",
+		Execute: func() error {
+			executed++
+			return nil
+		},
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	runNoDeps = false
+	if err := runRunDependencies(orch); err != nil {
+		t.Fatalf("runRunDependencies() error = %v", err)
+	}
+	if executed != 1 {
+		t.Fatalf("dependency command executed %d time(s), want 1", executed)
 	}
 }
 


### PR DESCRIPTION
Adds `azd app run --no-deps` for repeat starts where dependencies are already installed.

Changes:
- adds the `--no-deps` flag
- skips the reqs/deps orchestration phase when the flag is set
- rejects `--no-deps` with `--force`, since force requests a clean dependency reinstall

Validation:
- `go test .\src\cmd\app\commands -run "TestRunCommand|TestValidateRunOptions|TestRunRunDependencies" -count=1`

Closes #542