### PR TITLE
feat(open): add service URL opener

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/magefile/mage v1.17.2
 	github.com/mark3labs/mcp-go v0.57.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/prometheus/client_golang v1.24.1
 	github.com/shirou/gopsutil/v4 v4.26.6
 	github.com/sony/gobreaker v1.0.0
@@ -110,7 +111,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
-	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/cli/src/cmd/app/commands/open.go
+++ b/cli/src/cmd/app/commands/open.go
@@ -1,0 +1,180 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+var (
+	openPath  string
+	openPrint bool
+	openURL   = browser.OpenURL
+)
+
+// NewOpenCommand creates the open command.
+func NewOpenCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "open <service>",
+		Short: "Open a service URL in the default browser",
+		Long: `Resolve a service URL from azure.yaml or the running app state and open it in the default browser.
+
+Use --path to append a route such as /health. Use --print to write the URL without launching a browser.`,
+		Args:              cobra.ExactArgs(1),
+		SilenceUsage:      true,
+		RunE:              runOpen,
+		ValidArgsFunction: completeServiceArgs,
+	}
+	cmd.Flags().StringVar(&openPath, "path", "", "Path to append to the service URL")
+	cmd.Flags().BoolVar(&openPrint, "print", false, "Print the URL without opening a browser")
+	return cmd
+}
+
+func runOpen(_ *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	resolved, err := resolveOpenServiceURL(context.Background(), cwd, args[0], openPath)
+	if err != nil {
+		return err
+	}
+	if openPrint {
+		fmt.Println(resolved)
+		return nil
+	}
+	if err := openURL(resolved); err != nil {
+		return fmt.Errorf("failed to open %s: %w", resolved, err)
+	}
+	return nil
+}
+
+func resolveOpenServiceURL(_ context.Context, projectDir, serviceName, extraPath string) (string, error) {
+	infos, err := serviceinfo.GetServiceInfo(projectDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to load service information: %w", err)
+	}
+
+	var names []string
+	foundService := false
+	for _, info := range infos {
+		if info == nil {
+			continue
+		}
+		names = append(names, info.Name)
+		if strings.EqualFold(info.Name, serviceName) {
+			foundService = true
+			if base := bestOpenURL(info); base != "" {
+				return joinOpenURLPath(base, extraPath)
+			}
+			break
+		}
+	}
+
+	azureYaml, parseErr := service.ParseAzureYaml(projectDir)
+	if parseErr == nil {
+		for name, svc := range azureYaml.Services {
+			if !containsName(names, name) {
+				names = append(names, name)
+			}
+			if strings.EqualFold(name, serviceName) {
+				if base := openURLFromService(svc); base != "" {
+					return joinOpenURLPath(base, extraPath)
+				}
+				return "", fmt.Errorf("service %q has no known URL. Set local.customUrl or ports in azure.yaml", serviceName)
+			}
+		}
+	}
+	if foundService {
+		return "", fmt.Errorf("service %q has no known URL. Start it with 'azd app run' or set local.customUrl or ports in azure.yaml", serviceName)
+	}
+
+	sort.Strings(names)
+	if len(names) == 0 {
+		return "", fmt.Errorf("service %q not found. No services are defined in azure.yaml", serviceName)
+	}
+	return "", fmt.Errorf("service %q not found. Available services: %s", serviceName, strings.Join(names, ", "))
+}
+
+func bestOpenURL(info *serviceinfo.ServiceInfo) string {
+	if info.Local != nil {
+		if info.Local.CustomURL != "" {
+			return info.Local.CustomURL
+		}
+		if info.Local.URL != "" {
+			return info.Local.URL
+		}
+		if info.Local.Port > 0 {
+			return fmt.Sprintf("http://localhost:%d", info.Local.Port)
+		}
+	}
+	return ""
+}
+
+func openURLFromService(svc service.Service) string {
+	if svc.Local != nil && svc.Local.CustomURL != "" {
+		return svc.Local.CustomURL
+	}
+	for _, port := range svc.Ports {
+		if hostPort := hostPortFromMapping(port); hostPort != "" {
+			return "http://localhost:" + hostPort
+		}
+	}
+	return ""
+}
+
+func hostPortFromMapping(mapping string) string {
+	mapping = strings.TrimSpace(mapping)
+	if mapping == "" {
+		return ""
+	}
+	parts := strings.Split(mapping, ":")
+	if len(parts) == 1 {
+		return trimPortProtocol(parts[0])
+	}
+	return trimPortProtocol(parts[len(parts)-2])
+}
+
+func trimPortProtocol(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimSuffix(value, "/tcp")
+	value = strings.TrimSuffix(value, "/udp")
+	return value
+}
+
+func joinOpenURLPath(base, extraPath string) (string, error) {
+	if strings.TrimSpace(extraPath) == "" {
+		return base, nil
+	}
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("invalid service URL %q: %w", base, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid service URL %q: missing scheme or host", base)
+	}
+	parsed.Path = path.Join(parsed.Path, extraPath)
+	if strings.HasSuffix(extraPath, "/") && !strings.HasSuffix(parsed.Path, "/") {
+		parsed.Path += "/"
+	}
+	return parsed.String(), nil
+}
+
+func containsName(names []string, name string) bool {
+	for _, existing := range names {
+		if strings.EqualFold(existing, name) {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/src/cmd/app/commands/open.go
+++ b/cli/src/cmd/app/commands/open.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -9,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jongio/azd-app/cli/src/internal/detector"
 	"github.com/jongio/azd-app/cli/src/internal/service"
 	"github.com/jongio/azd-app/cli/src/internal/serviceinfo"
 	"github.com/pkg/browser"
@@ -39,18 +39,20 @@ Use --path to append a route such as /health. Use --print to write the URL witho
 	return cmd
 }
 
-func runOpen(_ *cobra.Command, args []string) error {
+func runOpen(cmd *cobra.Command, args []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current directory: %w", err)
 	}
 
-	resolved, err := resolveOpenServiceURL(context.Background(), cwd, args[0], openPath)
+	resolved, err := resolveOpenServiceURL(cwd, args[0], openPath)
 	if err != nil {
 		return err
 	}
 	if openPrint {
-		fmt.Println(resolved)
+		if _, writeErr := fmt.Fprintln(cmd.OutOrStdout(), resolved); writeErr != nil {
+			return fmt.Errorf("failed to write service URL: %w", writeErr)
+		}
 		return nil
 	}
 	if err := openURL(resolved); err != nil {
@@ -59,44 +61,56 @@ func runOpen(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func resolveOpenServiceURL(_ context.Context, projectDir, serviceName, extraPath string) (string, error) {
+// resolveOpenServiceURL resolves the browser URL for serviceName. The running
+// app state wins, because it knows the port a service actually bound to; the
+// azure.yaml definition is the fallback for services that are not running.
+func resolveOpenServiceURL(projectDir, serviceName, extraPath string) (string, error) {
 	infos, err := serviceinfo.GetServiceInfo(projectDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to load service information: %w", err)
 	}
 
-	var names []string
-	foundService := false
+	names := make([]string, 0, len(infos))
+	found := false
 	for _, info := range infos {
 		if info == nil {
 			continue
 		}
 		names = append(names, info.Name)
-		if strings.EqualFold(info.Name, serviceName) {
-			foundService = true
-			if base := bestOpenURL(info); base != "" {
-				return joinOpenURLPath(base, extraPath)
-			}
-			break
+		if !strings.EqualFold(info.Name, serviceName) {
+			continue
+		}
+		found = true
+		if base := bestOpenURL(info); base != "" {
+			return joinOpenURLPath(base, extraPath)
 		}
 	}
 
-	azureYaml, parseErr := service.ParseAzureYaml(projectDir)
-	if parseErr == nil {
+	// GetServiceInfo suppresses azure.yaml errors, so parse it again here to
+	// surface a malformed file instead of masking it as "service not found".
+	azureYaml, parseErr := parseOpenAzureYaml(projectDir)
+	if parseErr != nil {
+		return "", parseErr
+	}
+	if azureYaml != nil {
 		for name, svc := range azureYaml.Services {
 			if !containsName(names, name) {
 				names = append(names, name)
 			}
-			if strings.EqualFold(name, serviceName) {
-				if base := openURLFromService(svc); base != "" {
-					return joinOpenURLPath(base, extraPath)
-				}
-				return "", fmt.Errorf("service %q has no known URL. Set local.customUrl or ports in azure.yaml", serviceName)
+			if !strings.EqualFold(name, serviceName) {
+				continue
+			}
+			found = true
+			if base := openURLFromService(svc); base != "" {
+				return joinOpenURLPath(base, extraPath)
 			}
 		}
 	}
-	if foundService {
-		return "", fmt.Errorf("service %q has no known URL. Start it with 'azd app run' or set local.customUrl or ports in azure.yaml", serviceName)
+
+	if found {
+		return "", fmt.Errorf(
+			"service %q has no known URL. Start it with 'azd app run', or set local.customUrl or ports in azure.yaml",
+			serviceName)
 	}
 
 	sort.Strings(names)
@@ -104,6 +118,24 @@ func resolveOpenServiceURL(_ context.Context, projectDir, serviceName, extraPath
 		return "", fmt.Errorf("service %q not found. No services are defined in azure.yaml", serviceName)
 	}
 	return "", fmt.Errorf("service %q not found. Available services: %s", serviceName, strings.Join(names, ", "))
+}
+
+// parseOpenAzureYaml parses azure.yaml, returning (nil, nil) when the file does
+// not exist so a project without one still reports "service not found" rather
+// than a parse failure. Any other failure is returned to the caller.
+func parseOpenAzureYaml(projectDir string) (*service.AzureYaml, error) {
+	azureYamlPath, findErr := detector.FindAzureYaml(projectDir)
+	if findErr != nil {
+		return nil, fmt.Errorf("failed to locate azure.yaml: %w", findErr)
+	}
+	if azureYamlPath == "" {
+		return nil, nil
+	}
+	azureYaml, parseErr := service.ParseAzureYaml(projectDir)
+	if parseErr != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", azureYamlPath, parseErr)
+	}
+	return azureYaml, nil
 }
 
 func bestOpenURL(info *serviceinfo.ServiceInfo) string {
@@ -125,31 +157,30 @@ func openURLFromService(svc service.Service) string {
 	if svc.Local != nil && svc.Local.CustomURL != "" {
 		return svc.Local.CustomURL
 	}
-	for _, port := range svc.Ports {
-		if hostPort := hostPortFromMapping(port); hostPort != "" {
-			return "http://localhost:" + hostPort
-		}
+	if hostPort, ok := publishedHostPort(svc); ok {
+		return fmt.Sprintf("http://localhost:%d", hostPort)
 	}
 	return ""
 }
 
-func hostPortFromMapping(mapping string) string {
-	mapping = strings.TrimSpace(mapping)
-	if mapping == "" {
-		return ""
+// publishedHostPort returns the first TCP port a service actually publishes on
+// the host. It defers to the canonical port parser so Docker container-only
+// ports (e.g. "80", whose host port is auto-assigned at runtime), bind IPs,
+// IPv6 binds, protocol suffixes and malformed specs are all handled the same way
+// the rest of the CLI handles them. A mapping without a published host port
+// yields no URL rather than a URL pointing at the container port.
+func publishedHostPort(svc service.Service) (int, bool) {
+	mappings, _ := svc.GetPortMappings()
+	for _, mapping := range mappings {
+		if mapping.HostPort <= 0 {
+			continue
+		}
+		if mapping.Protocol != "" && !strings.EqualFold(mapping.Protocol, "tcp") {
+			continue
+		}
+		return mapping.HostPort, true
 	}
-	parts := strings.Split(mapping, ":")
-	if len(parts) == 1 {
-		return trimPortProtocol(parts[0])
-	}
-	return trimPortProtocol(parts[len(parts)-2])
-}
-
-func trimPortProtocol(value string) string {
-	value = strings.TrimSpace(value)
-	value = strings.TrimSuffix(value, "/tcp")
-	value = strings.TrimSuffix(value, "/udp")
-	return value
+	return 0, false
 }
 
 func joinOpenURLPath(base, extraPath string) (string, error) {
@@ -163,10 +194,14 @@ func joinOpenURLPath(base, extraPath string) (string, error) {
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return "", fmt.Errorf("invalid service URL %q: missing scheme or host", base)
 	}
-	parsed.Path = path.Join(parsed.Path, extraPath)
-	if strings.HasSuffix(extraPath, "/") && !strings.HasSuffix(parsed.Path, "/") {
-		parsed.Path += "/"
+	joined := path.Join(parsed.Path, extraPath)
+	if strings.HasSuffix(extraPath, "/") && !strings.HasSuffix(joined, "/") {
+		joined += "/"
 	}
+	parsed.Path = joined
+	// RawPath is the encoding of the previous Path, so it is stale now. Clear it
+	// to keep Path and RawPath consistent and force String() to re-encode.
+	parsed.RawPath = ""
 	return parsed.String(), nil
 }
 

--- a/cli/src/cmd/app/commands/open_test.go
+++ b/cli/src/cmd/app/commands/open_test.go
@@ -1,0 +1,96 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestJoinOpenURLPath(t *testing.T) {
+	got, err := joinOpenURLPath("http://localhost:3000/api", "/health")
+	if err != nil {
+		t.Fatalf("joinOpenURLPath failed: %v", err)
+	}
+	if got != "http://localhost:3000/api/health" {
+		t.Fatalf("URL = %q, want http://localhost:3000/api/health", got)
+	}
+}
+
+func TestResolveOpenServiceURLFromCustomURL(t *testing.T) {
+	dir := t.TempDir()
+	writeOpenAzureYaml(t, dir, `
+name: open-test
+services:
+  web:
+    host: local
+    project: ./web
+    local:
+      customUrl: https://web.example.test
+`)
+	mkdirOpenService(t, dir, "web")
+
+	got, err := resolveOpenServiceURL(t.Context(), dir, "web", "/health")
+	if err != nil {
+		t.Fatalf("resolveOpenServiceURL failed: %v", err)
+	}
+	if got != "https://web.example.test/health" {
+		t.Fatalf("URL = %q, want https://web.example.test/health", got)
+	}
+}
+
+func TestResolveOpenServiceURLFromPorts(t *testing.T) {
+	dir := t.TempDir()
+	writeOpenAzureYaml(t, dir, `
+name: open-test
+services:
+  api:
+    host: local
+    project: ./api
+    ports:
+      - "8080:80"
+`)
+	mkdirOpenService(t, dir, "api")
+
+	got, err := resolveOpenServiceURL(t.Context(), dir, "api", "docs")
+	if err != nil {
+		t.Fatalf("resolveOpenServiceURL failed: %v", err)
+	}
+	if got != "http://localhost:8080/docs" {
+		t.Fatalf("URL = %q, want http://localhost:8080/docs", got)
+	}
+}
+
+func TestResolveOpenServiceURLMissingURL(t *testing.T) {
+	dir := t.TempDir()
+	writeOpenAzureYaml(t, dir, `
+name: open-test
+services:
+  worker:
+    host: local
+    project: ./worker
+`)
+	mkdirOpenService(t, dir, "worker")
+
+	_, err := resolveOpenServiceURL(t.Context(), dir, "worker", "")
+	if err == nil {
+		t.Fatal("expected missing URL error")
+	}
+	if !strings.Contains(err.Error(), "no known URL") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func writeOpenAzureYaml(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+}
+
+func mkdirOpenService(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.Mkdir(filepath.Join(dir, name), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", name, err)
+	}
+}

--- a/cli/src/cmd/app/commands/open_test.go
+++ b/cli/src/cmd/app/commands/open_test.go
@@ -1,19 +1,158 @@
 package commands
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/jongio/azd-app/cli/src/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJoinOpenURLPath(t *testing.T) {
-	got, err := joinOpenURLPath("http://localhost:3000/api", "/health")
-	if err != nil {
-		t.Fatalf("joinOpenURLPath failed: %v", err)
+	tests := []struct {
+		name      string
+		base      string
+		extraPath string
+		want      string
+		wantErr   string
+	}{
+		{
+			name:      "appends route to base path",
+			base:      "http://localhost:3000/api",
+			extraPath: "/health",
+			want:      "http://localhost:3000/api/health",
+		},
+		{
+			name:      "empty path returns base unchanged",
+			base:      "http://localhost:3000/api",
+			extraPath: "   ",
+			want:      "http://localhost:3000/api",
+		},
+		{
+			name:      "preserves trailing slash",
+			base:      "http://localhost:3000",
+			extraPath: "docs/",
+			want:      "http://localhost:3000/docs/",
+		},
+		{
+			name:      "preserves query string",
+			base:      "http://localhost:3000/api?debug=1",
+			extraPath: "health",
+			want:      "http://localhost:3000/api/health?debug=1",
+		},
+		{
+			name:      "preserves fragment",
+			base:      "http://localhost:3000/api#top",
+			extraPath: "health",
+			want:      "http://localhost:3000/api/health#top",
+		},
+		{
+			name:      "re-encodes path after join",
+			base:      "http://localhost:3000/a%2Fb",
+			extraPath: "health",
+			want:      "http://localhost:3000/a/b/health",
+		},
+		{
+			name:      "rejects url without scheme",
+			base:      "localhost:3000",
+			extraPath: "/health",
+			wantErr:   "missing scheme or host",
+		},
+		{
+			name:      "rejects unparsable url",
+			base:      "http://[::1",
+			extraPath: "/health",
+			wantErr:   "invalid service URL",
+		},
 	}
-	if got != "http://localhost:3000/api/health" {
-		t.Fatalf("URL = %q, want http://localhost:3000/api/health", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := joinOpenURLPath(tt.base, tt.extraPath)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOpenURLFromService(t *testing.T) {
+	tests := []struct {
+		name string
+		svc  service.Service
+		want string
+	}{
+		{
+			name: "custom url wins over ports",
+			svc: service.Service{
+				Local: &service.LocalServiceConfig{CustomURL: "https://web.example.test"},
+				Ports: []string{"8080:80"},
+			},
+			want: "https://web.example.test",
+		},
+		{
+			name: "non-docker bare port is the host port",
+			svc:  service.Service{Ports: []string{"8080"}},
+			want: "http://localhost:8080",
+		},
+		{
+			name: "docker bare port has no published host port",
+			svc:  service.Service{Image: "nginx", Ports: []string{"80"}},
+			want: "",
+		},
+		{
+			name: "docker explicit mapping uses the host port",
+			svc:  service.Service{Image: "nginx", Ports: []string{"3000:80"}},
+			want: "http://localhost:3000",
+		},
+		{
+			name: "bind ip mapping uses the host port",
+			svc:  service.Service{Ports: []string{"127.0.0.1:3000:8080"}},
+			want: "http://localhost:3000",
+		},
+		{
+			name: "ipv6 bind mapping uses the host port",
+			svc:  service.Service{Ports: []string{"[::1]:3000:8080"}},
+			want: "http://localhost:3000",
+		},
+		{
+			name: "tcp protocol suffix is stripped",
+			svc:  service.Service{Ports: []string{"3000:8080/tcp"}},
+			want: "http://localhost:3000",
+		},
+		{
+			name: "udp mapping is skipped",
+			svc:  service.Service{Ports: []string{"3000:8080/udp"}},
+			want: "",
+		},
+		{
+			name: "first publishable port wins",
+			svc:  service.Service{Image: "nginx", Ports: []string{"80", "3000:8080"}},
+			want: "http://localhost:3000",
+		},
+		{
+			name: "malformed port spec is ignored",
+			svc:  service.Service{Ports: []string{"not-a-port"}},
+			want: "",
+		},
+		{
+			name: "no ports yields no url",
+			svc:  service.Service{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, openURLFromService(tt.svc))
+		})
 	}
 }
 
@@ -30,13 +169,9 @@ services:
 `)
 	mkdirOpenService(t, dir, "web")
 
-	got, err := resolveOpenServiceURL(t.Context(), dir, "web", "/health")
-	if err != nil {
-		t.Fatalf("resolveOpenServiceURL failed: %v", err)
-	}
-	if got != "https://web.example.test/health" {
-		t.Fatalf("URL = %q, want https://web.example.test/health", got)
-	}
+	got, err := resolveOpenServiceURL(dir, "web", "/health")
+	require.NoError(t, err)
+	assert.Equal(t, "https://web.example.test/health", got)
 }
 
 func TestResolveOpenServiceURLFromPorts(t *testing.T) {
@@ -52,13 +187,9 @@ services:
 `)
 	mkdirOpenService(t, dir, "api")
 
-	got, err := resolveOpenServiceURL(t.Context(), dir, "api", "docs")
-	if err != nil {
-		t.Fatalf("resolveOpenServiceURL failed: %v", err)
-	}
-	if got != "http://localhost:8080/docs" {
-		t.Fatalf("URL = %q, want http://localhost:8080/docs", got)
-	}
+	got, err := resolveOpenServiceURL(dir, "api", "docs")
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8080/docs", got)
 }
 
 func TestResolveOpenServiceURLMissingURL(t *testing.T) {
@@ -72,25 +203,121 @@ services:
 `)
 	mkdirOpenService(t, dir, "worker")
 
-	_, err := resolveOpenServiceURL(t.Context(), dir, "worker", "")
-	if err == nil {
-		t.Fatal("expected missing URL error")
+	_, err := resolveOpenServiceURL(dir, "worker", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no known URL")
+}
+
+func TestResolveOpenServiceURLNotFoundListsServices(t *testing.T) {
+	dir := t.TempDir()
+	writeOpenAzureYaml(t, dir, `
+name: open-test
+services:
+  api:
+    host: local
+    project: ./api
+  web:
+    host: local
+    project: ./web
+`)
+	mkdirOpenService(t, dir, "api")
+	mkdirOpenService(t, dir, "web")
+
+	_, err := resolveOpenServiceURL(dir, "missing", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `service "missing" not found`)
+	assert.Contains(t, err.Error(), "Available services: api, web")
+}
+
+func TestResolveOpenServiceURLSurfacesParseError(t *testing.T) {
+	dir := t.TempDir()
+	writeOpenAzureYaml(t, dir, "name: open-test\nservices: [this is not a map\n")
+
+	_, err := resolveOpenServiceURL(dir, "web", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse")
+	assert.NotContains(t, err.Error(), "No services are defined")
+}
+
+func TestRunOpenPrintWritesURLWithoutBrowser(t *testing.T) {
+	newOpenCommandFixture(t)
+
+	opened := false
+	restoreOpenState(t)
+	openURL = func(string) error {
+		opened = true
+		return nil
 	}
-	if !strings.Contains(err.Error(), "no known URL") {
-		t.Fatalf("unexpected error: %v", err)
+
+	out, err := executeOpenCommand(t, "web", "--print", "--path", "/health")
+	require.NoError(t, err)
+	assert.Equal(t, "https://web.example.test/health\n", out)
+	assert.False(t, opened, "browser should not be launched with --print")
+}
+
+func TestRunOpenLaunchesBrowser(t *testing.T) {
+	newOpenCommandFixture(t)
+
+	var openedURL string
+	restoreOpenState(t)
+	openURL = func(u string) error {
+		openedURL = u
+		return nil
 	}
+
+	out, err := executeOpenCommand(t, "web")
+	require.NoError(t, err)
+	assert.Equal(t, "https://web.example.test", openedURL)
+	assert.Empty(t, out)
+}
+
+// newOpenCommandFixture creates a project with a single "web" service that has a
+// custom URL and makes it the working directory for the test.
+func newOpenCommandFixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	writeOpenAzureYaml(t, dir, `
+name: open-test
+services:
+  web:
+    host: local
+    project: ./web
+    local:
+      customUrl: https://web.example.test
+`)
+	mkdirOpenService(t, dir, "web")
+	t.Chdir(dir)
+}
+
+// restoreOpenState resets the package-level flag and browser hooks that the open
+// command binds to, so tests do not leak state into each other.
+func restoreOpenState(t *testing.T) {
+	t.Helper()
+	originalOpenURL := openURL
+	t.Cleanup(func() {
+		openURL = originalOpenURL
+		openPath = ""
+		openPrint = false
+	})
+}
+
+func executeOpenCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	cmd := NewOpenCommand()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
 }
 
 func writeOpenAzureYaml(t *testing.T, dir, content string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(content), 0o600); err != nil {
-		t.Fatalf("write azure.yaml: %v", err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(content), 0o600))
 }
 
 func mkdirOpenService(t *testing.T, dir, name string) {
 	t.Helper()
-	if err := os.Mkdir(filepath.Join(dir, name), 0o750); err != nil {
-		t.Fatalf("mkdir %s: %v", name, err)
-	}
+	require.NoError(t, os.Mkdir(filepath.Join(dir, name), 0o750))
 }

--- a/cli/src/cmd/app/main.go
+++ b/cli/src/cmd/app/main.go
@@ -113,6 +113,7 @@ func main() {
 		commands.NewAddCommand(),
 		commands.NewSupportBundleCommand(),
 		commands.NewGraphCommand(),
+		commands.NewOpenCommand(),
 		commands.NewMetadataCommand(func() *cobra.Command { return rootCmd }),
 	)
 


### PR DESCRIPTION
Adds azd app open for opening a resolved local service URL. The command supports --path for routes and --print for scripts, and reports a clear error when a service has no URL source.

Closes #378

Validation: go test ./src/cmd/app/commands -run 'Test(ResolveOpenServiceURLFromCustomURL|ResolveOpenServiceURLFromPorts|ResolveOpenServiceURLMissingURL|JoinOpenURLPath)'