### PR TITLE
feat(logs): add no-timestamps flag

### DIFF
--- a/cli/src/cmd/app/commands/logs.go
+++ b/cli/src/cmd/app/commands/logs.go
@@ -146,6 +146,7 @@ type logsOptions struct {
 	tail         int
 	since        string
 	timestamps   bool
+	noTimestamps bool
 	noColor      bool
 	level        string
 	output       string
@@ -263,6 +264,9 @@ Examples:
   # View logs from the last 5 minutes
   azd app logs --since 5m
 
+  # Hide timestamp prefixes in text output
+  azd app logs --no-timestamps
+
   # Export logs to a file
   azd app logs --file logs.txt
 
@@ -292,6 +296,7 @@ Examples:
 	cmd.Flags().IntVarP(&opts.tail, "tail", "n", defaultTailLines, "Number of lines to show from the end")
 	cmd.Flags().StringVar(&opts.since, "since", "", "Show logs since duration (e.g., 5m, 1h)")
 	cmd.Flags().BoolVar(&opts.timestamps, "timestamps", true, "Show timestamps with each log entry")
+	cmd.Flags().BoolVar(&opts.noTimestamps, "no-timestamps", false, "Hide timestamps in text log output")
 	cmd.Flags().BoolVar(&opts.noColor, "no-color", false, "Disable colored output")
 	cmd.Flags().StringVar(&opts.level, "level", "all", "Filter by log level (info, warn, error, debug, all)")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "Output format (text, json)")
@@ -316,6 +321,8 @@ Examples:
 func runLogsWithOptions(opts *logsOptions, args []string) error {
 	cliout.CommandHeader("logs", "View logs from running services")
 
+	applyLogTimestampAliases(opts)
+
 	// Validate inputs
 	if err := validateLogsOptions(opts); err != nil {
 		return err
@@ -333,6 +340,12 @@ func runLogsWithOptions(opts *logsOptions, args []string) error {
 	executor.alertEngine = engine
 
 	return executor.execute(context.Background(), args)
+}
+
+func applyLogTimestampAliases(opts *logsOptions) {
+	if opts != nil && opts.noTimestamps {
+		opts.timestamps = false
+	}
 }
 
 // execute runs the logs command with the configured dependencies and options.

--- a/cli/src/cmd/app/commands/logs_command_test.go
+++ b/cli/src/cmd/app/commands/logs_command_test.go
@@ -239,7 +239,7 @@ func TestLogsCommandStructure(t *testing.T) {
 	t.Run("flags exist", func(t *testing.T) {
 		flags := []string{
 			"follow", "service", "tail", "since", "timestamps",
-			"no-color", "level", "output", "format", "file", "exclude", "no-builtins", "context",
+			"no-timestamps", "no-color", "level", "output", "format", "file", "exclude", "no-builtins", "context",
 		}
 		for _, flag := range flags {
 			if cmd.Flags().Lookup(flag) == nil {
@@ -275,6 +275,11 @@ func TestLogsCommandStructure(t *testing.T) {
 			t.Errorf("timestamps default = %q, want %q", timestampsFlag.DefValue, "true")
 		}
 
+		noTimestampsFlag := cmd.Flags().Lookup("no-timestamps")
+		if noTimestampsFlag.DefValue != "false" {
+			t.Errorf("no-timestamps default = %q, want %q", noTimestampsFlag.DefValue, "false")
+		}
+
 		levelFlag := cmd.Flags().Lookup("level")
 		if levelFlag.DefValue != "all" {
 			t.Errorf("level default = %q, want %q", levelFlag.DefValue, "all")
@@ -300,6 +305,7 @@ func TestLogsOptionsDocumentation(t *testing.T) {
 		tail:         100,
 		since:        "5m",
 		timestamps:   true,
+		noTimestamps: false,
 		noColor:      false,
 		level:        "info",
 		output:       "text",
@@ -325,6 +331,9 @@ func TestLogsOptionsDocumentation(t *testing.T) {
 	if opts.timestamps != true {
 		t.Error("timestamps field")
 	}
+	if opts.noTimestamps != false {
+		t.Error("noTimestamps field")
+	}
 	if opts.noColor != false {
 		t.Error("noColor field")
 	}
@@ -348,5 +357,14 @@ func TestLogsOptionsDocumentation(t *testing.T) {
 	}
 	if opts.source != "local" {
 		t.Error("source field")
+	}
+}
+
+func TestApplyLogTimestampAliases(t *testing.T) {
+	opts := &logsOptions{timestamps: true, noTimestamps: true}
+	applyLogTimestampAliases(opts)
+
+	if opts.timestamps {
+		t.Fatal("no-timestamps should disable timestamp rendering")
 	}
 }


### PR DESCRIPTION
Adds `azd app logs --no-timestamps` as a direct way to hide timestamp prefixes in text logs.

Validation:
- `go build ./...`
- `go test ./...`

Closes https://github.com/jongio/azd-app/issues/558