### PR TITLE
feat(status): add exit-code flag

### DIFF
--- a/cli/src/cmd/app/commands/status.go
+++ b/cli/src/cmd/app/commands/status.go
@@ -27,6 +27,7 @@ var (
 	statusInterval     time.Duration
 	statusService      string
 	statusDashboardURL bool
+	statusExitCode     bool
 )
 
 type statusReport struct {
@@ -50,12 +51,18 @@ Pass --watch to refresh the status on an interval until you press Ctrl+C, which
 is handy for keeping an eye on services while they start. The global --json flag
 prints a single snapshot and ignores --watch.
 
+Pass --exit-code to exit non-zero when the app is not running, which is handy in
+scripts and CI. It is ignored by the interactive --watch view.
+
 Examples:
   # One-time snapshot
   azd app status
 
   # Show one service
   azd app status --service api
+
+  # Exit non-zero when the app is not running
+  azd app status --exit-code
 
   # Live view, refreshed every 2 seconds
   azd app status --watch
@@ -69,6 +76,7 @@ Examples:
 	cmd.Flags().DurationVar(&statusInterval, "interval", 2*time.Second, "Refresh interval for --watch (minimum 1s)")
 	cmd.Flags().StringVarP(&statusService, "service", "s", "", "Filter to specific service(s), comma-separated")
 	cmd.Flags().BoolVar(&statusDashboardURL, "dashboard-url", false, "Print only the dashboard URL for the active run")
+	cmd.Flags().BoolVar(&statusExitCode, "exit-code", false, "Return a non-zero exit code when the app is not running (ignored with --watch)")
 	return cmd
 }
 
@@ -114,11 +122,24 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	}
 
 	if cliout.IsJSON() {
-		return cliout.PrintJSON(report)
+		if err := cliout.PrintJSON(report); err != nil {
+			return err
+		}
+		return statusExitCodeError(report)
 	}
 
 	cliout.CommandHeader("status", "Show app status")
 	printStatusReport(report)
+	return statusExitCodeError(report)
+}
+
+// statusExitCodeError returns a non-nil error when --exit-code is set and the
+// app is not running, so the command exits non-zero. The message matches the
+// text report so both surfaces describe the same state the same way.
+func statusExitCodeError(report statusReport) error {
+	if statusExitCode && !report.Running {
+		return fmt.Errorf("app is not running")
+	}
 	return nil
 }
 

--- a/cli/src/cmd/app/commands/status_test.go
+++ b/cli/src/cmd/app/commands/status_test.go
@@ -42,6 +42,7 @@ func TestNewStatusCommand(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("interval"), "expected --interval flag")
 	assert.NotNil(t, cmd.Flags().Lookup("service"), "expected --service flag")
 	assert.NotNil(t, cmd.Flags().Lookup("dashboard-url"), "expected --dashboard-url flag")
+	assert.NotNil(t, cmd.Flags().Lookup("exit-code"), "expected --exit-code flag")
 }
 
 func TestRenderStatusReport(t *testing.T) {
@@ -263,6 +264,22 @@ func TestDashboardURLFromStatusReport(t *testing.T) {
 	_, err = dashboardURLFromStatusReport(statusReport{Running: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "dashboard URL is not available")
+}
+
+func TestStatusExitCodeError(t *testing.T) {
+	t.Cleanup(func() {
+		statusExitCode = false
+	})
+
+	statusExitCode = true
+	err := statusExitCodeError(statusReport{Running: false})
+	require.Error(t, err)
+	// Matches the text report wording so both surfaces describe the same state.
+	assert.Equal(t, "app is not running", err.Error())
+	require.NoError(t, statusExitCodeError(statusReport{Running: true}))
+
+	statusExitCode = false
+	require.NoError(t, statusExitCodeError(statusReport{Running: false}))
 }
 
 func TestBuildStatusReportStaleStateRemovesFile(t *testing.T) {


### PR DESCRIPTION
Adds `azd app status --exit-code` so scripts can fail when the app runner is not active while keeping normal status output.

Validation:
- `go build ./...`
- `go test ./...`

Closes https://github.com/jongio/azd-app/issues/560