### PR TITLE
fix: detached runs, non-interactive port prompts, test command reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **azd-app-onboard Copilot skill** with Vally evals and CI integration
 
 ### Fixed
+- `azd app run --detach` dying immediately on Windows when the launching process owns a kill-on-close Job Object ([#555](https://github.com/jongio/azd-app/issues/555))
+- `azd app status` and `azd app stop` having no PID to work with until every service had started
+- `azd app stop` discarding the run state when it failed, leaving a live manager with no handle
+- `azd app run` aborting with `failed to read user input: EOF` when the port-conflict prompt got non-interactive stdin ([#556](https://github.com/jongio/azd-app/issues/556))
+- `azd app test` reporting the framework instead of the explicit `test.<type>.command` it actually runs, and reporting a test type it silently skips as passing ([#557](https://github.com/jongio/azd-app/issues/557))
 - Dashboard streaming RPC disconnects caused by WriteTimeout
 - Auto-resolve port conflicts with `--force` and in non-interactive mode
 - Security remediation — 29 findings across 7 workstreams

--- a/cli/src/cmd/app/commands/run.go
+++ b/cli/src/cmd/app/commands/run.go
@@ -257,11 +257,6 @@ func runServicesFromAzureYaml(ctx context.Context, azureYamlPath string, runtime
 
 // runAzdMode runs services in azd mode with individual service orchestration.
 func runAzdMode(ctx context.Context, azureYamlPath, azureYamlDir string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get current directory: %w", err)
-	}
-
 	// Parse azure.yaml
 	azureYaml, err := service.ParseAzureYaml(azureYamlPath)
 	if err != nil {
@@ -337,7 +332,7 @@ func runAzdMode(ctx context.Context, azureYamlPath, azureYamlDir string) error {
 	}
 
 	// Execute and monitor services
-	return executeAndMonitorServices(ctx, runtimes, cwd, azureYaml, azureYamlDir)
+	return executeAndMonitorServices(ctx, runtimes, azureYamlDir, azureYaml)
 }
 
 // showNoServicesMessage displays a message when no services are defined.

--- a/cli/src/cmd/app/commands/run_detach.go
+++ b/cli/src/cmd/app/commands/run_detach.go
@@ -2,10 +2,14 @@ package commands
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/jongio/azd-app/cli/src/internal/runstate"
 	"github.com/jongio/azd-core/cliout"
@@ -13,7 +17,11 @@ import (
 
 const (
 	detachedRunEnvVar = "AZD_APP_DETACHED"
-	runLogFileName    = "run.log"
+	// detachedRunEnvValue marks a child as the detached run. Only this exact
+	// value counts, so an unrelated truthy setting cannot make a foreground
+	// invocation behave like the background one.
+	detachedRunEnvValue = "1"
+	runLogFileName      = "run.log"
 )
 
 type detachedRunResult struct {
@@ -22,8 +30,15 @@ type detachedRunResult struct {
 	LogFile  string `json:"logFile"`
 }
 
+// detachedChildOnce guards the one-time read of the detached marker. It is a
+// pointer so tests can reset it between cases.
+var (
+	detachedChildOnce = new(sync.Once)
+	detachedChild     bool
+)
+
 func maybeStartDetachedRun(projectDir string) (*detachedRunResult, bool, error) {
-	if !runDetach || os.Getenv(detachedRunEnvVar) == "1" {
+	if !runDetach || IsDetachedChild() {
 		return nil, false, nil
 	}
 
@@ -33,6 +48,28 @@ func maybeStartDetachedRun(projectDir string) (*detachedRunResult, bool, error) 
 	}
 
 	return result, true, nil
+}
+
+// IsDetachedChild reports whether this process is the background run spawned by
+// `azd app run --detach` rather than the foreground invocation that spawned it.
+//
+// The marker is read once and then removed from this process's environment.
+// Spawned services and lifecycle hooks build their environment from
+// os.Environ(), so leaving it set would mark them, and any nested
+// `azd app run` they invoke, as detached children. Such a nested invocation
+// would skip LoadAzdEnvironment and silently run against the default azd
+// environment instead of the one it was given with -e. The result is cached
+// because callers run both before and after the unset.
+func IsDetachedChild() bool {
+	detachedChildOnce.Do(func() {
+		detachedChild = os.Getenv(detachedRunEnvVar) == detachedRunEnvValue
+		if detachedChild {
+			// A failure here only leaves the marker in place, which is the
+			// pre-existing behaviour, so there is nothing to recover from.
+			_ = os.Unsetenv(detachedRunEnvVar)
+		}
+	})
+	return detachedChild
 }
 
 func startDetachedRun(projectDir string) (*detachedRunResult, error) {
@@ -58,22 +95,100 @@ func startDetachedRun(projectDir string) (*detachedRunResult, error) {
 		return nil, fmt.Errorf("resolve executable path: %w", err)
 	}
 
-	cmd := exec.Command(exePath, stripDetachFlag(os.Args[1:])...)
-	cmd.Env = append(os.Environ(), detachedRunEnvVar+"=1")
-	cmd.SysProcAttr = detachSysProcAttr()
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-	cmd.Stdin = nil
-
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("start detached run process: %w", err)
+	proc, err := spawnDetached(
+		exePath,
+		stripDetachFlag(os.Args[1:]),
+		append(os.Environ(), detachedRunEnvVar+"="+detachedRunEnvValue),
+		logFile,
+	)
+	if err != nil {
+		return nil, err
 	}
+
+	recordDetachedRunState(projectDir, proc.Pid)
 
 	return &detachedRunResult{
 		Detached: true,
-		PID:      cmd.Process.Pid,
+		PID:      proc.Pid,
 		LogFile:  logPath,
 	}, nil
+}
+
+// spawnDetached starts the background process, trying each platform spawn
+// attempt in order until one succeeds or an attempt fails for a reason other
+// than a rejected job-object breakaway.
+func spawnDetached(exePath string, args, env []string, logFile *os.File) (*os.Process, error) {
+	return spawnWithAttempts(detachSpawnAttempts(), func(attr *syscall.SysProcAttr) (*os.Process, error) {
+		// A command that failed to start cannot be started again, so each
+		// attempt needs its own exec.Cmd. Reusing logFile is safe because
+		// os/exec passes an *os.File straight through and never closes it.
+		cmd := exec.Command(exePath, args...)
+		cmd.Env = env
+		cmd.SysProcAttr = attr
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+		cmd.Stdin = nil
+
+		if err := cmd.Start(); err != nil {
+			return nil, err
+		}
+		return cmd.Process, nil
+	})
+}
+
+// spawnWithAttempts runs each attempt until one succeeds. It only moves on to
+// the next attempt when the failure was a rejected breakaway request; any other
+// failure would repeat identically, so it is returned immediately.
+func spawnWithAttempts(
+	attempts []*syscall.SysProcAttr,
+	start func(*syscall.SysProcAttr) (*os.Process, error),
+) (*os.Process, error) {
+	if len(attempts) == 0 {
+		return nil, fmt.Errorf("start detached run process: no spawn attempts configured")
+	}
+
+	var lastErr error
+	for _, attr := range attempts {
+		proc, err := start(attr)
+		if err == nil {
+			return proc, nil
+		}
+
+		lastErr = err
+		if !isBreakawayRejected(err) {
+			break
+		}
+	}
+
+	return nil, fmt.Errorf("start detached run process: %w", lastErr)
+}
+
+// recordDetachedRunState persists a minimal run state as soon as the background
+// process exists so that `azd app status` and `azd app stop` can find it during
+// the seconds it takes services and the dashboard to come up. The child
+// overwrites this record with full service and dashboard details once ready.
+//
+// The child normally takes seconds to get that far, but nothing guarantees this
+// seed lands first. Any state already recorded against the PID we just spawned
+// can only have come from that child, so it is left alone rather than being
+// reduced back to a bare PID.
+func recordDetachedRunState(projectDir string, pid int) {
+	if existing, found, err := runstate.Read(projectDir); err == nil && found && existing.PID == pid {
+		return
+	}
+
+	err := runstate.Write(projectDir, runstate.RunState{
+		PID:       pid,
+		StartTime: time.Now(),
+	})
+	if err != nil {
+		// The process is already running, so this is not fatal: only status and
+		// stop discovery is degraded until the child writes its own state.
+		slog.Warn("failed to write detached run state", "error", err, "pid", pid)
+		if !cliout.IsJSON() {
+			cliout.Warning("Failed to write run state: %v", err)
+		}
+	}
 }
 
 func printDetachedStartResult(result *detachedRunResult) error {
@@ -89,9 +204,19 @@ func printDetachedStartResult(result *detachedRunResult) error {
 	return nil
 }
 
+// stripDetachFlag removes --detach from the argv handed to the child, so the
+// child runs in the foreground instead of detaching again.
+//
+// Everything after a bare "--" is a positional argument rather than a flag, and
+// `azd app run` forwards positionals through to service selection. Those are
+// copied verbatim so a service whose name happens to look like the flag is not
+// silently dropped.
 func stripDetachFlag(args []string) []string {
 	filtered := make([]string, 0, len(args))
-	for _, arg := range args {
+	for i, arg := range args {
+		if arg == "--" {
+			return append(filtered, args[i:]...)
+		}
 		if arg == "--detach" || strings.HasPrefix(arg, "--detach=") {
 			continue
 		}

--- a/cli/src/cmd/app/commands/run_detach_test.go
+++ b/cli/src/cmd/app/commands/run_detach_test.go
@@ -1,9 +1,13 @@
 package commands
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/jongio/azd-app/cli/src/internal/runstate"
 	"github.com/jongio/azd-core/cliout"
@@ -39,6 +43,21 @@ func TestStripDetachFlag(t *testing.T) {
 			args: []string{"run", "--runtime", "aspire"},
 			want: []string{"run", "--runtime", "aspire"},
 		},
+		{
+			name: "keeps positional args after the terminator verbatim",
+			args: []string{"run", "--detach", "--", "--detach", "api"},
+			want: []string{"run", "--", "--detach", "api"},
+		},
+		{
+			name: "keeps a lone terminator",
+			args: []string{"run", "--detach", "--"},
+			want: []string{"run", "--"},
+		},
+		{
+			name: "does not strip flags that merely start with the name",
+			args: []string{"run", "--detach-timeout", "5"},
+			want: []string{"run", "--detach-timeout", "5"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -62,6 +81,7 @@ func TestMaybeStartDetachedRunSkips(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			withRunDetach(t, tt.detach)
 			t.Setenv(detachedRunEnvVar, tt.envVal)
+			resetDetachedChildCache(t)
 
 			result, detached, err := maybeStartDetachedRun(t.TempDir())
 			require.NoError(t, err)
@@ -69,6 +89,63 @@ func TestMaybeStartDetachedRunSkips(t *testing.T) {
 			assert.Nil(t, result)
 		})
 	}
+}
+
+// resetDetachedChildCache clears the one-time detached marker read so each test
+// observes its own environment, and clears it again afterwards so a cached
+// value cannot leak into unrelated tests.
+func resetDetachedChildCache(t *testing.T) {
+	t.Helper()
+	detachedChildOnce = new(sync.Once)
+	detachedChild = false
+	t.Cleanup(func() {
+		detachedChildOnce = new(sync.Once)
+		detachedChild = false
+	})
+}
+
+func TestIsDetachedChild(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string
+		want   bool
+	}{
+		{name: "unset", envVal: "", want: false},
+		{name: "detached child", envVal: "1", want: true},
+		{name: "other value is not a detached child", envVal: "0", want: false},
+		{name: "truthy string is not a detached child", envVal: "true", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(detachedRunEnvVar, tt.envVal)
+			resetDetachedChildCache(t)
+			assert.Equal(t, tt.want, IsDetachedChild())
+		})
+	}
+}
+
+// The marker must not survive in the environment, because services and
+// lifecycle hooks inherit os.Environ(). A nested `azd app run` that still saw
+// the marker would skip loading the azd environment it was given with -e.
+func TestIsDetachedChildConsumesMarker(t *testing.T) {
+	t.Setenv(detachedRunEnvVar, detachedRunEnvValue)
+	resetDetachedChildCache(t)
+
+	require.True(t, IsDetachedChild())
+	assert.Empty(t, os.Getenv(detachedRunEnvVar), "marker must be removed so children do not inherit it")
+
+	// Later callers still need the answer after the variable is gone.
+	assert.True(t, IsDetachedChild(), "result must be cached once the marker is consumed")
+}
+
+// A foreground run must not touch the environment it was handed.
+func TestIsDetachedChildLeavesForeignValueIntact(t *testing.T) {
+	t.Setenv(detachedRunEnvVar, "0")
+	resetDetachedChildCache(t)
+
+	assert.False(t, IsDetachedChild())
+	assert.Equal(t, "0", os.Getenv(detachedRunEnvVar))
 }
 
 func TestPrintDetachedStartResult(t *testing.T) {
@@ -94,6 +171,7 @@ func TestMaybeStartDetachedRunSpawns(t *testing.T) {
 	withRunDetach(t, true)
 	// Ensure the parent is not itself treated as an already-detached child.
 	t.Setenv(detachedRunEnvVar, "")
+	resetDetachedChildCache(t)
 	// The spawned child inherits this sentinel and exits immediately via TestMain.
 	t.Setenv(testDetachChildEnv, "1")
 
@@ -114,9 +192,178 @@ func TestMaybeStartDetachedRunSpawns(t *testing.T) {
 	_, statErr := os.Stat(result.LogFile)
 	assert.NoError(t, statErr)
 
+	// Run state must exist as soon as the parent returns so that `azd app
+	// status` and `azd app stop` work during the child's startup window,
+	// instead of only after every service and the dashboard are ready.
+	state, found, readErr := runstate.Read(projectDir)
+	require.NoError(t, readErr)
+	require.True(t, found, "detached run state must be written before the parent returns")
+	assert.Equal(t, result.PID, state.PID)
+	assert.False(t, state.StartTime.IsZero())
+
 	// The child exits on its own; release/kill defensively so nothing leaks.
 	if proc, ferr := os.FindProcess(result.PID); ferr == nil {
 		_ = proc.Kill()
 		_ = proc.Release()
 	}
+}
+
+func TestRecordDetachedRunState(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "record-project")
+	statePath, err := runstate.Path(projectDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(statePath)) })
+
+	before := time.Now()
+	recordDetachedRunState(projectDir, 4242)
+
+	state, found, err := runstate.Read(projectDir)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, 4242, state.PID)
+	assert.False(t, state.StartTime.Before(before.Truncate(time.Second)))
+	// The child fills these in once it is ready.
+	assert.Empty(t, state.DashboardURL)
+	assert.Empty(t, state.Services)
+}
+
+func TestRecordDetachedRunStateSurvivesWriteFailure(t *testing.T) {
+	// A run state write failure must never take down an already-running
+	// background process, so this must return normally rather than panic.
+	assert.NotPanics(t, func() {
+		recordDetachedRunState(string([]byte{0}), 1)
+	})
+}
+
+func TestSpawnWithAttempts(t *testing.T) {
+	sentinel := errors.New("spawn failed")
+
+	t.Run("returns the process from the first successful attempt", func(t *testing.T) {
+		calls := 0
+		want := &os.Process{Pid: 77}
+
+		got, err := spawnWithAttempts(
+			[]*syscall.SysProcAttr{{}, {}},
+			func(*syscall.SysProcAttr) (*os.Process, error) {
+				calls++
+				return want, nil
+			},
+		)
+
+		require.NoError(t, err)
+		assert.Same(t, want, got)
+		assert.Equal(t, 1, calls, "must not keep trying after success")
+	})
+
+	t.Run("stops on a failure that is not a rejected breakaway", func(t *testing.T) {
+		calls := 0
+
+		got, err := spawnWithAttempts(
+			[]*syscall.SysProcAttr{{}, {}},
+			func(*syscall.SysProcAttr) (*os.Process, error) {
+				calls++
+				return nil, sentinel
+			},
+		)
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+		assert.ErrorIs(t, err, sentinel)
+		assert.Contains(t, err.Error(), "start detached run process")
+		assert.Equal(t, 1, calls, "a retry would fail identically")
+	})
+
+	t.Run("reports a clear error when no attempts are configured", func(t *testing.T) {
+		got, err := spawnWithAttempts(nil, func(*syscall.SysProcAttr) (*os.Process, error) {
+			t.Fatal("start must not be called without attempts")
+			return nil, nil
+		})
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+		assert.Contains(t, err.Error(), "no spawn attempts configured")
+	})
+
+	t.Run("passes each attempt's attributes through to the starter", func(t *testing.T) {
+		attempts := detachSpawnAttempts()
+		var seen *syscall.SysProcAttr
+
+		_, err := spawnWithAttempts(attempts, func(attr *syscall.SysProcAttr) (*os.Process, error) {
+			seen = attr
+			return &os.Process{Pid: 1}, nil
+		})
+
+		require.NoError(t, err)
+		assert.Same(t, attempts[0], seen, "the preferred attempt must be tried first")
+	})
+}
+
+// The child publishes richer state than the parent seed. If the child wins the
+// race, the seed must not reduce it back to a bare PID.
+func TestRecordDetachedRunStateDoesNotClobberChildState(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "clobber-project")
+	statePath, err := runstate.Path(projectDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(statePath)) })
+
+	full := runstate.RunState{
+		PID:          4242,
+		DashboardURL: "http://localhost:5000",
+		Services:     []runstate.ServiceState{{Name: "api", Port: 3000}},
+		StartTime:    time.Now(),
+	}
+	require.NoError(t, runstate.Write(projectDir, full))
+
+	recordDetachedRunState(projectDir, 4242)
+
+	state, found, err := runstate.Read(projectDir)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "http://localhost:5000", state.DashboardURL, "child state must survive a late seed")
+	assert.Len(t, state.Services, 1)
+}
+
+// State left by a previous run under a different PID is stale and must be
+// replaced, otherwise a new detached run would inherit a dead dashboard URL.
+func TestRecordDetachedRunStateReplacesStaleStateFromAnotherPID(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "stale-project")
+	statePath, err := runstate.Path(projectDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(statePath)) })
+
+	require.NoError(t, runstate.Write(projectDir, runstate.RunState{
+		PID:          1111,
+		DashboardURL: "http://localhost:4999",
+		StartTime:    time.Now(),
+	}))
+
+	recordDetachedRunState(projectDir, 2222)
+
+	state, found, err := runstate.Read(projectDir)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, 2222, state.PID)
+	assert.Empty(t, state.DashboardURL, "stale dashboard URL must not carry over")
+}
+
+// The child may publish services before the dashboard URL is known. Gating the
+// seed on the PID alone keeps that partial-but-real state from being erased.
+func TestRecordDetachedRunStateDoesNotClobberChildStateWithoutDashboard(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "no-dashboard-project")
+	statePath, err := runstate.Path(projectDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(statePath)) })
+
+	require.NoError(t, runstate.Write(projectDir, runstate.RunState{
+		PID:       7777,
+		Services:  []runstate.ServiceState{{Name: "api", Port: 3000}},
+		StartTime: time.Now(),
+	}))
+
+	recordDetachedRunState(projectDir, 7777)
+
+	state, found, err := runstate.Read(projectDir)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Len(t, state.Services, 1, "child services must survive a late seed")
 }

--- a/cli/src/cmd/app/commands/run_detach_unix.go
+++ b/cli/src/cmd/app/commands/run_detach_unix.go
@@ -4,8 +4,17 @@ package commands
 
 import "syscall"
 
-func detachSysProcAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{
-		Setsid: true,
+// detachSpawnAttempts returns the single process attribute set used on Unix.
+// Setsid puts the child in a new session with no controlling terminal, which is
+// all that is needed to survive the parent exiting. There is no job object
+// equivalent to break away from, so there is nothing to retry.
+func detachSpawnAttempts() []*syscall.SysProcAttr {
+	return []*syscall.SysProcAttr{
+		{Setsid: true},
 	}
+}
+
+// isBreakawayRejected always reports false on Unix; see detachSpawnAttempts.
+func isBreakawayRejected(error) bool {
+	return false
 }

--- a/cli/src/cmd/app/commands/run_detach_unix_test.go
+++ b/cli/src/cmd/app/commands/run_detach_unix_test.go
@@ -3,13 +3,34 @@
 package commands
 
 import (
+	"errors"
+	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDetachSysProcAttr(t *testing.T) {
-	attr := detachSysProcAttr()
-	require.NotNil(t, attr)
-	require.True(t, attr.Setsid)
+func TestDetachSpawnAttempts(t *testing.T) {
+	attempts := detachSpawnAttempts()
+	require.Len(t, attempts, 1, "Unix has no job object, so there is nothing to retry")
+	require.NotNil(t, attempts[0])
+	assert.True(t, attempts[0].Setsid)
+}
+
+func TestIsBreakawayRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "nil", err: nil},
+		{name: "permission denied", err: syscall.EACCES},
+		{name: "unrelated error", err: errors.New("boom")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, isBreakawayRejected(tt.err), "Unix never retries a spawn")
+		})
+	}
 }

--- a/cli/src/cmd/app/commands/run_detach_windows.go
+++ b/cli/src/cmd/app/commands/run_detach_windows.go
@@ -2,13 +2,36 @@
 
 package commands
 
-import "syscall"
+import (
+	"errors"
+	"syscall"
+)
 
-func detachSysProcAttr() *syscall.SysProcAttr {
-	const detachedProcess = 0x00000008
-	const createNewProcessGroup = 0x00000200
+// Windows process creation flags used when spawning the background run.
+const (
+	detachedProcess        = 0x00000008
+	createNewProcessGroup  = 0x00000200
+	createBreakawayFromJob = 0x01000000
+)
 
-	return &syscall.SysProcAttr{
-		CreationFlags: detachedProcess | createNewProcessGroup,
+// detachSpawnAttempts returns the process attributes to try, most preferred first.
+//
+// DETACHED_PROCESS only releases the console; it does not remove the child from
+// the parent's job object. Terminals, IDEs, and CI agents commonly run azd
+// inside a job with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, so the "detached" child
+// is killed the moment the parent exits. CREATE_BREAKAWAY_FROM_JOB escapes that
+// job, but it fails with ERROR_ACCESS_DENIED when the job does not set
+// JOB_OBJECT_LIMIT_BREAKAWAY_OK. The second attempt drops the flag so those
+// environments keep the previous behaviour instead of failing to start at all.
+func detachSpawnAttempts() []*syscall.SysProcAttr {
+	return []*syscall.SysProcAttr{
+		{CreationFlags: createBreakawayFromJob | detachedProcess | createNewProcessGroup},
+		{CreationFlags: detachedProcess | createNewProcessGroup},
 	}
+}
+
+// isBreakawayRejected reports whether a start failure was the job object
+// refusing the breakaway request, which means the next attempt should be tried.
+func isBreakawayRejected(err error) bool {
+	return errors.Is(err, syscall.ERROR_ACCESS_DENIED)
 }

--- a/cli/src/cmd/app/commands/run_detach_windows_test.go
+++ b/cli/src/cmd/app/commands/run_detach_windows_test.go
@@ -3,16 +3,95 @@
 package commands
 
 import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDetachSysProcAttr(t *testing.T) {
-	attr := detachSysProcAttr()
-	require.NotNil(t, attr)
+func TestDetachSpawnAttempts(t *testing.T) {
+	attempts := detachSpawnAttempts()
+	require.Len(t, attempts, 2, "must offer a breakaway attempt and a fallback")
 
-	const detachedProcess = 0x00000008
-	const createNewProcessGroup = 0x00000200
-	require.Equal(t, uint32(detachedProcess|createNewProcessGroup), attr.CreationFlags)
+	assert.Equal(
+		t,
+		uint32(createBreakawayFromJob|detachedProcess|createNewProcessGroup),
+		attempts[0].CreationFlags,
+		"first attempt must request breakaway so a kill-on-close job cannot take the child down",
+	)
+	assert.Equal(
+		t,
+		uint32(detachedProcess|createNewProcessGroup),
+		attempts[1].CreationFlags,
+		"fallback must preserve the previous flags for jobs that forbid breakaway",
+	)
+}
+
+func TestIsBreakawayRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "access denied", err: syscall.ERROR_ACCESS_DENIED, want: true},
+		{
+			name: "access denied wrapped by os/exec",
+			err:  &fs.PathError{Op: "fork/exec", Path: "azd.exe", Err: syscall.ERROR_ACCESS_DENIED},
+			want: true,
+		},
+		{name: "file not found", err: syscall.ERROR_FILE_NOT_FOUND, want: false},
+		{name: "unrelated error", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isBreakawayRejected(tt.err))
+		})
+	}
+}
+
+// A job object without JOB_OBJECT_LIMIT_BREAKAWAY_OK rejects the breakaway
+// request with ERROR_ACCESS_DENIED. The spawn must fall back instead of
+// reporting a failure to the user.
+func TestSpawnWithAttemptsFallsBackWhenBreakawayRejected(t *testing.T) {
+	rejected := &fs.PathError{Op: "fork/exec", Path: "azd.exe", Err: syscall.ERROR_ACCESS_DENIED}
+	attempts := detachSpawnAttempts()
+	want := &os.Process{Pid: 99}
+
+	var seen []*syscall.SysProcAttr
+	got, err := spawnWithAttempts(attempts, func(attr *syscall.SysProcAttr) (*os.Process, error) {
+		seen = append(seen, attr)
+		if len(seen) == 1 {
+			return nil, rejected
+		}
+		return want, nil
+	})
+
+	require.NoError(t, err)
+	assert.Same(t, want, got)
+	require.Len(t, seen, 2, "must retry once the breakaway request is rejected")
+	assert.Equal(t, uint32(createBreakawayFromJob|detachedProcess|createNewProcessGroup), seen[0].CreationFlags)
+	assert.Equal(t, uint32(detachedProcess|createNewProcessGroup), seen[1].CreationFlags)
+}
+
+func TestSpawnWithAttemptsReportsLastErrorWhenAllRejected(t *testing.T) {
+	calls := 0
+	got, err := spawnWithAttempts(
+		detachSpawnAttempts(),
+		func(*syscall.SysProcAttr) (*os.Process, error) {
+			calls++
+			return nil, syscall.ERROR_ACCESS_DENIED
+		},
+	)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, 2, calls, "every attempt must be tried before giving up")
+	assert.ErrorIs(t, err, syscall.ERROR_ACCESS_DENIED)
+	assert.Contains(t, err.Error(), "start detached run process")
 }

--- a/cli/src/cmd/app/commands/run_orchestration.go
+++ b/cli/src/cmd/app/commands/run_orchestration.go
@@ -24,7 +24,7 @@ import (
 )
 
 // executeAndMonitorServices starts services and monitors them until interrupted.
-func executeAndMonitorServices(ctx context.Context, runtimes []*service.ServiceRuntime, cwd string, azureYaml *service.AzureYaml, azureYamlDir string) error {
+func executeAndMonitorServices(ctx context.Context, runtimes []*service.ServiceRuntime, projectDir string, azureYaml *service.AzureYaml) error {
 	// Create logger
 	logger := service.NewServiceLogger(runVerbose)
 	logger.LogStartup(len(runtimes))
@@ -48,16 +48,16 @@ func executeAndMonitorServices(ctx context.Context, runtimes []*service.ServiceR
 	}
 
 	// Display service URLs (local + custom + Azure endpoints/domains)
-	serviceSummaries := buildServiceSummaries(cwd, azureYaml, result.Processes)
+	serviceSummaries := buildServiceSummaries(projectDir, azureYaml, result.Processes)
 	logger.LogSummary(serviceSummaries)
 
 	logger.LogReady()
 
 	// Record per-service startup timing and surface regressions vs prior runs.
-	recordStartupTimings(cwd, result)
+	recordStartupTimings(projectDir, result)
 
 	// Execute postrun hook after all services are ready
-	if err := executePostrunHook(ctx, azureYaml, azureYamlDir); err != nil {
+	if err := executePostrunHook(ctx, azureYaml, projectDir); err != nil {
 		cliout.Warning("Postrun hook failed but services are running: %v", err)
 	}
 
@@ -74,7 +74,7 @@ func executeAndMonitorServices(ctx context.Context, runtimes []*service.ServiceR
 	}
 
 	// Start dashboard and wait for shutdown
-	return monitorServicesUntilShutdown(result, cwd, azureYaml, azureYamlDir)
+	return monitorServicesUntilShutdown(result, projectDir, azureYaml)
 }
 
 // monitorServicesUntilShutdown monitors all services with full process isolation.
@@ -93,23 +93,23 @@ func executeAndMonitorServices(ctx context.Context, runtimes []*service.ServiceR
 //
 // This uses sync.WaitGroup (not errgroup) because we want all goroutines to complete
 // independently rather than failing fast on first error.
-func monitorServicesUntilShutdown(result *service.OrchestrationResult, cwd string, azureYaml *service.AzureYaml, azureYamlDir string) error {
+func monitorServicesUntilShutdown(result *service.OrchestrationResult, projectDir string, azureYaml *service.AzureYaml) error {
 	// Create context that cancels on SIGINT/SIGTERM only
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
 	var wg sync.WaitGroup
-	dashboardServer := dashboard.GetServer(cwd)
+	dashboardServer := dashboard.GetServer(projectDir)
 
 	// Start notification manager for OS notifications on service issues
 	notifMgr, err := notifications.NewNotificationManager(
-		notifications.DefaultNotificationManagerConfig(cwd),
+		notifications.DefaultNotificationManagerConfig(projectDir),
 	)
 	if err != nil {
 		cliout.Warning("Notifications unavailable: %v", err)
 	} else {
 		notifMgr.Start()
-		configureAutoRestartSupervisor(ctx, notifMgr, result.Processes, cwd)
+		configureAutoRestartSupervisor(ctx, notifMgr, result.Processes, projectDir)
 		defer func() { _ = notifMgr.Stop() }()
 	}
 
@@ -117,10 +117,10 @@ func monitorServicesUntilShutdown(result *service.OrchestrationResult, cwd strin
 	startDashboardMonitor(ctx, &wg, dashboardServer, notifMgr)
 
 	// Start service process monitors
-	startServiceMonitors(ctx, &wg, result.Processes, cwd)
+	startServiceMonitors(ctx, &wg, result.Processes, projectDir)
 
 	if azureYaml != nil {
-		writeRunState(cwd, result, dashboardServer)
+		writeRunState(projectDir, result, dashboardServer)
 	}
 
 	// Also cancel on remote shutdown request (from `azd app stop` in another terminal)
@@ -136,7 +136,7 @@ func monitorServicesUntilShutdown(result *service.OrchestrationResult, cwd strin
 	wg.Wait()
 
 	// Perform cleanup shutdown with hooks
-	return performGracefulShutdown(cwd, dashboardServer, result.Processes, azureYaml, azureYamlDir)
+	return performGracefulShutdown(projectDir, dashboardServer, result.Processes, azureYaml)
 }
 
 // startDashboardMonitor starts the dashboard server in a separate goroutine with panic recovery.
@@ -245,7 +245,7 @@ func configureAutoRestartSupervisor(
 // performGracefulShutdown stops all services and dashboard with a timeout.
 // Runs prestop/poststop hooks around service shutdown.
 // Returns nil due to process isolation design - individual failures are logged but don't fail the command.
-func performGracefulShutdown(projectDir string, dashboardServer *dashboard.Server, processes map[string]*service.ServiceProcess, azureYaml *service.AzureYaml, azureYamlDir string) error {
+func performGracefulShutdown(projectDir string, dashboardServer *dashboard.Server, processes map[string]*service.ServiceProcess, azureYaml *service.AzureYaml) error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 
@@ -255,7 +255,7 @@ func performGracefulShutdown(projectDir string, dashboardServer *dashboard.Serve
 
 	// Execute prestop hook
 	if azureYaml != nil {
-		if hookErr := executePrestopHook(shutdownCtx, azureYaml, azureYamlDir); hookErr != nil {
+		if hookErr := executePrestopHook(shutdownCtx, azureYaml, projectDir); hookErr != nil {
 			cliout.Warning("Prestop hook failed: %v", hookErr)
 		}
 	}
@@ -278,7 +278,7 @@ func performGracefulShutdown(projectDir string, dashboardServer *dashboard.Serve
 
 	// Execute poststop hook
 	if azureYaml != nil {
-		if hookErr := executePoststopHook(shutdownCtx, azureYaml, azureYamlDir); hookErr != nil {
+		if hookErr := executePoststopHook(shutdownCtx, azureYaml, projectDir); hookErr != nil {
 			cliout.Warning("Poststop hook failed: %v", hookErr)
 		}
 	}

--- a/cli/src/cmd/app/commands/run_test.go
+++ b/cli/src/cmd/app/commands/run_test.go
@@ -269,7 +269,7 @@ func TestMonitorServicesUntilShutdown_StartupTimeout(t *testing.T) {
 	// Run monitoring in goroutine with timeout
 	done := make(chan error, 1)
 	go func() {
-		done <- monitorServicesUntilShutdown(result, tmpDir, nil, "")
+		done <- monitorServicesUntilShutdown(result, tmpDir, nil)
 	}()
 
 	// Ensure cleanup if test exits early
@@ -353,7 +353,7 @@ func TestMonitorServicesUntilShutdown_SignalHandling(t *testing.T) {
 	}()
 
 	startTime := time.Now()
-	_ = monitorServicesUntilShutdown(result, tmpDir, nil, "")
+	_ = monitorServicesUntilShutdown(result, tmpDir, nil)
 	elapsed := time.Since(startTime)
 
 	// Should complete reasonably quickly after signal
@@ -608,7 +608,7 @@ func TestMonitorServices_RunsIndefinitely(t *testing.T) {
 	}()
 
 	startTime := time.Now()
-	_ = monitorServicesUntilShutdown(result, tmpDir, nil, "")
+	_ = monitorServicesUntilShutdown(result, tmpDir, nil)
 	elapsed := time.Since(startTime)
 
 	// Should have run for approximately 5 seconds (not stop at 30 seconds or earlier)
@@ -848,7 +848,7 @@ func TestProcessExit_DoesNotStopOtherServices(t *testing.T) {
 	// Run monitoring in a goroutine since it waits indefinitely for signals
 	done := make(chan error, 1)
 	go func() {
-		done <- monitorServicesUntilShutdown(result, tmpDir, nil, "")
+		done <- monitorServicesUntilShutdown(result, tmpDir, nil)
 	}()
 
 	// Ensure cleanup if test exits

--- a/cli/src/cmd/app/commands/status_test.go
+++ b/cli/src/cmd/app/commands/status_test.go
@@ -17,7 +17,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// restoreStatusFlags snapshots the package-level vars that NewStatusCommand
+// binds its flags to and restores them when the test ends. Constructing or
+// executing the status command mutates these globals, which otherwise leaks
+// into every subsequent test in this binary.
+func restoreStatusFlags(t *testing.T) {
+	t.Helper()
+	watch, interval, service := statusWatch, statusInterval, statusService
+	t.Cleanup(func() {
+		statusWatch, statusInterval, statusService = watch, interval, service
+	})
+}
+
 func TestNewStatusCommand(t *testing.T) {
+	restoreStatusFlags(t)
+
 	cmd := NewStatusCommand()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "status", cmd.Use)
@@ -84,6 +98,11 @@ func TestRunStatusWatchIntervalTooSmall(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte("name: statustest\nservices: {}\n"), 0o600))
 	t.Chdir(dir)
+
+	// NewStatusCommand binds its flags to package-level vars, so executing it
+	// here leaves statusWatch/statusInterval set for every later test in this
+	// binary. Restore them so repeated runs (go test -count=2) stay isolated.
+	restoreStatusFlags(t)
 
 	cmd := NewStatusCommand()
 	cmd.SetArgs([]string{"--watch", "--interval", "100ms"})

--- a/cli/src/cmd/app/commands/stop.go
+++ b/cli/src/cmd/app/commands/stop.go
@@ -122,9 +122,12 @@ func runStopApp() error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = runstate.Remove(projectDir)
-	}()
+
+	// A manager that died leaves its run state behind, and the port and token
+	// files it needed may never have been written. Clear that record up front so
+	// every failure path below reports the same thing rather than chasing a
+	// dashboard that is not there.
+	clearRunStateIfManagerDead(projectDir)
 
 	// Discover the running dashboard port
 	dashboardPort, err := discoverDashboardPort(projectDir)
@@ -139,16 +142,43 @@ func runStopApp() error {
 	// removed when the server shuts down.
 	token := dashboard.ReadTokenFile(projectDir)
 	if token == "" {
-		return fmt.Errorf("could not read session token — is 'azd app run' active in this project?")
+		return fmt.Errorf("could not read session token - is 'azd app run' active in this project?")
 	}
 
 	// Send shutdown request
 	if err := sendShutdownRequest(baseURL, token); err != nil {
+		clearRunStateIfManagerDead(projectDir)
 		return err
 	}
 
-	cliout.Success("Shutdown signal sent — app is stopping")
+	// Only clear the recorded run state once shutdown has actually been
+	// accepted. Removing it on failure would discard the PID that `status` and
+	// a follow-up `stop` need, leaving a live manager with no way to reach it.
+	clearRunState(projectDir)
+
+	cliout.Success("Shutdown signal sent - app is stopping")
 	return nil
+}
+
+// clearRunState removes the recorded run state, warning rather than failing
+// because the shutdown itself already succeeded.
+func clearRunState(projectDir string) {
+	if err := runstate.Remove(projectDir); err != nil {
+		cliout.Warning("Failed to clear run state: %v", err)
+	}
+}
+
+// clearRunStateIfManagerDead drops the run state only when the recorded manager
+// process is gone. A failed shutdown against a live manager must keep the state
+// so `status` and a follow-up `stop` can still reach it. `azd app status` prunes
+// dead records too, so this keeps `stop` consistent with it rather than being
+// the only cleaner.
+func clearRunStateIfManagerDead(projectDir string) {
+	st, ok, err := runstate.Read(projectDir)
+	if err != nil || !ok || runstate.IsRunning(st) {
+		return
+	}
+	clearRunState(projectDir)
 }
 
 // findProjectDir locates the project root by finding azure.yaml.
@@ -159,7 +189,7 @@ func findProjectDir() (string, error) {
 	}
 	azureYamlPath, err := detector.FindAzureYaml(cwd)
 	if err != nil || azureYamlPath == "" {
-		return "", fmt.Errorf("could not find azure.yaml — are you in a project directory?")
+		return "", fmt.Errorf("could not find azure.yaml - are you in a project directory?")
 	}
 	return filepath.Dir(azureYamlPath), nil
 }
@@ -180,7 +210,7 @@ func discoverDashboardPort(projectDir string) (int, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("no running app found — is 'azd app run' active in this project?")
+	return 0, fmt.Errorf("no running app found - is 'azd app run' active in this project?")
 }
 
 // sendShutdownRequest sends a POST to the dashboard's shutdown endpoint.

--- a/cli/src/cmd/app/commands/stop_extra_test.go
+++ b/cli/src/cmd/app/commands/stop_extra_test.go
@@ -4,14 +4,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/jongio/azd-app/cli/src/internal/runstate"
 	"github.com/stretchr/testify/require"
 )
 
 // TestRunStopAppNoRunningApp exercises the whole-app stop path when nothing is
-// running: findProjectDir succeeds (the deferred run-state cleanup is armed),
-// but no dashboard port can be discovered, so runStopApp returns an error.
+// running: findProjectDir succeeds, but no dashboard port can be discovered, so
+// runStopApp returns an error.
 func TestRunStopAppNoRunningApp(t *testing.T) {
 	resetStopFlags(t)
 
@@ -27,4 +28,30 @@ func TestRunStopAppNoRunningApp(t *testing.T) {
 
 	err := runStopApp()
 	require.Error(t, err)
+}
+
+// A crashed manager leaves run.json behind. The up-front cleanup in runStopApp
+// is what frees it: stop cannot reach its normal success-path cleanup because
+// dashboard discovery fails first. Without that up-front call the record would
+// survive forever and keep `azd app status` reporting an app that is gone
+// (#555). This pins the call-site placement, which the helper's own unit tests
+// cannot do.
+func TestRunStopAppClearsStateForDeadManager(t *testing.T) {
+	resetStopFlags(t)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte("name: test\n"), 0o600))
+	t.Chdir(dir)
+
+	statePath, err := runstate.Path(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(statePath)) })
+	require.NoError(t, runstate.Write(dir, runstate.RunState{PID: deadPIDForTest(t), StartTime: time.Now()}))
+
+	// No dashboard is listening, so the stop itself still fails.
+	require.Error(t, runStopApp())
+
+	_, found, err := runstate.Read(dir)
+	require.NoError(t, err)
+	require.False(t, found, "a dead manager's run state must be cleared")
 }

--- a/cli/src/cmd/app/commands/stop_test.go
+++ b/cli/src/cmd/app/commands/stop_test.go
@@ -1,8 +1,12 @@
 package commands
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/jongio/azd-app/cli/src/internal/runstate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,4 +66,57 @@ func TestRunStopRoutesToServicesWhenServiceSet(t *testing.T) {
 	// must succeed (no-op) instead of attempting whole-app teardown.
 	stopAll = true
 	require.NoError(t, runStop(nil, nil))
+}
+
+// seedRunState writes a run state for a throwaway project and returns its dir.
+func seedRunState(t *testing.T, pid int) string {
+	t.Helper()
+	projectDir := filepath.Join(t.TempDir(), "stop-project")
+	statePath, err := runstate.Path(projectDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(statePath)) })
+	require.NoError(t, runstate.Write(projectDir, runstate.RunState{PID: pid, StartTime: time.Now()}))
+	return projectDir
+}
+
+// A failed shutdown against a live manager must keep the state, otherwise the
+// only record of the PID is lost and the manager becomes unreachable.
+func TestClearRunStateIfManagerDeadKeepsStateForLiveProcess(t *testing.T) {
+	projectDir := seedRunState(t, os.Getpid())
+
+	clearRunStateIfManagerDead(projectDir)
+
+	_, found, err := runstate.Read(projectDir)
+	require.NoError(t, err)
+	assert.True(t, found, "state for a live manager must survive a failed stop")
+}
+
+// A manager that crashed leaves state nothing else would clean up, so a failed
+// stop should drop it rather than report a phantom run forever.
+func TestClearRunStateIfManagerDeadRemovesStateForDeadProcess(t *testing.T) {
+	projectDir := seedRunState(t, deadPIDForTest(t))
+
+	clearRunStateIfManagerDead(projectDir)
+
+	_, found, err := runstate.Read(projectDir)
+	require.NoError(t, err)
+	assert.False(t, found, "stale state from a crashed manager must be cleared")
+}
+
+func TestClearRunStateIfManagerDeadIgnoresMissingState(t *testing.T) {
+	assert.NotPanics(t, func() {
+		clearRunStateIfManagerDead(filepath.Join(t.TempDir(), "no-state"))
+	})
+}
+
+// deadPIDForTest returns a PID that is not running.
+func deadPIDForTest(t *testing.T) int {
+	t.Helper()
+	for pid := 300000; pid < 300100; pid++ {
+		if !runstate.IsRunning(&runstate.RunState{PID: pid}) {
+			return pid
+		}
+	}
+	t.Skip("could not find a free PID to represent a dead manager")
+	return 0
 }

--- a/cli/src/cmd/app/commands/test.go
+++ b/cli/src/cmd/app/commands/test.go
@@ -311,7 +311,7 @@ func runTestDryRun(orchestrator *testing.TestOrchestrator, opts *TestOptions, se
 		services = filtered
 	}
 
-	validations := testing.ValidateServices(services)
+	validations := testing.ValidateServicesForType(services, opts.Type)
 	displayValidationSummary(validations)
 
 	return nil
@@ -368,15 +368,23 @@ func displayValidationSummary(validations []testing.ServiceValidation) {
 
 	// Show each service's validation status
 	for _, v := range validations {
-		if v.CanTest {
-			testFilesInfo := ""
-			if v.TestFiles > 0 {
-				testFilesInfo = fmt.Sprintf(" (%d test files)", v.TestFiles)
-			}
-			cliout.ItemSuccess("%s: %s detected%s", v.Name, v.Framework, testFilesInfo)
-		} else {
+		if !v.CanTest {
 			cliout.ItemWarning("%s: %s (skipping)", v.Name, v.SkipReason)
+			continue
 		}
+		// An explicit command wins over the configured framework, so report the
+		// command that will actually run rather than claiming the framework was
+		// detected.
+		if v.Command != "" {
+			cliout.ItemSuccess("%s: custom command (%s)", v.Name, v.Command)
+			continue
+		}
+
+		testFilesInfo := ""
+		if v.TestFiles > 0 {
+			testFilesInfo = fmt.Sprintf(" (%d test files)", v.TestFiles)
+		}
+		cliout.ItemSuccess("%s: %s detected%s", v.Name, v.Framework, testFilesInfo)
 	}
 
 	cliout.Newline()

--- a/cli/src/cmd/app/commands/test_test.go
+++ b/cli/src/cmd/app/commands/test_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	testrunner "github.com/jongio/azd-app/cli/src/internal/testing"
+	"github.com/jongio/azd-core/cliout"
 )
 
 // TestNewTestCommand verifies that the test command is created correctly.
@@ -499,4 +500,90 @@ func TestLoadAzdEnvironment(t *testing.T) {
 			t.Fatalf("loadAzdEnvironment() error = %v", err)
 		}
 	})
+}
+
+// Issue #557: an explicit test.<type>.command must be reported as the command
+// that will actually run. Reporting the framework instead told users their
+// configured command was being ignored, which is what made the execution bug
+// look like it was still present after it had been fixed.
+func TestDisplayValidationSummary_ExplicitCommandReportedOverFramework(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		displayValidationSummary([]testrunner.ServiceValidation{
+			{Name: "api", CanTest: true, Framework: "pytest", Command: "uv run pytest -q"},
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("captureStdout: %v", err)
+	}
+
+	if !strings.Contains(out, "uv run pytest -q") {
+		t.Errorf("summary must name the command that will run, got:\n%s", out)
+	}
+	if strings.Contains(out, "pytest detected") {
+		t.Errorf("summary must not claim framework detection when a command is set, got:\n%s", out)
+	}
+}
+
+// A service with no explicit command still reports its detected framework.
+func TestDisplayValidationSummary_FrameworkReportedWhenNoCommand(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		displayValidationSummary([]testrunner.ServiceValidation{
+			{Name: "web", CanTest: true, Framework: "vitest", TestFiles: 3},
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("captureStdout: %v", err)
+	}
+
+	if !strings.Contains(out, "vitest detected") {
+		t.Errorf("expected framework detection line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "3 test files") {
+		t.Errorf("expected test file count, got:\n%s", out)
+	}
+}
+
+// Skipped services report why they were skipped and are excluded from the count.
+func TestDisplayValidationSummary_ReportsSkippedServices(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		displayValidationSummary([]testrunner.ServiceValidation{
+			{Name: "api", CanTest: true, Command: "go test ./..."},
+			{Name: "docs", CanTest: false, SkipReason: "no test framework detected"},
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("captureStdout: %v", err)
+	}
+
+	if !strings.Contains(out, "no test framework detected") {
+		t.Errorf("expected skip reason, got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 testable services (1 skipped)") {
+		t.Errorf("expected testable/skipped counts, got:\n%s", out)
+	}
+}
+
+// JSON output is a machine contract, so the human summary must stay out of it.
+func TestDisplayValidationSummary_SilentInJSONMode(t *testing.T) {
+	if err := cliout.SetFormat("json"); err != nil {
+		t.Fatalf("SetFormat: %v", err)
+	}
+	t.Cleanup(func() { _ = cliout.SetFormat("default") })
+
+	out, err := captureStdout(t, func() error {
+		displayValidationSummary([]testrunner.ServiceValidation{
+			{Name: "api", CanTest: true, Command: "go test ./..."},
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("captureStdout: %v", err)
+	}
+
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("JSON mode must emit no human summary, got:\n%s", out)
+	}
 }

--- a/cli/src/cmd/app/main.go
+++ b/cli/src/cmd/app/main.go
@@ -43,8 +43,15 @@ func main() {
 			}
 		}
 
-		// Handle environment selection
-		if extCtx.Environment != "" {
+		// Handle environment selection.
+		//
+		// The detached background run already inherits the values its parent
+		// resolved, so reloading them is redundant. It is also actively harmful:
+		// LoadAzdEnvironment shells out to `azd env get-values`, and the azd host
+		// that served the parent exits as soon as the parent returns. That left
+		// the detached child blocked and completely silent for seconds, which is
+		// why its run.log was empty before it died.
+		if extCtx.Environment != "" && !commands.IsDetachedChild() {
 			if err := env.LoadAzdEnvironment(cmd.Context(), extCtx.Environment); err != nil {
 				return fmt.Errorf("failed to load environment '%s': %w", extCtx.Environment, err)
 			}

--- a/cli/src/internal/portmanager/portmanager_prompts.go
+++ b/cli/src/internal/portmanager/portmanager_prompts.go
@@ -3,11 +3,18 @@ package portmanager
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
 )
+
+// errNoInput reports that a prompt's input stream was exhausted before the user
+// answered. Callers translate it into their documented non-interactive
+// behaviour rather than failing the run.
+var errNoInput = errors.New("no input available")
 
 // PortConflictAction represents the user's chosen action for handling a port conflict.
 type PortConflictAction int
@@ -25,8 +32,9 @@ const (
 
 // handlePortConflict prompts the user to resolve a port conflict and returns the chosen action.
 // It checks force mode and always-kill preference first, returning ActionKill without
-// prompting when either is enabled. In non-interactive environments (piped stdin),
-// it auto-kills with a warning instead of crashing with EOF.
+// prompting when either is enabled. In non-interactive environments it auto-kills with a
+// warning instead of crashing with EOF, whether stdin is detectably non-interactive
+// (piped or redirected) or merely looks interactive but is never written to.
 //
 // Parameters:
 //   - pm: The port manager instance (used for preferences and force mode)
@@ -75,23 +83,60 @@ func handlePortConflict(pm *PortManager, port int, serviceName string, processIn
 	fmt.Fprintf(os.Stderr, "Choose (1/2/3/4): ")
 
 	// Read user input
-	reader := bufio.NewReader(os.Stdin)
-	response, err := reader.ReadString('\n')
+	response, err := readPromptLine(bufio.NewReader(os.Stdin))
 	if err != nil {
+		// stdin looked interactive (a character device) but yielded nothing.
+		// This happens when a host process hands down a console handle it never
+		// writes to. Degrade to the documented non-interactive behaviour rather
+		// than aborting the run.
+		if errors.Is(err, errNoInput) {
+			slog.Warn("stdin closed at port conflict prompt, auto-killing process on port", "port", port, "service", serviceName)
+			printNonInteractiveKillMessage(serviceName, port, processInfo, isExplicit)
+			return ActionKill, nil
+		}
 		return ActionCancel, fmt.Errorf("failed to read user input: %w", err)
 	}
 
-	response = strings.TrimSpace(response)
+	return parsePortConflictChoice(response), nil
+}
+
+// parsePortConflictChoice maps a menu selection to its action. Anything
+// unrecognised cancels, which is the safe default for a destructive menu.
+func parsePortConflictChoice(response string) PortConflictAction {
 	switch response {
 	case "1":
-		return ActionAlwaysKill, nil
+		return ActionAlwaysKill
 	case "2":
-		return ActionKill, nil
+		return ActionKill
 	case "3":
-		return ActionReassign, nil
+		return ActionReassign
 	default:
-		return ActionCancel, nil
+		return ActionCancel
 	}
+}
+
+// readPromptLine reads a single trimmed answer from r.
+//
+// bufio.Reader.ReadString returns both the buffered data and io.EOF when the
+// stream ends without the delimiter, so a final answer typed without a trailing
+// newline is still honoured. Partial data is only trusted on io.EOF, which is an
+// orderly end of stream. Any other read failure is returned verbatim and its
+// partial data discarded, because a truncated read from a broken stream is not
+// evidence that the user chose a destructive menu entry. An exhausted stream
+// with nothing to return yields errNoInput so callers can apply their
+// non-interactive fallback.
+func readPromptLine(r *bufio.Reader) (string, error) {
+	line, err := r.ReadString('\n')
+	if err == nil {
+		return strings.TrimSpace(line), nil
+	}
+	if !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	if answer := strings.TrimSpace(line); answer != "" {
+		return answer, nil
+	}
+	return "", errNoInput
 }
 
 // printAutoKillMessage prints the message shown when auto-kill preference is enabled.
@@ -129,13 +174,12 @@ func promptUpdateAzureYaml(pm *PortManager, port int) bool {
 	fmt.Fprintf(os.Stderr, "\n⚠️  IMPORTANT: Update your application code to use port %d\n", port)
 	fmt.Fprintf(os.Stderr, "Would you like to update azure.yaml to use port %d for future runs? (y/N): ", port)
 
-	reader := bufio.NewReader(os.Stdin)
-	response, err := reader.ReadString('\n')
+	response, err := readPromptLine(bufio.NewReader(os.Stdin))
 	if err != nil {
 		return false
 	}
 
-	response = strings.TrimSpace(strings.ToLower(response))
+	response = strings.ToLower(response)
 	return response == "y" || response == "yes"
 }
 

--- a/cli/src/internal/portmanager/prompts_test.go
+++ b/cli/src/internal/portmanager/prompts_test.go
@@ -1,7 +1,15 @@
 package portmanager
 
 import (
+	"bufio"
+	"errors"
+	"os"
+	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPortConflictAction_Constants(t *testing.T) {
@@ -248,4 +256,153 @@ func TestConstants(t *testing.T) {
 	if StalePortCleanupAge <= 0 {
 		t.Errorf("StalePortCleanupAge = %v, should be positive", StalePortCleanupAge)
 	}
+}
+
+// errReadFailure is an arbitrary non-EOF read failure used to prove that
+// partial data from a broken stream is never treated as an answer.
+var errReadFailure = errors.New("read failure")
+
+// truncatedReader returns data followed by a non-EOF error, mimicking a stream
+// that breaks midway through a line.
+type truncatedReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *truncatedReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, errReadFailure
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func TestReadPromptLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr error
+	}{
+		{name: "answer with newline", input: "2\n", want: "2"},
+		{name: "answer with carriage return", input: "3\r\n", want: "3"},
+		{name: "surrounding whitespace trimmed", input: "  1  \n", want: "1"},
+		{name: "answer without trailing newline is honoured", input: "4", want: "4"},
+		{name: "empty stream reports no input", input: "", wantErr: errNoInput},
+		{name: "whitespace only stream reports no input", input: "   ", wantErr: errNoInput},
+		{name: "blank line is a valid empty answer", input: "\n", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readPromptLine(bufio.NewReader(strings.NewReader(tt.input)))
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("readPromptLine() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readPromptLine() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("readPromptLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A truncated read from a broken stream is not consent to pick a destructive
+// menu entry, so the partial data must be discarded and the error surfaced.
+func TestReadPromptLineDiscardsPartialDataOnNonEOFError(t *testing.T) {
+	got, err := readPromptLine(bufio.NewReader(&truncatedReader{data: []byte("2")}))
+
+	if !errors.Is(err, errReadFailure) {
+		t.Fatalf("readPromptLine() error = %v, want %v", err, errReadFailure)
+	}
+	if errors.Is(err, errNoInput) {
+		t.Error("readPromptLine() reported errNoInput, which would trigger the non-interactive fallback")
+	}
+	if got != "" {
+		t.Errorf("readPromptLine() = %q, want empty so no menu choice is inferred", got)
+	}
+}
+
+func TestParsePortConflictChoice(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		want     PortConflictAction
+	}{
+		{name: "always kill", response: "1", want: ActionAlwaysKill},
+		{name: "kill", response: "2", want: ActionKill},
+		{name: "reassign", response: "3", want: ActionReassign},
+		{name: "cancel", response: "4", want: ActionCancel},
+		{name: "empty cancels", response: "", want: ActionCancel},
+		{name: "unrecognised cancels", response: "9", want: ActionCancel},
+		{name: "word cancels", response: "kill", want: ActionCancel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parsePortConflictChoice(tt.response); got != tt.want {
+				t.Errorf("parsePortConflictChoice(%q) = %d, want %d", tt.response, got, tt.want)
+			}
+		})
+	}
+}
+
+// nullDevicePath returns the platform's null device, which is a character
+// device that yields EOF immediately.
+func nullDevicePath() string {
+	if runtime.GOOS == "windows" {
+		return "NUL"
+	}
+	return "/dev/null"
+}
+
+// useStdin swaps os.Stdin for the duration of a test.
+func useStdin(t *testing.T, f *os.File) {
+	t.Helper()
+	original := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() { os.Stdin = original })
+}
+
+// Regression test for #556. The azd host hands down a console-like stdin that
+// nothing ever writes to, so the prompt looks interactive but reads EOF. That
+// used to abort the whole run with "failed to read user input: EOF". It must now
+// degrade to the documented non-interactive behaviour instead.
+func TestHandlePortConflict_InteractiveStdinYieldingEOF_DoesNotError(t *testing.T) {
+	nullDev, err := os.Open(nullDevicePath())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nullDev.Close() })
+	useStdin(t, nullDev)
+
+	// The scenario only matters when stdin looks interactive; otherwise the
+	// earlier non-interactive guard would handle it and prove nothing.
+	require.True(t, isStdinInteractive(), "null device should report as a character device")
+
+	pm := &PortManager{}
+	action, err := handlePortConflict(pm, 3000, "api", " by node (PID 1)", true)
+
+	require.NoError(t, err, "EOF at the prompt must not fail the run")
+	assert.Equal(t, ActionKill, action)
+}
+
+// The non-interactive guard still short-circuits before the prompt is drawn.
+func TestHandlePortConflict_NonInteractiveStdin_AutoKills(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	require.NoError(t, w.Close())
+	useStdin(t, r)
+
+	require.False(t, isStdinInteractive(), "a pipe must not look interactive")
+
+	action, err := handlePortConflict(&PortManager{}, 3000, "api", "", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, ActionKill, action)
 }

--- a/cli/src/internal/runstate/runstate.go
+++ b/cli/src/internal/runstate/runstate.go
@@ -43,16 +43,25 @@ func stateDir(projectDir string) (string, error) {
 	return filepath.Join(base, azdconfig.ProjectHash(projectDir)), nil
 }
 
+// stateFileName is the run state file name within a project's state directory.
+const stateFileName = "run.json"
+
 // Path returns the run-state path for the given project.
 func Path(projectDir string) (string, error) {
 	dir, err := stateDir(projectDir)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, "run.json"), nil
+	return filepath.Join(dir, stateFileName), nil
 }
 
 // Write persists the run state for a project.
+//
+// A detached run has the parent seed this file and the child rewrite it seconds
+// later, so writes are ordered in practice rather than concurrent. Replacing the
+// file atomically is deliberately not attempted: Windows refuses to rename over
+// a file a reader currently has open, which would trade a rare short read window
+// for a writer that can fail outright.
 func Write(projectDir string, st RunState) error {
 	path, err := Path(projectDir)
 	if err != nil {

--- a/cli/src/internal/testing/explicit_config_test.go
+++ b/cli/src/internal/testing/explicit_config_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -221,5 +222,171 @@ func TestIsRecognizedTestLanguage(t *testing.T) {
 		if isRecognizedTestLanguage(lang) {
 			t.Errorf("expected %q to NOT be a recognized test language", lang)
 		}
+	}
+}
+
+// A service whose language has no framework runner must not be reported as
+// testable for a type it never configured. executeServiceTests skips that
+// combination, so claiming it is testable produces a bogus "passed" summary
+// for a run that never happened.
+func TestValidateServiceForType_UnconfiguredTypeOnUnrecognizedLanguage_Skipped(t *testing.T) {
+	service := ServiceInfo{
+		Name:     "postgres",
+		Language: "docker",
+		Dir:      t.TempDir(),
+		Config:   &ServiceTestConfig{Unit: &TestTypeConfig{Command: "./run-unit.sh"}},
+	}
+
+	v := ValidateServiceForType(service, "e2e")
+
+	if v.CanTest {
+		t.Fatalf("expected CanTest=false for e2e on a docker service that only configures unit")
+	}
+	if !strings.Contains(v.SkipReason, "e2e") {
+		t.Errorf("expected SkipReason to name the missing type, got %q", v.SkipReason)
+	}
+}
+
+func TestValidateServiceForType_ConfiguredTypeOnUnrecognizedLanguage_Testable(t *testing.T) {
+	service := ServiceInfo{
+		Name:     "postgres",
+		Language: "docker",
+		Dir:      t.TempDir(),
+		Config:   &ServiceTestConfig{Unit: &TestTypeConfig{Command: "./run-unit.sh"}},
+	}
+
+	v := ValidateServiceForType(service, "unit")
+
+	if !v.CanTest {
+		t.Fatalf("expected CanTest=true for the configured type, got false (skip: %s)", v.SkipReason)
+	}
+	if v.Command != "./run-unit.sh" {
+		t.Errorf("expected the explicit unit command, got %q", v.Command)
+	}
+}
+
+// A recognized language keeps its framework runner for types it did not
+// configure explicitly, so it stays testable and reports no explicit command.
+func TestValidateServiceForType_UnconfiguredTypeOnRecognizedLanguage_StillTestable(t *testing.T) {
+	service := ServiceInfo{
+		Name:     "web",
+		Language: "typescript",
+		Dir:      t.TempDir(),
+		Config:   &ServiceTestConfig{Framework: "vitest", Unit: &TestTypeConfig{Command: "npm run unit"}},
+	}
+
+	v := ValidateServiceForType(service, "e2e")
+
+	if !v.CanTest {
+		t.Fatalf("expected CanTest=true for a recognized language, got false (skip: %s)", v.SkipReason)
+	}
+	if v.Command != "" {
+		t.Errorf("expected no explicit command for the framework-driven type, got %q", v.Command)
+	}
+}
+
+// Validation and execution must agree on which service/type pairs run.
+func TestValidateServiceForTypeMatchesExecutionGuard(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &ServiceTestConfig{Unit: &TestTypeConfig{Command: "./run-unit.sh"}}
+
+	for _, testType := range orderedTestTypes {
+		t.Run(testType, func(t *testing.T) {
+			service := ServiceInfo{Name: "svc", Language: "docker", Dir: dir, Config: cfg}
+
+			canTest := ValidateServiceForType(service, testType).CanTest
+			willRun := typeHasExplicitCommand(cfg, testType)
+
+			if canTest != willRun {
+				t.Errorf("validation reports CanTest=%v but execution would run=%v for type %q", canTest, willRun, testType)
+			}
+		})
+	}
+}
+
+// AC10: the requested type's explicit command is what displayValidationSummary
+// reports, so validation must surface it even when a framework is also set.
+func TestValidateServiceForType_ReportsExplicitCommandForRequestedType(t *testing.T) {
+	service := ServiceInfo{
+		Name:     "web",
+		Language: "typescript",
+		Dir:      t.TempDir(),
+		Config: &ServiceTestConfig{
+			Framework: "vitest",
+			Unit:      &TestTypeConfig{Command: "npm run unit"},
+			E2E:       &TestTypeConfig{Command: "npx tsx scripts/smoke.ts"},
+		},
+	}
+
+	v := ValidateServiceForType(service, "e2e")
+
+	if v.Command != "npx tsx scripts/smoke.ts" {
+		t.Errorf("expected the e2e command, got %q", v.Command)
+	}
+	if v.Framework != "vitest" {
+		t.Errorf("Framework should keep its configured meaning, got %q", v.Framework)
+	}
+}
+
+// Requesting every type lists each configured command so the summary does not
+// silently pick one.
+func TestValidateServiceForType_AllListsEveryConfiguredCommand(t *testing.T) {
+	service := ServiceInfo{
+		Name:     "web",
+		Language: "docker",
+		Dir:      t.TempDir(),
+		Config: &ServiceTestConfig{
+			Unit: &TestTypeConfig{Command: "run-unit"},
+			E2E:  &TestTypeConfig{Command: "run-e2e"},
+		},
+	}
+
+	v := ValidateServiceForType(service, testFilterAll)
+
+	if !strings.Contains(v.Command, "unit: run-unit") || !strings.Contains(v.Command, "e2e: run-e2e") {
+		t.Errorf("expected both commands listed, got %q", v.Command)
+	}
+}
+
+// A single configured command needs no type prefix.
+func TestValidateServiceForType_AllWithOneCommandOmitsPrefix(t *testing.T) {
+	service := ServiceInfo{
+		Name:     "web",
+		Language: "docker",
+		Dir:      t.TempDir(),
+		Config:   &ServiceTestConfig{E2E: &TestTypeConfig{Command: "run-e2e"}},
+	}
+
+	if got := ValidateServiceForType(service, testFilterAll).Command; got != "run-e2e" {
+		t.Errorf("expected the bare command, got %q", got)
+	}
+}
+
+// ValidateService must stay equivalent to requesting every type.
+func TestValidateServiceDelegatesToAllTypes(t *testing.T) {
+	service := ServiceInfo{
+		Name:     "web",
+		Language: "docker",
+		Dir:      t.TempDir(),
+		Config:   &ServiceTestConfig{Unit: &TestTypeConfig{Command: "run-unit"}},
+	}
+
+	if ValidateService(service).Command != ValidateServiceForType(service, testFilterAll).Command {
+		t.Error("ValidateService should match ValidateServiceForType with the all filter")
+	}
+}
+
+// Framework-driven services report no explicit command, preserving the original
+// "<framework> detected" summary line.
+func TestValidateServiceForType_FrameworkDrivenReportsNoCommand(t *testing.T) {
+	service := ServiceInfo{
+		Name:     "web",
+		Language: "typescript",
+		Dir:      t.TempDir(),
+		Config:   &ServiceTestConfig{Framework: "vitest", Unit: &TestTypeConfig{}},
+	}
+
+	if got := ValidateServiceForType(service, "unit").Command; got != "" {
+		t.Errorf("expected no command for a framework-driven service, got %q", got)
 	}
 }

--- a/cli/src/internal/testing/orchestrator.go
+++ b/cli/src/internal/testing/orchestrator.go
@@ -424,7 +424,7 @@ func (o *TestOrchestrator) ExecuteTestsWithValidation(testType string, serviceFi
 
 	validations := make([]ServiceValidation, 0, len(services))
 	for _, service := range services {
-		validation := ValidateService(service)
+		validation := ValidateServiceForType(service, testType)
 		validations = append(validations, validation)
 
 		o.emitProgress(ProgressEvent{
@@ -470,20 +470,11 @@ func (o *TestOrchestrator) ExecuteTestsWithValidation(testType string, serviceFi
 
 	// Execute tests for each testable service
 	for _, service := range testableServices {
-		// Find the validation for this service to get framework info
-		var framework string
-		for _, v := range validations {
-			if v.Name == service.Name {
-				framework = v.Framework
-				break
-			}
-		}
-
 		// Emit test start progress event
 		o.emitProgress(ProgressEvent{
 			Type:      ProgressEventTestStart,
 			Service:   service.Name,
-			Framework: framework,
+			Framework: runnerLabel(validations, service.Name),
 		})
 
 		testResult, err := o.executeServiceTests(service, testType)
@@ -651,19 +642,22 @@ func isRecognizedTestLanguage(language string) bool {
 // typeHasExplicitCommand reports whether the service declares an explicit command
 // for the given test type (unit/integration/e2e).
 func typeHasExplicitCommand(config *ServiceTestConfig, testType string) bool {
-	if config == nil {
-		return false
+	return config.explicitCommands()[strings.ToLower(strings.TrimSpace(testType))] != ""
+}
+
+// runnerLabel describes what will run for a service, so progress output does not
+// claim a framework was used when an explicit command takes over.
+func runnerLabel(validations []ServiceValidation, serviceName string) string {
+	for _, v := range validations {
+		if v.Name != serviceName {
+			continue
+		}
+		if v.Command != "" {
+			return customRunnerLabel
+		}
+		return v.Framework
 	}
-	var t *TestTypeConfig
-	switch strings.ToLower(testType) {
-	case testTypeUnit:
-		t = config.Unit
-	case testTypeIntegration:
-		t = config.Integration
-	case testTypeE2E:
-		t = config.E2E
-	}
-	return t != nil && strings.TrimSpace(t.Command) != ""
+	return ""
 }
 
 // newRunnerForService selects a test runner for a service. It dispatches on the
@@ -714,21 +708,14 @@ func (o *TestOrchestrator) runExplicitTypes(service ServiceInfo, config *Service
 		Success:  true,
 	}
 
-	ordered := []struct {
-		name string
-		cfg  *TestTypeConfig
-	}{
-		{testTypeUnit, config.Unit},
-		{testTypeIntegration, config.Integration},
-		{testTypeE2E, config.E2E},
-	}
+	commands := config.explicitCommands()
 
-	for _, t := range ordered {
-		if t.cfg == nil || strings.TrimSpace(t.cfg.Command) == "" {
+	for _, testType := range orderedTestTypes {
+		if commands[testType] == "" {
 			continue
 		}
 
-		res, err := o.executeServiceTests(service, t.name)
+		res, err := o.executeServiceTests(service, testType)
 		if err != nil {
 			aggregate.Success = false
 			if aggregate.Error == "" {

--- a/cli/src/internal/testing/types.go
+++ b/cli/src/internal/testing/types.go
@@ -65,21 +65,44 @@ type ServiceTestConfig struct {
 	Coverage *CoverageConfig `yaml:"coverage" json:"coverage"`
 }
 
+// orderedTestTypes lists the test types in the order they are configured,
+// reported, and executed.
+var orderedTestTypes = []string{testTypeUnit, testTypeIntegration, testTypeE2E}
+
+// customRunnerLabel describes a service whose test run is driven by an explicit
+// `test.<type>.command` rather than by framework detection.
+const customRunnerLabel = "custom command"
+
+// explicitCommands returns the service's non-empty explicit test commands keyed
+// by test type. A nil config yields a nil map, which is safe to read from.
+func (c *ServiceTestConfig) explicitCommands() map[string]string {
+	if c == nil {
+		return nil
+	}
+	byType := map[string]*TestTypeConfig{
+		testTypeUnit:        c.Unit,
+		testTypeIntegration: c.Integration,
+		testTypeE2E:         c.E2E,
+	}
+	commands := make(map[string]string, len(byType))
+	for name, cfg := range byType {
+		if cfg == nil {
+			continue
+		}
+		if cmd := strings.TrimSpace(cfg.Command); cmd != "" {
+			commands[name] = cmd
+		}
+	}
+	return commands
+}
+
 // HasExplicitCommand reports whether the service declares an explicit test
 // command for at least one test type (unit, integration, or e2e). A service
 // with an explicit command is testable regardless of its detected language,
 // which lets container/`docker` (or language-less) services opt into
 // `azd app test` by specifying `test.<type>.command` in azure.yaml.
 func (c *ServiceTestConfig) HasExplicitCommand() bool {
-	if c == nil {
-		return false
-	}
-	for _, t := range []*TestTypeConfig{c.Unit, c.Integration, c.E2E} {
-		if t != nil && strings.TrimSpace(t.Command) != "" {
-			return true
-		}
-	}
-	return false
+	return len(c.explicitCommands()) > 0
 }
 
 // TestTypeConfig represents configuration for a specific test type.

--- a/cli/src/internal/testing/validation.go
+++ b/cli/src/internal/testing/validation.go
@@ -21,12 +21,30 @@ type ServiceValidation struct {
 	TestFiles int
 	// CanTest indicates if the service can be tested
 	CanTest bool
+	// Command is the explicit test command that will run for the requested test
+	// type, when the service configures one in azure.yaml. Empty when the
+	// service is driven by framework detection. When the request spans every
+	// test type and more than one is configured, it lists each as
+	// "<type>: <command>".
+	Command string
 	// SkipReason explains why a service cannot be tested (if CanTest is false)
 	SkipReason string
 }
 
-// ValidateService checks if a service is testable and returns validation details.
+// ValidateService checks if a service is testable and returns validation details
+// for a request covering every test type.
 func ValidateService(service ServiceInfo) ServiceValidation {
+	return ValidateServiceForType(service, testFilterAll)
+}
+
+// ValidateServiceForType checks if a service is testable and returns validation
+// details for the requested test type (unit, integration, e2e, or all).
+//
+// The test type matters for reporting: a service can declare both a `framework`
+// and an explicit `test.<type>.command`, in which case the command is what
+// actually runs. Reporting the framework alone makes it look like the command
+// was ignored.
+func ValidateServiceForType(service ServiceInfo, testType string) ServiceValidation {
 	validation := ServiceValidation{
 		Name:     service.Name,
 		Language: service.Language,
@@ -51,11 +69,24 @@ func ValidateService(service ServiceInfo) ServiceValidation {
 	// `test.<type>.command` in azure.yaml; the runner is then selected by the
 	// configured `framework` (see executeServiceTests).
 	if service.Config.HasExplicitCommand() {
+		command := explicitCommandForType(service.Config, testType)
+
+		// A service whose language has no framework runner can only run the
+		// types it explicitly configures. executeServiceTests already skips the
+		// rest, so reporting them as testable would promise a run that never
+		// happens and is then summarised as passing. This mirrors the guard in
+		// executeServiceTests; the two must agree.
+		if command == "" && !isRecognizedTestLanguage(service.Language) {
+			validation.SkipReason = "No " + testType + " command configured"
+			return validation
+		}
+
 		validation.CanTest = true
 		validation.Framework = service.Config.Framework
 		if validation.Framework == "" {
 			validation.Framework = "custom"
 		}
+		validation.Command = command
 		return validation
 	}
 
@@ -349,13 +380,47 @@ func countTestFiles(dir string, patterns []string) int {
 	return count
 }
 
-// ValidateServices validates all services and returns validation results.
+// ValidateServices validates all services and returns validation results for a
+// request covering every test type.
 func ValidateServices(services []ServiceInfo) []ServiceValidation {
+	return ValidateServicesForType(services, testFilterAll)
+}
+
+// ValidateServicesForType validates all services for the requested test type.
+func ValidateServicesForType(services []ServiceInfo, testType string) []ServiceValidation {
 	validations := make([]ServiceValidation, 0, len(services))
 	for _, service := range services {
-		validations = append(validations, ValidateService(service))
+		validations = append(validations, ValidateServiceForType(service, testType))
 	}
 	return validations
+}
+
+// explicitCommandForType returns the explicit command that will run for the
+// requested test type. A request for a specific type resolves to that type's
+// command, or empty when the type has none. A request spanning every type
+// resolves to the single configured command, or to a "<type>: <command>" list
+// when several are configured, because each runs in turn.
+func explicitCommandForType(config *ServiceTestConfig, testType string) string {
+	commands := config.explicitCommands()
+	if len(commands) == 0 {
+		return ""
+	}
+
+	switch normalized := strings.ToLower(strings.TrimSpace(testType)); normalized {
+	case testTypeUnit, testTypeIntegration, testTypeE2E:
+		return commands[normalized]
+	}
+
+	parts := make([]string, 0, len(commands))
+	for _, name := range orderedTestTypes {
+		if cmd, ok := commands[name]; ok {
+			if len(commands) == 1 {
+				return cmd
+			}
+			parts = append(parts, name+": "+cmd)
+		}
+	}
+	return strings.Join(parts, "; ")
 }
 
 // GetTestableServices returns only the services that can be tested.

--- a/docs/specs/detach-port-testcmd/spec.md
+++ b/docs/specs/detach-port-testcmd/spec.md
@@ -1,0 +1,323 @@
+---
+issue: https://github.com/jongio/azd-app/issues/555
+author: "@jongio"
+status: shipped
+---
+
+# Reliable unattended runs: detach, non-interactive prompts, explicit test commands
+
+## Problem
+
+Three separate reports describe the same underlying theme: `azd app` works when a
+human is watching an interactive terminal, and misbehaves the moment nobody is.
+
+**1. `azd app run --detach` dies immediately on Windows ([#555](https://github.com/jongio/azd-app/issues/555)).**
+The command prints a PID and a log path, then the child is gone within a second.
+`run.log` is created but empty. `azd app status` reports "App is not running" and
+`azd app stop` has nothing to stop, yet service processes started before the death
+keep running and self-restart, holding ports. The user is left with orphans and no
+handle to kill them.
+
+Investigation found this is not one bug but five, each independently capable of
+producing part of the report. The orphaned services are downstream of the manager
+dying, so the fixes below target why it dies and why it leaves no handle behind.
+
+**2. Port-conflict prompt crashes under non-interactive stdin ([#556](https://github.com/jongio/azd-app/issues/556)).**
+When a port is busy, `azd app run` prints the "what would you like to do" menu and
+then fails with `failed to read user input: EOF`. The code already has a documented
+non-interactive path (print a message, auto-kill the conflicting process), but the
+guard that selects it does not fire, so the run aborts instead of degrading.
+
+**3. `azd app test` appears to ignore explicit commands ([#557](https://github.com/jongio/azd-app/issues/557)).**
+A service configured with both `framework: vitest` and an explicit
+`test.e2e.command` is reported as `web: vitest detected` and
+`web (vitest) - Running...`, followed by `0 passed, 0 total` and
+`All tests passed!`. Every signal the CLI emits says the framework runner ran and
+found nothing, so the explicit command looks ignored.
+
+### Root causes
+
+**#555a: the detached child is still inside the parent's Job Object.**
+`detachSysProcAttr` sets `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`. Neither flag
+removes the child from the parent's job. When the launching process (an azd host, a
+terminal wrapper, VS Code) owns a job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and
+that job handle closes, Windows terminates the "detached" child. Verified with a
+purpose-built probe:
+
+| Spawn conditions | Child started | Child survived |
+|---|---|---|
+| No job, `DETACHED_PROCESS` | yes | yes |
+| Kill-on-close job, `DETACHED_PROCESS` only (current code) | yes | **no** |
+| Kill-on-close job plus `CREATE_BREAKAWAY_FROM_JOB` | yes | **yes** |
+
+The child dies after `CreateProcess` succeeds but before it writes anything, which
+is exactly why `run.log` exists and is empty.
+
+`CREATE_BREAKAWAY_FROM_JOB` cannot be applied unconditionally: if the job lacks
+`JOB_OBJECT_LIMIT_BREAKAWAY_OK`, `CreateProcess` fails outright with
+`ERROR_ACCESS_DENIED`. The probe confirmed this too. So the spawn needs an ordered
+set of attempts, not a single flag change.
+
+**#555b: run state is written far too late.**
+`startDetachedRun` returns right after `cmd.Start()` without persisting anything.
+The child writes `run.json` only from `monitorServicesUntilShutdown`, after every
+service has started and after `waitForDashboardURL` waits up to 10 seconds. During
+that window (or forever, if the child dies) `status` and `stop` have no PID to work
+with.
+
+**#555c: the detached child redundantly reloads the azd environment.**
+`PersistentPreRunE` in `main.go` calls `env.LoadAzdEnvironment` whenever `-e` is
+set. That helper shells out to `azd env get-values`, and retries without
+`--output json` on failure, so it costs up to two subprocess round-trips. It runs
+before any command output exists, so the process is completely silent while it
+blocks. The detached child inherits `-e` (only `--detach` is stripped), so it
+repeats this work against an azd host that is already exiting. Measured on a
+trivial single-service project:
+
+| Invocation | First bytes in `run.log` |
+|---|---|
+| `run --detach` (no `-e`) | ~320 ms |
+| `run --detach -e <env>` (before) | ~1590 ms |
+| `run --detach -e <env>` (after) | ~328 ms |
+
+The reload is pure waste: cobra runs `PersistentPreRunE` before `RunE`, and
+`maybeStartDetachedRun` is called from `RunE`, so the parent has already resolved
+every value and exported it into its own environment. `cmd.Env` is built from
+`os.Environ()`, so the child inherits all of them. This is the root cause of the
+0-byte `run.log` in the report: a job kill alone always left 11-15 KB of output in
+testing, never an empty file.
+
+**#555d: parent and child key run state by different directories.**
+The parent identifies the project by `filepath.Dir(azureYamlPath)`, while the
+child's `writeRunState` was reached with `os.Getwd()`. Running from a
+subdirectory produced two different state files, so the child never overwrote the
+parent's seed record and `stop`, which uses the azure.yaml directory, looked in a
+third place. This also broke the dashboard port and token files the same way.
+
+**#555e: `stop` deleted run state even when it failed.**
+`runStopApp` removed the state file from a `defer` that ran unconditionally. A
+`stop` that could not reach the dashboard discarded the only PID record, leaving a
+live manager with no handle at all. This directly defeats the point of writing the
+PID early.
+
+**#556: EOF is treated as a hard error.**
+`handlePortConflict` guards the prompt with `isStdinInteractive()`, which only tests
+`os.ModeCharDevice`. The azd host hands down a console-like stdin with no reader, so
+the guard passes, the menu prints, and `reader.ReadString('\n')` returns `io.EOF`,
+which is converted into a fatal error. The existing non-interactive fallback is
+never reached.
+
+**#557: the message describes detection, not execution.**
+The execution path is already correct on `main`: `ValidateService` short-circuits on
+`HasExplicitCommand()` and `runExplicitTypes` runs the configured command. Verified
+empirically with marker files for both recognized (`js`) and unrecognized (`docker`)
+languages. What is wrong is the reporting: `ValidateService` has no idea which test
+type was requested, so it labels the service with the configured `framework`, and
+`displayValidationSummary` prints `"%s: %s detected"`. A user running
+`--type e2e` against an explicit e2e command is told `vitest detected`. The
+`0 passed, 0 total` line follows because a custom command emits no framework-shaped
+counts.
+
+**#557b: validation claimed types that execution silently skips.**
+`HasExplicitCommand()` is type-agnostic. A service whose language has no framework
+runner (for example `docker`) and which configures only `test.unit.command` was
+reported as testable for `--type e2e`. `executeServiceTests` already refuses that
+combination and returns `Success: true` without running anything, so the user was
+shown a passing e2e run that never happened.
+
+## Goals
+
+- `azd app run --detach` on Windows survives the launching process exiting, including
+  when that process owns a kill-on-close Job Object.
+- A failed breakaway degrades to the previous behaviour instead of failing the run.
+- `azd app status` and `azd app stop` work the instant `--detach` returns.
+- The detached child starts producing output immediately instead of blocking on work
+  its parent already did.
+- One project identity is used for run state, dashboard port, and token files, no
+  matter which directory the command is run from.
+- Port-conflict handling degrades to the documented non-interactive behaviour when
+  stdin yields EOF, instead of aborting the run.
+- `azd app test` reports the command it will actually run for the requested type, and
+  never reports a type it will silently skip.
+
+## Non-Goals
+
+- Reworking `--detach` into a service manager, supervisor, or daemon.
+- Parsing arbitrary custom test command output into pass/fail counts. Exit code
+  remains the contract for custom commands.
+- Changing which process wins a port conflict, or the auto-kill policy itself.
+- Unix orphan reaping via process groups. Unix already gets `setsid` isolation and
+  the reported harm is Windows-specific.
+- Replacing `isStdinInteractive` with a full TTY-detection dependency.
+- **OS-enforced service teardown via a Job Object.** Deferred to a follow-up issue.
+  An architecture review found that attaching a kill-on-close job from the shared
+  `service.StartService` would kill services started by the short-lived
+  `azd app start` and tie MCP-started services to the MCP host's lifetime, that
+  post-start attachment races with wrapper processes such as npm and mise which
+  spawn grandchildren before the assignment lands, and that it would not cover
+  Aspire, containers, or Unix. Doing it correctly requires an explicitly owned
+  group threaded through orchestration plus suspended process creation, which is a
+  new subsystem in the service start path used by every command. The reported
+  orphan symptom is a consequence of the manager dying, which the fixes above
+  address directly.
+
+## Solution
+
+### 1. Ordered detach spawn attempts (#555a)
+
+Replace the single `detachSysProcAttr()` platform hook with an ordered list of
+attempts plus a predicate that identifies a breakaway rejection.
+
+- Windows: `[breakaway | detached | new group, detached | new group]`, and
+  `isBreakawayRejected` returns true for `ERROR_ACCESS_DENIED`.
+- Unix: a single `{Setsid: true}` attempt, and `isBreakawayRejected` always false.
+
+`startDetachedRun` iterates the attempts. Because a failed `exec.Cmd` cannot be
+restarted, each attempt constructs a fresh `exec.Cmd`. Retry happens only when the
+platform predicate says the failure was a breakaway rejection, so genuine spawn
+errors still surface immediately.
+
+### 2. Persist run state at spawn time (#555b)
+
+Immediately after a successful `cmd.Start()`, write `run.json` with the child's PID
+and start time. The child later overwrites the same file with the dashboard URL and
+service list. `cmd.Process.Pid` is the child's own `os.Getpid()`, so the two writes
+agree on identity. A failure to persist is logged and does not fail the detach: the
+run is already alive, and returning an error would strand it.
+
+### 3. Skip the redundant environment reload in the detached child (#555c)
+
+Export `commands.IsDetachedChild()`, which reports whether `AZD_APP_DETACHED_RUN`
+marks this process as the spawned background run, and consult it in
+`PersistentPreRunE`:
+
+```go
+if extCtx.Environment != "" && !commands.IsDetachedChild() {
+    ...LoadAzdEnvironment...
+}
+```
+
+Skipping the reload is preferred over stripping `-e` from the child's arguments,
+because `extCtx.Environment` has other consumers and clearing it would change more
+than the reload.
+
+### 3b. One project identity (#555d)
+
+`runAzdMode` passed `os.Getwd()` down the orchestration chain as the project key
+while `stop`, `status`, and the new seed write all used the azure.yaml directory.
+The two parameters that had to be equal (`cwd` and `azureYamlDir`) are collapsed
+into a single `projectDir`, which is the azure.yaml directory. Removing the second
+parameter removes the ability for them to diverge again.
+
+### 3c. `stop` clears state based on manager liveness (#555e)
+
+The unconditional `defer runstate.Remove(projectDir)` is replaced by two paths.
+On success the state is cleared as before. On failure the state is kept when the
+recorded PID is still alive, so `status` and a retry can still reach the manager,
+and cleared when that PID is gone, so a crashed manager does not leave a phantom
+run that nothing would ever clean up. Keeping state unconditionally on failure
+would trade one bug for the other.
+
+### 3d. The detached marker is consumed, not just read
+
+`IsDetachedChild()` reads `AZD_APP_DETACHED` once, then removes it from the
+process environment and caches the answer.
+
+Services and lifecycle hooks build their environment from `os.Environ()`, so a
+marker left in place would propagate to every child. Any nested `azd app run`
+would then classify itself as a detached child and skip `LoadAzdEnvironment`,
+silently running against the default azd environment instead of the one the user
+selected with `-e`. Caching matters because callers run both before the unset
+(`main.go`, in `PersistentPreRunE`) and after it (`maybeStartDetachedRun`, in
+`RunE`); without it the child would fail to recognise itself and would spawn a
+second detached run.
+
+The marker is only removed when it actually matched, so an unrelated value the
+user set is left untouched.
+
+This does not defend against a user who exports `AZD_APP_DETACHED=1` in their
+shell profile. Anyone able to set that variable can already set the azd values
+directly, so this is a footgun guard rather than a security boundary.
+
+### 4. EOF-tolerant port-conflict prompt (#556)
+
+Extract `readPromptLine`, which decides what a read result means:
+
+1. No error: the trimmed line is the answer.
+2. A non-EOF error: return the error and **discard** any partial data. A truncated
+   read from a broken stream is not consent to pick a destructive menu entry.
+3. `io.EOF` with non-empty partial data: honour it, because
+   `bufio.Reader.ReadString` returns both the buffered data and `io.EOF` when the
+   user's final answer had no trailing newline.
+4. `io.EOF` with nothing to return: report `errNoInput`, and let
+   `handlePortConflict` fall through to the existing
+   `printNonInteractiveKillMessage` plus `ActionKill` path that already serves
+   detectably non-interactive stdin.
+
+`promptUpdateAzureYaml` uses the same helper, since it had the identical bug.
+
+### 5. Report the effective test command (#557)
+
+Thread the requested test type into validation via a new
+`ValidateServiceForType(service, testType)`; `ValidateService` delegates with
+`TestTypeAll` so existing callers are unaffected. When the requested type has an
+explicit command, record it on a new `ServiceValidation.Command` field.
+
+`displayValidationSummary` prints the command when present:
+
+```
+web: custom command (mise exec -- npx tsx scripts/smoke-pat.ts --fresh)
+```
+
+instead of `web: vitest detected`. `Framework` keeps its current meaning so
+`SaveTestConfigToAzureYaml` and other consumers are untouched.
+
+### 5b. Validation agrees with execution (#557b)
+
+When the requested type has no explicit command and the service's language has no
+framework runner, `ValidateServiceForType` now reports the service as skipped with
+a reason naming the missing type, mirroring the guard in `executeServiceTests`. A
+test asserts the two agree for every test type so they cannot drift.
+
+## Acceptance criteria
+
+| # | Criterion |
+|---|---|
+| AC1 | On Windows the detached spawn requests `CREATE_BREAKAWAY_FROM_JOB` first, so the child survives a parent whose job is kill-on-close |
+| AC2 | A breakaway rejection (`ERROR_ACCESS_DENIED`) retries with the previous flags on a fresh `exec.Cmd`; other spawn errors do not retry |
+| AC3 | `run.json` carries the detached child's PID before `run --detach` returns, and a persist failure does not fail the run |
+| AC4 | The detached child does not reload the azd environment its parent already resolved, so `run.log` starts filling at the same speed with and without `-e` |
+| AC5 | Run state, dashboard port, and token files use the azure.yaml directory as the single project identity, regardless of the working directory |
+| AC6 | A failed `azd app stop` leaves the run state intact while the manager is alive, and clears it once the manager is gone |
+| AC7 | A port-conflict prompt that reads EOF with no input falls back to the non-interactive auto-kill path instead of erroring |
+| AC8 | A final answer with no trailing newline is honoured rather than discarded |
+| AC9 | A non-EOF read error still fails and its partial data is discarded, rather than silently selecting a menu entry |
+| AC10 | `azd app test --type <t>` reports the explicit `test.<t>.command` when configured, and the framework otherwise |
+| AC11 | A service that cannot run the requested type is reported as skipped rather than passing |
+| AC12 | The detached marker is consumed at startup so services, hooks, and any nested `azd app run` do not inherit it |
+| AC13 | Positional arguments after a `--` terminator reach the detached child verbatim |
+
+## Trade-offs and risks
+
+- **Two-attempt spawn adds a failure mode to reason about.** Mitigated by retrying
+  only on the specific breakaway rejection, and by keeping the fallback identical to
+  today's behaviour, so the worst case is the status quo.
+- **Early run-state write can be overwritten by the child.** The seed is skipped
+  when the file already holds richer state for the same PID, so a lost race
+  cannot reduce a published dashboard URL back to a bare PID. Stale state left by
+  a previous run under a different PID is still replaced.
+- **The state file is written in place rather than atomically replaced.** A
+  temp-file-plus-rename was tried and rejected: Windows refuses to rename over a
+  file a reader currently has open, which converts a rare short read window into
+  a writer that fails outright. The read window is pre-existing, unchanged in
+  kind by this work, and costs at most one retryable `status` invocation.
+- **Skipping the environment reload assumes the child inherits the parent's values.**
+  Guaranteed by ordering: `PersistentPreRunE` runs before `RunE`, the reload calls
+  `os.Setenv`, and the child's environment is built from `os.Environ()`.
+- **Switching the project key from the working directory to the azure.yaml
+  directory changes where state lives** for anyone who ran from a subdirectory.
+  Those runs were already broken, since `stop` looked in the azure.yaml directory
+  all along; this makes every command agree.
+- **`ServiceValidation` gains a field.** Additive, so no consumer breaks.
+- **Marking unrunnable type/service pairs as skipped changes summary output.** It
+  replaces a false "passed" with an accurate skip, which is the point.

--- a/docs/specs/detach-port-testcmd/test-plan.md
+++ b/docs/specs/detach-port-testcmd/test-plan.md
@@ -1,0 +1,108 @@
+# Test Plan: Reliable unattended runs
+
+Issues: [#555](https://github.com/jongio/azd-app/issues/555),
+[#556](https://github.com/jongio/azd-app/issues/556),
+[#557](https://github.com/jongio/azd-app/issues/557)
+Spec: ./spec.md
+
+## Status: AUTOMATED
+
+Framework: Go `testing` plus `stretchr/testify`, table-driven with `t.Run`.
+
+Platform-specific spawn behaviour is tested through the platform hooks
+(`detachSpawnAttempts`, `isBreakawayRejected`) so the shared retry logic is
+asserted on every OS, with `//go:build` files pinning the per-platform flag
+values. The retry loop is exercised through `spawnWithAttempts`, which takes the
+starter as a parameter, so rejection and fallback are tested without depending on
+a real Job Object.
+
+Live kill-on-close job behaviour cannot be simulated in a unit test. It was
+verified with a purpose-built end-to-end harness that creates a real job, spawns
+the built binary under it, closes the handle, and inspects survival plus
+`run.log`. Results are recorded in the spec.
+
+## Coverage
+
+| # | AC | Test | Location |
+|---|----|------|----------|
+| T1 | AC1 | `TestDetachSpawnAttempts` | `run_detach_windows_test.go`: attempt 1 sets `CREATE_BREAKAWAY_FROM_JOB` with detached plus new group |
+| T2 | AC2 | `TestDetachSpawnAttempts` | `run_detach_windows_test.go`: attempt 2 equals the previous flags exactly |
+| T3 | AC1 | `TestDetachSpawnAttempts` | `run_detach_unix_test.go`: exactly one attempt, `Setsid` set |
+| T4 | AC2 | `TestIsBreakawayRejected` | both platform test files, including `fs.PathError` unwrapping and nil |
+| T5 | AC2 | `TestSpawnWithAttemptsFallsBackWhenBreakawayRejected` | `run_detach_windows_test.go` |
+| T6 | AC2 | `TestSpawnWithAttempts` | `run_detach_test.go`: non-breakaway failure returns after one attempt |
+| T7 | AC2 | `TestSpawnWithAttempts` | `run_detach_test.go`: each attempt receives a distinct `exec.Cmd` |
+| T8 | AC2 | `TestSpawnWithAttemptsReportsLastErrorWhenAllRejected` | `run_detach_windows_test.go` |
+| T9 | AC3 | `TestMaybeStartDetachedRunSpawns` | `run_detach_test.go`: run state readable before the parent returns |
+| T10 | AC3 | `TestRecordDetachedRunState` | `run_detach_test.go`: PID and start time persisted |
+| T10b | AC3 | `TestRecordDetachedRunStateDoesNotClobberChildState` | `run_detach_test.go`: a late seed leaves the child's richer state alone |
+| T10c | AC3 | `TestRecordDetachedRunStateReplacesStaleStateFromAnotherPID` | `run_detach_test.go`: a previous run's state is replaced |
+| T11 | AC3 | `TestRecordDetachedRunStateSurvivesWriteFailure` | `run_detach_test.go`: unwritable state dir does not fail the detach |
+| T12 | AC4 | `TestIsDetachedChild` | `run_detach_test.go`: only the exact marker value counts as the child |
+| T13 | AC4 | end-to-end measurement | `run.log` first-byte latency with `-e`, recorded in the spec |
+| T14 | AC5 | compile-time | the duplicate directory parameter is removed, so the two cannot diverge |
+| T15 | AC6 | `TestClearRunStateIfManagerDeadKeepsStateForLiveProcess` | `stop_test.go`: live PID keeps its state |
+| T15b | AC6 | `TestClearRunStateIfManagerDeadRemovesStateForDeadProcess` | `stop_test.go`: crashed manager's stale state is cleared |
+| T15c | AC6 | `TestClearRunStateIfManagerDeadIgnoresMissingState` | `stop_test.go` |
+| T16 | AC7 | `TestReadPromptLine` | `prompts_test.go`: empty and whitespace-only streams report `errNoInput` |
+| T17 | AC8 | `TestReadPromptLine` | `prompts_test.go`: answer without a trailing newline is honoured |
+| T18 | AC9 | `TestReadPromptLineDiscardsPartialDataOnNonEOFError` | `prompts_test.go`: partial data discarded, `errNoInput` not reported |
+| T19 | AC7 | `TestParsePortConflictChoice` | `prompts_test.go`: every menu choice maps correctly, unknown input cancels |
+| T20 | AC7 | `TestHandlePortConflict_ForceMode` and siblings | `prompts_test.go`: pre-existing force and always-kill paths unchanged |
+| T21 | AC10 | `TestValidateServiceForType_ReportsExplicitCommandForRequestedType` | `explicit_config_test.go` |
+| T22 | AC10 | `TestValidateServiceForType_AllListsEveryConfiguredCommand` | `explicit_config_test.go` |
+| T23 | AC10 | `TestValidateServiceForType_AllWithOneCommandOmitsPrefix` | `explicit_config_test.go` |
+| T24 | AC10 | `TestValidateServiceDelegatesToAllTypes` | `explicit_config_test.go` |
+| T25 | AC10 | `TestValidateServiceForType_FrameworkDrivenReportsNoCommand` | `explicit_config_test.go` |
+| T26 | AC11 | `TestValidateServiceForType_UnconfiguredTypeOnUnrecognizedLanguage_Skipped` | `explicit_config_test.go` |
+| T27 | AC11 | `TestValidateServiceForType_ConfiguredTypeOnUnrecognizedLanguage_Testable` | `explicit_config_test.go` |
+| T28 | AC11 | `TestValidateServiceForType_UnconfiguredTypeOnRecognizedLanguage_StillTestable` | `explicit_config_test.go` |
+| T29 | AC11 | `TestValidateServiceForTypeMatchesExecutionGuard` | `explicit_config_test.go`: validation and execution agree for every test type |
+
+| T30 | AC12 | `TestIsDetachedChildConsumesMarker` | `run_detach_test.go`: marker removed from the environment, answer still cached |
+| T31 | AC12 | `TestIsDetachedChildLeavesForeignValueIntact` | `run_detach_test.go`: a non-matching value is not touched |
+| T32 | AC13 | `TestStripDetachFlag/keeps_positional_args_after_the_terminator_verbatim` | `run_detach_test.go` |
+| T33 | AC13 | `TestStripDetachFlag/keeps_a_lone_terminator` | `run_detach_test.go` |
+| T34 | AC6 | `TestRunStopAppClearsStateForDeadManager` | `stop_extra_test.go`: end-to-end, pins the up-front cleanup call site |
+| T35 | AC7 | `TestHandlePortConflict_InteractiveStdinYieldingEOF_DoesNotError` | `prompts_test.go`: end-to-end reproduction of #556 through the real entry point |
+| T36 | AC7 | `TestHandlePortConflict_NonInteractiveStdin_AutoKills` | `prompts_test.go`: pre-existing guard still short-circuits |
+| T37 | AC10 | `TestDisplayValidationSummary_ExplicitCommandReportedOverFramework` | `test_test.go`: the user-visible #557 output |
+| T38 | AC10 | `TestDisplayValidationSummary_FrameworkReportedWhenNoCommand` | `test_test.go` |
+| T39 | AC10 | `TestDisplayValidationSummary_ReportsSkippedServices` | `test_test.go` |
+| T40 | AC10 | `TestDisplayValidationSummary_SilentInJSONMode` | `test_test.go`: JSON contract stays machine-only |
+
+## Notes
+
+T14 is structural rather than behavioural: the duplicate-parameter removal is
+enforced by the compiler and is covered indirectly by the existing `commands`
+suite, which continues to pass.
+
+## Results
+
+Full suite: 39 packages, 0 failures. `mage lint`: 0 issues. `gofmt`/`go vet`: clean.
+Cross-compiles clean for linux/amd64, darwin/arm64 and windows/amd64.
+
+Every test above that guards a fix was mutation-tested: the fix was temporarily
+reverted and the test confirmed to fail, then restored. This was done for the
+#556 EOF path, the #557 reporting path, the `stop` cleanup call site, and the
+run-state seed guard, so none of them are tautological.
+
+## Determinism
+
+The suite was re-run with `-count=2` to prove the new tests are order-independent
+and leave no global state behind. That surfaced two pre-existing isolation
+defects, neither introduced here and neither visible to CI (CI runs without
+`-count`, so every test executes once):
+
+1. `cmd/app/commands`: `NewStatusCommand` binds `--watch`/`--interval`/`--service`
+   to package-level vars, so `TestRunStatusWatchIntervalTooSmall` left
+   `statusWatch=true, statusInterval=100ms` behind and the second pass of
+   `TestRunStatusNotRunning` failed with `--interval must be at least 1s`.
+   Fixed here with a `restoreStatusFlags` helper, because the new tests added by
+   this change share that test binary and would otherwise inherit the flakiness.
+2. `internal/service`: the log-manager singleton is never reset between runs, so
+   `TestLogManagerGetAllBuffers`, `TestLogManagerGetAllLogs` and
+   `TestLogManagerGetServiceNames` fail on the second pass. That package is not
+   touched by this change and the defect is left as-is to keep the diff scoped.
+
+After fix 1, `cmd/app/commands` passes at `-count=2`.


### PR DESCRIPTION
## Description

Three reports share one theme: `azd app` works when a human is watching an interactive terminal, and misbehaves the moment nobody is.

**#555 `azd app run --detach` dies immediately on Windows.** This turned out to be five independent causes:

- The detached child stays inside the parent's Job Object. `DETACHED_PROCESS` does not remove it, so a kill-on-close job takes the child down after `CreateProcess` succeeds but before it writes anything, which is exactly why `run.log` existed and was empty. The spawn now requests `CREATE_BREAKAWAY_FROM_JOB` first and falls back to the old flags on `ERROR_ACCESS_DENIED`, with a fresh `exec.Cmd` per attempt.
- Run state was written only after every service started and after a 10s dashboard wait, so `status` and `stop` had no PID. It is now seeded right after `cmd.Start()`.
- The child re-ran `LoadAzdEnvironment`, shelling out to `azd env get-values` against an azd host that was already exiting. First bytes in `run.log` went from ~1590ms to ~328ms once skipped.
- Parent and child keyed run state by different directories, so `stop` looked in a third place.
- `stop` removed run state from an unconditional `defer`, discarding the only PID record when it failed.

**#556 The port-conflict prompt turned `io.EOF` into a fatal error** even though a non-interactive fallback already existed. `readPromptLine` now separates EOF with partial data (honour it) from EOF with nothing (fall through to the documented auto-kill path), and still discards partial data on a genuine read error.

**#557 Execution was already correct; the reporting was not.** Validation had no idea which type was requested, so a service with both `framework: vitest` and an explicit `test.e2e.command` was reported as `vitest detected`. Validation now takes the requested type, reports the effective command, and reports a type it would silently skip as skipped rather than passed.

Full root-cause analysis, evidence tables, trade-offs and acceptance criteria: [`docs/specs/detach-port-testcmd/spec.md`](https://github.com/jongio/azd-app/blob/fix/detach-port-testcmd/docs/specs/detach-port-testcmd/spec.md)

Closes #555
Closes #556
Closes #557

## Checklist

- [x] All tests pass
- [x] Documentation updated
- [x] CHANGELOG.md updated
- [x] Follows code style guidelines

---

## Testing

39 packages, 0 failures. `mage lint` 0 issues. `gofmt` and `go vet` clean. Cross-compiles for linux/amd64, darwin/arm64 and windows/amd64. Roughly 840 lines of tests to 460 of source.

Every test that guards a fix was mutation-tested: the fix was temporarily reverted and the test confirmed to fail, then restored, so none of them are tautological.

#556 is covered end to end by pointing stdin at the OS null device, which is a character device that yields EOF instantly and so reproduces the exact reported condition. A pipe cannot, because it fails the interactive guard before reaching the crash site.

### Quality Gates

| Gate | Status | Notes |
|---|---|---|
| `mq` (full pipeline) | PASS | Four parallel audit agents, verified at `99b1fc7` |
| `cr` (code-review) | PASS | Quad coverage. CR-001 withdrawn on evidence, CR-002/003/004 fixed |
| `pf` (preflight) | PASS | gofmt, build, vet, lint, full suite |
| `secops` (security) | PASS | Evidence-backed re-run. One real finding (detach marker leaking into every service and hook) fixed |
| `th` (test-health) | PASS | Closed the two coverage gaps on the user-visible fixes |

## Notes for reviewers

- **A temp-file plus rename for `runstate.Write` was tried and deliberately reverted.** Windows refuses to rename over a file another handle has open, so it converts a rare, self-correcting short read into a hard write failure that loses the PID. A bounded retry still starved under a sustained reader. Evidence is in the spec trade-offs.
- **OS-enforced service teardown is deliberately out of scope.** An architecture review found that attaching a kill-on-close job from the shared service start path would kill services started by the short-lived `azd app start` and tie MCP-started services to the MCP host lifetime. A follow-up issue will capture it.
- `status_test.go` restores the status command's package-level flag vars. They leaked across runs and broke `go test -count=2` in the very package this PR adds tests to. A second pre-existing `-count=2` defect in `internal/service` is documented in the test plan and left alone to keep this diff scoped.
- This touches `run.go` and `status_test.go`, which several open `idea/*` PRs also touch (#563, #544, #513, #502, #498). No semantic overlap, mechanical conflicts only.