### PR TITLE
feat(health): add fail on degraded flag

### DIFF
--- a/cli/src/cmd/app/commands/health.go
+++ b/cli/src/cmd/app/commands/health.go
@@ -58,6 +58,7 @@ var (
 	healthRateLimit         int
 	healthCacheTTL          time.Duration
 	healthProfileSave       bool
+	healthFailOnDegraded    bool
 )
 
 // NewHealthCommand creates the health command.
@@ -124,6 +125,7 @@ Examples:
 	// Rate limiting and caching flags
 	cmd.Flags().IntVar(&healthRateLimit, "rate-limit", 0, "Max health checks per second per service (0 = unlimited)")
 	cmd.Flags().DurationVar(&healthCacheTTL, "cache-ttl", 0, "Cache TTL for health results (0 = no caching)")
+	cmd.Flags().BoolVar(&healthFailOnDegraded, "fail-on-degraded", false, "Return a non-zero exit code when any service is degraded")
 
 	registerServiceFlagCompletion(cmd, "service")
 
@@ -355,11 +357,16 @@ func runStaticMode(ctx context.Context, monitor *healthcheck.HealthMonitor, serv
 		return err
 	}
 
-	// Return exit code based on health status
+	return healthReportExitError(report)
+}
+
+func healthReportExitError(report *healthcheck.HealthReport) error {
 	if report.Summary.Unhealthy > 0 {
 		return fmt.Errorf("%d service(s) unhealthy", report.Summary.Unhealthy)
 	}
-
+	if healthFailOnDegraded && report.Summary.Degraded > 0 {
+		return fmt.Errorf("%d service(s) degraded", report.Summary.Degraded)
+	}
 	return nil
 }
 

--- a/cli/src/cmd/app/commands/health_test.go
+++ b/cli/src/cmd/app/commands/health_test.go
@@ -37,6 +37,7 @@ func TestHealthCommandFlags(t *testing.T) {
 		{"timeout flag", "timeout", "duration"},
 		{"all flag", "all", "bool"},
 		{"verbose flag", "verbose", "bool"},
+		{"fail on degraded flag", "fail-on-degraded", "bool"},
 	}
 
 	for _, tt := range tests {
@@ -45,10 +46,38 @@ func TestHealthCommandFlags(t *testing.T) {
 			if flag == nil {
 				t.Fatalf("Flag %s not found", tt.flagName)
 			}
+
 			if flag.Value.Type() != tt.expectedType {
 				t.Errorf("Expected flag type %s, got %s", tt.expectedType, flag.Value.Type())
 			}
 		})
+	}
+}
+
+func TestHealthReportExitErrorFailOnDegraded(t *testing.T) {
+	original := healthFailOnDegraded
+	t.Cleanup(func() { healthFailOnDegraded = original })
+
+	report := &healthcheck.HealthReport{
+		Summary: healthcheck.HealthSummary{
+			Total:    1,
+			Degraded: 1,
+			Overall:  healthcheck.HealthStatusDegraded,
+		},
+	}
+
+	healthFailOnDegraded = false
+	if err := healthReportExitError(report); err != nil {
+		t.Fatalf("healthReportExitError() default behavior error = %v", err)
+	}
+
+	healthFailOnDegraded = true
+	err := healthReportExitError(report)
+	if err == nil {
+		t.Fatal("healthReportExitError() expected degraded error")
+	}
+	if err.Error() != "1 service(s) degraded" {
+		t.Fatalf("healthReportExitError() error = %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
Adds `azd app health --fail-on-degraded` so CI and smoke scripts can treat degraded services as a failing result.

Validation:
- `pnpm build` in `cli/dashboard`
- `go test .\src\cmd\app\commands -run 'TestHealth(CommandFlags|ReportExitErrorFailOnDegraded)'`

Closes #567