### PR TITLE
test(portmanager): stop reporting a timed-out port lookup as a failure

### DIFF
--- a/cli/src/internal/portmanager/process_timeout_test.go
+++ b/cli/src/internal/portmanager/process_timeout_test.go
@@ -57,14 +57,19 @@ func TestGetProcessOnPort_WithActivePort(t *testing.T) {
 	pid, err := pm.getProcessOnPort(port)
 	elapsed := time.Since(start)
 
-	// Should complete quickly
-	if elapsed > 3*time.Second {
-		t.Errorf("getProcessOnPort took %v, should be much faster", elapsed)
+	if err != nil {
+		// The lookup tool may be missing, or slow enough on a loaded runner to hit
+		// commandTimeout. Skip before asserting on timing, otherwise a timed-out call
+		// is reported as a failure instead of taking the skip this branch is here for.
+		t.Skipf("Skipping test - process detection not available in this environment: %v", err)
 	}
 
-	if err != nil {
-		// In CI environments, lsof may not be able to detect processes properly
-		t.Skipf("Skipping test - process detection not available in this environment: %v", err)
+	// Bound the success path by the same budget the command itself uses, matching
+	// TestGetProcessOnPort_DoesNotHang. A fixed threshold below commandTimeout would
+	// contradict the timeout the code is allowed to spend.
+	maxAllowed := commandTimeout + 2*time.Second
+	if elapsed > maxAllowed {
+		t.Errorf("getProcessOnPort took %v, expected < %v (possible hang)", elapsed, maxAllowed)
 	}
 
 	if pid <= 0 {


### PR DESCRIPTION
`TestGetProcessOnPort_WithActivePort` failed on `windows-latest` in CI (PR #583, run 30457992708) after taking 5.06s. Re-running the same job on the same commit passed, so the failure was environmental.

## What actually happened

`getProcessOnPort` shells out to PowerShell on Windows under a 5s `commandTimeout` (`process.go:102`). On a loaded runner it spent that whole budget. The sibling test logged `getProcessOnPort completed in 5.0356788s` on the same run, which pins the elapsed time to the deadline rather than a hang.

Two coupled defects turned that into a failure:

**1. The CI escape hatch was unreachable.** The test already skips when process detection isn't available, but the timing assertion ran first. A timed-out call recorded `t.Errorf` and stayed failed even though it then hit the skip written for exactly that case. Checking `err` first matches how `portmanager_unix_test.go` handles the same condition in three places (lines 40-42, 102-105, 184-187).

**2. The threshold contradicted the code.** It asserted under 3s on a call whose own timeout is 5s, so the code was permitted to take longer than the test allowed. The budget now derives from `commandTimeout`, matching `TestGetProcessOnPort_DoesNotHang` and the two other timing assertions in this file.

## Scope

Test-only. No product code changes.

I left `TestContextTimeoutIsRespected`'s bare `3*time.Second` alone: its context deadline is 1s, so that's the same "deadline plus 2s buffer" shape and isn't the same defect.

## Verification

- `go build ./...` clean
- `go vet ./src/internal/portmanager/...` clean
- `golangci-lint run ./src/internal/portmanager/...` reports 0 issues
- `gofmt -l src` clean
- Full `portmanager` package suite passes
