### PR TITLE
feat(graph): add services-only filter

### DIFF
--- a/cli/src/cmd/app/commands/graph.go
+++ b/cli/src/cmd/app/commands/graph.go
@@ -23,10 +23,11 @@ const (
 )
 
 type graphOptions struct {
-	output     string
-	outputFile string
-	focus      string
-	writer     io.Writer
+	output       string
+	outputFile   string
+	focus        string
+	servicesOnly bool
+	writer       io.Writer
 }
 
 type graphResult struct {
@@ -65,6 +66,10 @@ Combine with --output-file to write the result to a file instead of stdout.
 Pass --focus <service> to narrow the graph to one service, everything it depends
 on, and everything that depends on it. This works with every output format.
 
+Pass --services-only to omit resource nodes and show only service-to-service
+edges. This is useful for diagrams that need the app service shape without
+managed resources.
+
 Examples:
   # Human-readable text (default)
   azd app graph
@@ -79,7 +84,10 @@ Examples:
   azd app graph --output markdown
 
   # Just the api service and its connected nodes
-  azd app graph --focus api`,
+  azd app graph --focus api
+
+  # Service-only Mermaid diagram
+  azd app graph --services-only --output mermaid`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGraph(opts)
@@ -88,6 +96,7 @@ Examples:
 	cmd.Flags().StringVarP(&opts.output, "output", "o", graphOutputText, "Output format: text, json, markdown, mermaid, or dot")
 	cmd.Flags().StringVar(&opts.outputFile, "output-file", "", "Write output to this file instead of stdout")
 	cmd.Flags().StringVar(&opts.focus, "focus", "", "Limit the graph to a service, its dependencies, and its dependents")
+	cmd.Flags().BoolVar(&opts.servicesOnly, "services-only", false, "Show only services and service-to-service edges")
 	return cmd
 }
 
@@ -132,6 +141,9 @@ func runGraph(opts *graphOptions) error {
 			return err
 		}
 	}
+	if opts.servicesOnly {
+		result = filterGraphServicesOnly(result)
+	}
 
 	// When --output-file is set, buffer the rendered output and write it to disk.
 	writer := opts.writer
@@ -152,6 +164,47 @@ func runGraph(opts *graphOptions) error {
 		_, _ = fmt.Fprintf(opts.writer, "Wrote %s graph to %s\n", opts.output, opts.outputFile)
 	}
 	return nil
+}
+
+func filterGraphServicesOnly(result graphResult) graphResult {
+	keep := make(map[string]struct{}, len(result.Nodes))
+	nodes := make([]graphNode, 0, len(result.Nodes))
+	for _, n := range result.Nodes {
+		if n.Type != "service" {
+			continue
+		}
+		keep[n.Name] = struct{}{}
+		nodes = append(nodes, n)
+	}
+
+	edges := make([]graphEdge, 0, len(result.Edges))
+	for _, e := range result.Edges {
+		if _, ok := keep[e.From]; !ok {
+			continue
+		}
+		if _, ok := keep[e.To]; !ok {
+			continue
+		}
+		edges = append(edges, e)
+	}
+
+	levels := make([][]string, 0, len(result.Levels))
+	for _, level := range result.Levels {
+		filtered := make([]string, 0, len(level))
+		for _, name := range level {
+			if _, ok := keep[name]; ok {
+				filtered = append(filtered, name)
+			}
+		}
+		if len(filtered) > 0 {
+			levels = append(levels, filtered)
+		}
+	}
+
+	result.Nodes = nodes
+	result.Edges = edges
+	result.Levels = levels
+	return result
 }
 
 func renderGraph(w io.Writer, format string, result graphResult) error {

--- a/cli/src/cmd/app/commands/graph_test.go
+++ b/cli/src/cmd/app/commands/graph_test.go
@@ -25,6 +25,9 @@ func TestNewGraphCommand(t *testing.T) {
 	if cmd.Flags().Lookup("focus") == nil {
 		t.Fatal("focus flag not found")
 	}
+	if cmd.Flags().Lookup("services-only") == nil {
+		t.Fatal("services-only flag not found")
+	}
 }
 
 func focusSampleGraph() graphResult {
@@ -115,6 +118,30 @@ func TestFocusGraphResult(t *testing.T) {
 	})
 }
 
+func TestFilterGraphServicesOnly(t *testing.T) {
+	result := filterGraphServicesOnly(focusSampleGraph())
+
+	names := nodeNameSet(result.Nodes)
+	for _, want := range []string{"api", "web", "worker"} {
+		if !names[want] {
+			t.Fatalf("expected service %q in graph, got %#v", want, result.Nodes)
+		}
+	}
+	if names["db"] {
+		t.Fatalf("resource db should be excluded, got %#v", result.Nodes)
+	}
+	if len(result.Edges) != 1 || result.Edges[0] != (graphEdge{From: "web", To: "api"}) {
+		t.Fatalf("edges = %#v, want only web -> api", result.Edges)
+	}
+	for _, level := range result.Levels {
+		for _, name := range level {
+			if name == "db" {
+				t.Fatalf("resource db should be excluded from levels: %#v", result.Levels)
+			}
+		}
+	}
+}
+
 func TestRunGraphFocus(t *testing.T) {
 	dir := t.TempDir()
 	azureYaml := []byte(`
@@ -143,6 +170,7 @@ resources:
 	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), azureYaml, 0o600); err != nil {
 		t.Fatalf("write azure.yaml: %v", err)
 	}
+
 	for _, sub := range []string{"api", "web", "lonely"} {
 		if err := os.Mkdir(filepath.Join(dir, sub), 0o750); err != nil {
 			t.Fatalf("mkdir %s: %v", sub, err)
@@ -165,6 +193,58 @@ resources:
 	}
 	if names["lonely"] {
 		t.Fatalf("lonely service should be excluded when focusing api: %#v", got.Nodes)
+	}
+}
+
+func TestRunGraphServicesOnly(t *testing.T) {
+	dir := t.TempDir()
+	azureYaml := []byte(`
+name: graph-test
+services:
+  api:
+    host: local
+    language: go
+    project: ./api
+    uses:
+      - db
+  web:
+    host: local
+    language: node
+    project: ./web
+    uses:
+      - api
+resources:
+  db:
+    type: postgres
+`)
+	if err := os.WriteFile(filepath.Join(dir, "azure.yaml"), azureYaml, 0o600); err != nil {
+		t.Fatalf("write azure.yaml: %v", err)
+	}
+	for _, sub := range []string{"api", "web"} {
+		if err := os.Mkdir(filepath.Join(dir, sub), 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+	err := runGraph(&graphOptions{output: graphOutputJSON, servicesOnly: true, writer: &buf})
+	if err != nil {
+		t.Fatalf("runGraph failed: %v", err)
+	}
+	var got graphResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	names := nodeNameSet(got.Nodes)
+	if !names["api"] || !names["web"] {
+		t.Fatalf("services-only graph should contain services: %#v", got.Nodes)
+	}
+	if names["db"] {
+		t.Fatalf("services-only graph should exclude resources: %#v", got.Nodes)
+	}
+	if len(got.Edges) != 1 || got.Edges[0] != (graphEdge{From: "web", To: "api"}) {
+		t.Fatalf("edges = %#v, want only web -> api", got.Edges)
 	}
 }
 


### PR DESCRIPTION
Adds `azd app graph --services-only` to omit resource nodes from graph output and keep only service-to-service edges.

Validation:
- `go build ./...`
- `go test ./...`

Closes https://github.com/jongio/azd-app/issues/559