### PR TITLE
feat(health): add summary only output

### DIFF
--- a/cli/src/cmd/app/commands/health.go
+++ b/cli/src/cmd/app/commands/health.go
@@ -127,7 +127,7 @@ Examples:
 	cmd.Flags().IntVar(&healthRateLimit, "rate-limit", 0, "Max health checks per second per service (0 = unlimited)")
 	cmd.Flags().DurationVar(&healthCacheTTL, "cache-ttl", 0, "Cache TTL for health results (0 = no caching)")
 	cmd.Flags().BoolVar(&healthFailOnDegraded, "fail-on-degraded", false, "Return a non-zero exit code when any service is degraded")
-	cmd.Flags().BoolVar(&healthSummaryOnly, "summary-only", false, "Print only the aggregate health summary for text output")
+	cmd.Flags().BoolVar(&healthSummaryOnly, "summary-only", false, "Print only the aggregate health summary for non-JSON output")
 
 	registerServiceFlagCompletion(cmd, "service")
 

--- a/cli/src/cmd/app/commands/health.go
+++ b/cli/src/cmd/app/commands/health.go
@@ -59,6 +59,7 @@ var (
 	healthCacheTTL          time.Duration
 	healthProfileSave       bool
 	healthFailOnDegraded    bool
+	healthSummaryOnly       bool
 )
 
 // NewHealthCommand creates the health command.
@@ -126,6 +127,7 @@ Examples:
 	cmd.Flags().IntVar(&healthRateLimit, "rate-limit", 0, "Max health checks per second per service (0 = unlimited)")
 	cmd.Flags().DurationVar(&healthCacheTTL, "cache-ttl", 0, "Cache TTL for health results (0 = no caching)")
 	cmd.Flags().BoolVar(&healthFailOnDegraded, "fail-on-degraded", false, "Return a non-zero exit code when any service is degraded")
+	cmd.Flags().BoolVar(&healthSummaryOnly, "summary-only", false, "Print only the aggregate health summary for text output")
 
 	registerServiceFlagCompletion(cmd, "service")
 
@@ -447,6 +449,10 @@ func performStreamCheck(ctx context.Context, monitor *healthcheck.HealthMonitor,
 }
 
 func displayHealthReport(report *healthcheck.HealthReport) error {
+	if healthSummaryOnly && healthOutput != jsonOutputVal {
+		return displaySummaryOnlyReport(report)
+	}
+
 	switch healthOutput {
 	case jsonOutputVal:
 		return displayJSONReport(report)
@@ -454,6 +460,21 @@ func displayHealthReport(report *healthcheck.HealthReport) error {
 		return displayTableReport(report)
 	default: // text
 		return displayTextReport(report)
+	}
+}
+
+func displaySummaryOnlyReport(report *healthcheck.HealthReport) error {
+	for _, line := range healthReportSummaryLines(report) {
+		fmt.Println(line)
+	}
+	return nil
+}
+
+func healthReportSummaryLines(report *healthcheck.HealthReport) []string {
+	return []string{
+		fmt.Sprintf("Overall Status: %s", strings.ToUpper(string(report.Summary.Overall))),
+		fmt.Sprintf("Summary: %d healthy, %d degraded, %d unhealthy",
+			report.Summary.Healthy, report.Summary.Degraded, report.Summary.Unhealthy),
 	}
 }
 

--- a/cli/src/cmd/app/commands/health_test.go
+++ b/cli/src/cmd/app/commands/health_test.go
@@ -38,6 +38,7 @@ func TestHealthCommandFlags(t *testing.T) {
 		{"all flag", "all", "bool"},
 		{"verbose flag", "verbose", "bool"},
 		{"fail on degraded flag", "fail-on-degraded", "bool"},
+		{"summary only flag", "summary-only", "bool"},
 	}
 
 	for _, tt := range tests {
@@ -78,6 +79,28 @@ func TestHealthReportExitErrorFailOnDegraded(t *testing.T) {
 	}
 	if err.Error() != "1 service(s) degraded" {
 		t.Fatalf("healthReportExitError() error = %q", err.Error())
+	}
+}
+
+func TestHealthReportSummaryLines(t *testing.T) {
+	report := &healthcheck.HealthReport{
+		Summary: healthcheck.HealthSummary{
+			Healthy:   2,
+			Degraded:  1,
+			Unhealthy: 3,
+			Overall:   healthcheck.HealthStatusUnhealthy,
+		},
+	}
+
+	lines := healthReportSummaryLines(report)
+	if len(lines) != 2 {
+		t.Fatalf("healthReportSummaryLines() got %d lines, want 2", len(lines))
+	}
+	if lines[0] != "Overall Status: UNHEALTHY" {
+		t.Fatalf("healthReportSummaryLines()[0] = %q", lines[0])
+	}
+	if lines[1] != "Summary: 2 healthy, 1 degraded, 3 unhealthy" {
+		t.Fatalf("healthReportSummaryLines()[1] = %q", lines[1])
 	}
 }
 

--- a/cli/src/cmd/app/commands/health_test.go
+++ b/cli/src/cmd/app/commands/health_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,6 +102,95 @@ func TestHealthReportSummaryLines(t *testing.T) {
 	}
 	if lines[1] != "Summary: 2 healthy, 1 degraded, 3 unhealthy" {
 		t.Fatalf("healthReportSummaryLines()[1] = %q", lines[1])
+	}
+}
+
+func TestDisplayHealthReportSummaryOnly(t *testing.T) {
+	originalSummaryOnly := healthSummaryOnly
+	originalOutput := healthOutput
+	t.Cleanup(func() {
+		healthSummaryOnly = originalSummaryOnly
+		healthOutput = originalOutput
+	})
+
+	report := &healthcheck.HealthReport{
+		Timestamp: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		Project:   "/test/project",
+		Services: []healthcheck.HealthCheckResult{
+			{
+				ServiceName:  "web",
+				Status:       healthcheck.HealthStatusHealthy,
+				CheckType:    healthcheck.HealthCheckTypeHTTP,
+				Endpoint:     "http://localhost:3000/health",
+				ResponseTime: 45 * time.Millisecond,
+				Timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			},
+		},
+		Summary: healthcheck.HealthSummary{
+			Total:   1,
+			Healthy: 1,
+			Overall: healthcheck.HealthStatusHealthy,
+		},
+	}
+
+	wantSummary := "Overall Status: HEALTHY\nSummary: 1 healthy, 0 degraded, 0 unhealthy\n"
+
+	tests := []struct {
+		name        string
+		output      string
+		wantSummary bool
+	}{
+		{"text output prints summary only", "text", true},
+		{"table output prints summary only", "table", true},
+		{"json output is unaffected", jsonOutputVal, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			healthSummaryOnly = true
+			healthOutput = tt.output
+
+			out, err := captureStdout(t, func() error { return displayHealthReport(report) })
+			if err != nil {
+				t.Fatalf("displayHealthReport() error = %v", err)
+			}
+
+			if tt.wantSummary {
+				if out != wantSummary {
+					t.Fatalf("displayHealthReport() = %q, want %q", out, wantSummary)
+				}
+				return
+			}
+
+			if !json.Valid([]byte(out)) {
+				t.Fatalf("displayHealthReport() produced invalid JSON: %q", out)
+			}
+			if !strings.Contains(out, "web") {
+				t.Errorf("displayHealthReport() JSON dropped per-service detail: %q", out)
+			}
+		})
+	}
+}
+
+func TestDisplaySummaryOnlyReport(t *testing.T) {
+	report := &healthcheck.HealthReport{
+		Summary: healthcheck.HealthSummary{
+			Total:     3,
+			Healthy:   1,
+			Degraded:  1,
+			Unhealthy: 1,
+			Overall:   healthcheck.HealthStatusUnhealthy,
+		},
+	}
+
+	out, err := captureStdout(t, func() error { return displaySummaryOnlyReport(report) })
+	if err != nil {
+		t.Fatalf("displaySummaryOnlyReport() error = %v", err)
+	}
+
+	want := "Overall Status: UNHEALTHY\nSummary: 1 healthy, 1 degraded, 1 unhealthy\n"
+	if out != want {
+		t.Fatalf("displaySummaryOnlyReport() = %q, want %q", out, want)
 	}
 }
 


### PR DESCRIPTION
Adds `azd app health --summary-only` for compact text output when scripts only need aggregate health.

Validation:
- `go test .\src\cmd\app\commands -run 'TestHealth(CommandFlags|ReportSummaryLines)'`

Closes #568