### PR TITLE
feat(status): print dashboard url

### DIFF
--- a/cli/src/cmd/app/commands/status.go
+++ b/cli/src/cmd/app/commands/status.go
@@ -23,9 +23,10 @@ import (
 const minStatusWatchInterval = time.Second
 
 var (
-	statusWatch    bool
-	statusInterval time.Duration
-	statusService  string
+	statusWatch        bool
+	statusInterval     time.Duration
+	statusService      string
+	statusDashboardURL bool
 )
 
 type statusReport struct {
@@ -66,6 +67,7 @@ Examples:
 	cmd.Flags().BoolVar(&statusWatch, "watch", false, "Refresh the status on an interval until interrupted")
 	cmd.Flags().DurationVar(&statusInterval, "interval", 2*time.Second, "Refresh interval for --watch (minimum 1s)")
 	cmd.Flags().StringVarP(&statusService, "service", "s", "", "Filter to specific service(s), comma-separated")
+	cmd.Flags().BoolVar(&statusDashboardURL, "dashboard-url", false, "Print only the dashboard URL for the active run")
 	return cmd
 }
 
@@ -90,8 +92,6 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		return watchStatus(ctx, os.Stdout, projectDir, statusInterval, requested)
 	}
 
-	cliout.CommandHeader("status", "Show app status")
-
 	report, err := buildStatusReport(projectDir)
 	if err != nil {
 		return err
@@ -103,12 +103,32 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	if statusDashboardURL {
+		url, err := dashboardURLFromStatusReport(report)
+		if err != nil {
+			return err
+		}
+		fmt.Println(url)
+		return nil
+	}
+
 	if cliout.IsJSON() {
 		return cliout.PrintJSON(report)
 	}
 
+	cliout.CommandHeader("status", "Show app status")
 	printStatusReport(report)
 	return nil
+}
+
+func dashboardURLFromStatusReport(report statusReport) (string, error) {
+	if !report.Running {
+		return "", fmt.Errorf("app is not running")
+	}
+	if report.DashboardURL == "" {
+		return "", fmt.Errorf("dashboard URL is not available")
+	}
+	return report.DashboardURL, nil
 }
 
 // watchStatus renders the status to w immediately and then again on every tick

--- a/cli/src/cmd/app/commands/status_test.go
+++ b/cli/src/cmd/app/commands/status_test.go
@@ -26,6 +26,7 @@ func TestNewStatusCommand(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("watch"), "expected --watch flag")
 	assert.NotNil(t, cmd.Flags().Lookup("interval"), "expected --interval flag")
 	assert.NotNil(t, cmd.Flags().Lookup("service"), "expected --service flag")
+	assert.NotNil(t, cmd.Flags().Lookup("dashboard-url"), "expected --dashboard-url flag")
 }
 
 func TestRenderStatusReport(t *testing.T) {
@@ -170,6 +171,23 @@ func TestFilterStatusReportNotRunning(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, filtered.Running)
 	assert.Empty(t, filtered.Services)
+}
+
+func TestDashboardURLFromStatusReport(t *testing.T) {
+	url, err := dashboardURLFromStatusReport(statusReport{
+		Running:      true,
+		DashboardURL: "http://localhost:40000",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:40000", url)
+
+	_, err = dashboardURLFromStatusReport(statusReport{Running: false})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "app is not running")
+
+	_, err = dashboardURLFromStatusReport(statusReport{Running: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dashboard URL is not available")
 }
 
 func TestBuildStatusReportStaleStateRemovesFile(t *testing.T) {


### PR DESCRIPTION
Adds `azd app status --dashboard-url` so scripts can get the current dashboard URL after a detached run starts.

Validation:
- `go test .\src\cmd\app\commands -run 'Test(NewStatusCommand|DashboardURLFromStatusReport)'`

Closes #569