### PR TITLE
fix(security): update Go to 1.26.6

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -5,7 +5,7 @@ This devcontainer provides a complete development environment for the App Extens
 ## What's Included
 
 ### Languages & Runtimes
-- **Go 1.25.5** - Primary development language
+- **Go 1.26** (latest patch) - Primary development language
 - **Node.js LTS** - For Node.js project testing
 - **Python 3.12** - For Python project testing
 - **.NET 8.0** - For .NET and Aspire project testing

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -5,7 +5,7 @@ This devcontainer provides a complete development environment for the App Extens
 ## What's Included
 
 ### Languages & Runtimes
-- **Go 1.26** (latest patch) - Primary development language
+- **Go 1.26 image channel** - Tracks Microsoft's latest published 1.26 patch. Go commands automatically resolve the exact version declared in [`cli/go.mod`](../cli/go.mod).
 - **Node.js LTS** - For Node.js project testing
 - **Python 3.12** - For Python project testing
 - **.NET 8.0** - For .NET and Aspire project testing

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	// For format details, see https://aka.ms/devcontainer.json. For config options, see the
 	// README at: https://github.com/devcontainers/templates/tree/main/src/go
 	"name": "App Extension for Azure Developer CLI",
-	"image": "mcr.microsoft.com/devcontainers/go:1.26.5-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1.26.6-bookworm",
 	
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	// For format details, see https://aka.ms/devcontainer.json. For config options, see the
 	// README at: https://github.com/devcontainers/templates/tree/main/src/go
 	"name": "App Extension for Azure Developer CLI",
-	"image": "mcr.microsoft.com/devcontainers/go:1.26.6-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1.26-bookworm",
 	
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,3 +384,4 @@ jobs:
             cli/tests/projects/integration/health-test/*.log
             cli/.azure/**/*.log
           if-no-files-found: ignore
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,3 +385,4 @@ jobs:
             cli/tests/projects/integration/health-test/*.log
             cli/.azure/**/*.log
           if-no-files-found: ignore
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           path: ~/go/bin
           key: go-tools-${{ runner.os }}-${{ hashFiles('cli/go.mod') }}
+          restore-keys: |
+            go-tools-${{ runner.os }}-
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -382,4 +384,3 @@ jobs:
             cli/tests/projects/integration/health-test/*.log
             cli/.azure/**/*.log
           if-no-files-found: ignore
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ defaults:
   run:
     working-directory: cli
 
-env:
-  GO_VERSION: '1.26.6'
-
 jobs:
   preflight:
     name: Preflight Checks
@@ -45,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 
@@ -53,7 +50,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/bin
-          key: go-tools-${{ runner.os }}-${{ env.GO_VERSION }}
+          key: go-tools-${{ runner.os }}-${{ hashFiles('cli/go.mod') }}
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -139,7 +136,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 
@@ -193,7 +190,7 @@ jobs:
         with:
           files: coverage/coverage.out
           flags: unittests
-          name: codecov-${{ matrix.os }}-go-${{ env.GO_VERSION }}
+          name: codecov-${{ matrix.os }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
@@ -226,7 +223,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 
@@ -261,7 +258,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 
@@ -303,7 +300,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ defaults:
     working-directory: cli
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   preflight:
@@ -385,4 +385,3 @@ jobs:
             cli/tests/projects/integration/health-test/*.log
             cli/.azure/**/*.log
           if-no-files-found: ignore
-

--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -24,9 +24,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.26.6'
-
 jobs:
   docs-gate:
     name: Docs Gate
@@ -42,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 

--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -36,6 +36,30 @@ jobs:
           # Full history so the merge base with the target branch resolves.
           fetch-depth: 0
 
+      - name: Guard Go version source
+        run: |
+          set -euo pipefail
+          set +e
+          matches="$(git grep -niE '(^|[^[:alnum:]_])go(([ _-]version[^0-9]*)|[[:space:]]+)1\.[0-9]+\.[0-9]+([^0-9]|$)' -- \
+            ':(glob)**/*.md' \
+            ':(glob).github/workflows/*.yml' \
+            ':(glob).github/workflows/*.yaml' \
+            ':(glob)web/src/pages/**/*.astro' \
+            ':(exclude,glob)**/CHANGELOG.md' \
+            ':(exclude,glob)web/src/pages/reference/changelog/**' \
+            ':(exclude,glob)web/src/pages/reference/whats-new/**')"
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "Hard-coded Go patch versions found. Reference cli/go.mod instead:"
+            echo "$matches"
+            exit 1
+          fi
+          if [ "$status" -ne 1 ]; then
+            echo "Failed to scan for hard-coded Go patch versions."
+            exit "$status"
+          fi
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   docs-gate:

--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -40,8 +40,9 @@ jobs:
         run: |
           set -euo pipefail
           set +e
-          matches="$(git grep -niE '(^|[^[:alnum:]_])go(([ _-]version[^0-9]*)|[[:space:]]+)1\.[0-9]+\.[0-9]+([^0-9]|$)' -- \
+          matches="$(git grep -niE '(^|[^[:alnum:]_])go(([ _-]version[^0-9]*)|[[:space:]]+|:)1\.[0-9]+\.[0-9]+([^0-9]|$)' -- \
             ':(glob)**/*.md' \
+            ':(glob).devcontainer/**' \
             ':(glob).github/workflows/*.yml' \
             ':(glob).github/workflows/*.yaml' \
             ':(glob)web/src/pages/**/*.astro' \

--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -46,6 +46,7 @@ jobs:
             ':(glob).github/workflows/*.yaml' \
             ':(glob)web/src/pages/**/*.astro' \
             ':(exclude,glob)**/CHANGELOG.md' \
+            ':(exclude)docs/task-4-completion-report.md' \
             ':(exclude,glob)web/src/pages/reference/changelog/**' \
             ':(exclude,glob)web/src/pages/reference/whats-new/**')"
           status=$?

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -24,7 +24,7 @@ defaults:
     working-directory: cli
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   build:

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -23,9 +23,6 @@ defaults:
     shell: bash
     working-directory: cli
 
-env:
-  GO_VERSION: '1.26.6'
-
 jobs:
   build:
     name: Build Latest
@@ -38,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -30,7 +30,7 @@ defaults:
     working-directory: cli
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   # Check if build should run

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -29,9 +29,6 @@ defaults:
   run:
     working-directory: cli
 
-env:
-  GO_VERSION: '1.26.6'
-
 jobs:
   # Check if build should run
   check-permission:
@@ -210,7 +207,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ defaults:
     working-directory: cli
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   preflight:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           path: ~/go/bin
           key: go-tools-${{ runner.os }}-${{ hashFiles('cli/go.mod') }}
+          restore-keys: |
+            go-tools-${{ runner.os }}-
 
       - name: Verify Go version
         run: go version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,6 @@ defaults:
     shell: bash
     working-directory: cli
 
-env:
-  GO_VERSION: '1.26.6'
-
 jobs:
   preflight:
     name: Preflight Checks
@@ -40,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 
@@ -48,7 +45,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/bin
-          key: go-tools-${{ runner.os }}-${{ env.GO_VERSION }}
+          key: go-tools-${{ runner.os }}-${{ hashFiles('cli/go.mod') }}
 
       - name: Verify Go version
         run: go version
@@ -113,7 +110,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 
@@ -171,7 +168,7 @@ jobs:
         with:
           files: coverage/coverage.out
           flags: unittests
-          name: codecov-${{ matrix.os }}-go-${{ env.GO_VERSION }}
+          name: codecov-${{ matrix.os }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
@@ -210,7 +207,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 

--- a/.github/workflows/update-azd-core.yml
+++ b/.github/workflows/update-azd-core.yml
@@ -22,9 +22,6 @@ defaults:
   run:
     working-directory: cli
 
-env:
-  GO_VERSION: '1.26.6'
-
 jobs:
   update:
     name: Update azd-core dependency
@@ -85,7 +82,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version-file: cli/go.mod
           cache: true
           cache-dependency-path: cli/go.sum
 

--- a/.github/workflows/update-azd-core.yml
+++ b/.github/workflows/update-azd-core.yml
@@ -23,7 +23,7 @@ defaults:
     working-directory: cli
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   update:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Monorepo with three major components:
 ### CLI (Go)
 
 - **Module**: `github.com/jongio/azd-app/cli`
-- **Go version**: 1.26.6 (pinned in go.mod and CI)
+- **Go version**: Declared in `cli/go.mod`; CI reads it directly
 - **Framework**: Cobra (CLI), Connect-RPC (dashboard ↔ CLI transport)
 - **Core dependency**: `github.com/jongio/azd-core` (shared extension SDK)
 - **Build tool**: Mage (`magefile.go` at `cli/magefile.go`)
@@ -75,7 +75,7 @@ Conventional Commits strictly enforced:
 ## CI/CD
 
 - **Main CI**: `.github/workflows/ci.yml` — preflight, lint, test on ubuntu/windows/macos matrix
-- **Go version**: 1.26.6, Node: 22, pnpm: 9
+- **Go version**: `cli/go.mod`, Node: 22, pnpm: 9
 - **Race detector**: Enabled on Linux/Windows, disabled on macOS
 - **Coverage**: codecov integration with threshold enforcement
 - **Security**: CodeQL + govulncheck (push/PR/weekly schedule)
@@ -92,7 +92,7 @@ Conventional Commits strictly enforced:
 
 ## Dev Environment
 
-- **Devcontainer**: Go 1.26.6 base, Node LTS, Python 3.12, .NET 8, Docker-in-Docker
+- **Devcontainer**: Latest Go 1.26 patch, Node LTS, Python 3.12, .NET 8, Docker-in-Docker
 - **IDE**: VS Code with golang.go, Copilot, Azure Dev extensions
 - **Gopls settings**: nilness, shadow, ST1003, unusedparams, unusedwrite, useany, staticcheck
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Monorepo with three major components:
 ### CLI (Go)
 
 - **Module**: `github.com/jongio/azd-app/cli`
-- **Go version**: 1.26.5 (pinned in go.mod and CI)
+- **Go version**: 1.26.6 (pinned in go.mod and CI)
 - **Framework**: Cobra (CLI), Connect-RPC (dashboard ↔ CLI transport)
 - **Core dependency**: `github.com/jongio/azd-core` (shared extension SDK)
 - **Build tool**: Mage (`magefile.go` at `cli/magefile.go`)
@@ -75,7 +75,7 @@ Conventional Commits strictly enforced:
 ## CI/CD
 
 - **Main CI**: `.github/workflows/ci.yml` — preflight, lint, test on ubuntu/windows/macos matrix
-- **Go version**: 1.26.5, Node: 22, pnpm: 9
+- **Go version**: 1.26.6, Node: 22, pnpm: 9
 - **Race detector**: Enabled on Linux/Windows, disabled on macOS
 - **Coverage**: codecov integration with threshold enforcement
 - **Security**: CodeQL + govulncheck (push/PR/weekly schedule)
@@ -92,7 +92,7 @@ Conventional Commits strictly enforced:
 
 ## Dev Environment
 
-- **Devcontainer**: Go 1.26.5 base, Node LTS, Python 3.12, .NET 8, Docker-in-Docker
+- **Devcontainer**: Go 1.26.6 base, Node LTS, Python 3.12, .NET 8, Docker-in-Docker
 - **IDE**: VS Code with golang.go, Copilot, Azure Dev extensions
 - **Gopls settings**: nilness, shadow, ST1003, unusedparams, unusedwrite, useany, staticcheck
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to azd-app! This document provides g
 
 Before contributing, ensure you have the following installed:
 
-- **Go**: 1.26.5 or later
+- **Go**: 1.26.6 or later
 - **Node.js**: 22.0.0 or later
 - **pnpm**: 9.0.0 or later  
 - **PowerShell**: 7.4 or later (recommended: 7.5.4 for full compatibility)
@@ -17,7 +17,7 @@ Before contributing, ensure you have the following installed:
 
 You can verify your versions:
 ```bash
-go version                  # Should be 1.26.5+
+go version                  # Should be 1.26.6+
 node --version             # Should be v22.0.0+
 pnpm --version             # Should be 9.0.0+
 pwsh --version            # Should be 7.4+ or 7.5.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to azd-app! This document provides g
 
 Before contributing, ensure you have the following installed:
 
-- **Go**: 1.26.6 or later
+- **Go**: The version declared in [`cli/go.mod`](cli/go.mod) or later
 - **Node.js**: 22.0.0 or later
 - **pnpm**: 9.0.0 or later  
 - **PowerShell**: 7.4 or later (recommended: 7.5.4 for full compatibility)
@@ -17,7 +17,7 @@ Before contributing, ensure you have the following installed:
 
 You can verify your versions:
 ```bash
-go version                  # Should be 1.26.6+
+go version                  # Must satisfy cli/go.mod
 node --version             # Should be v22.0.0+
 pnpm --version             # Should be 9.0.0+
 pwsh --version            # Should be 7.4+ or 7.5.4

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ One command starts all services, manages dependencies, and provides real-time mo
 [![Go Reference](https://pkg.go.dev/badge/github.com/jongio/azd-app/cli.svg)](https://pkg.go.dev/github.com/jongio/azd-app/cli)
 [![govulncheck](https://img.shields.io/badge/govulncheck-passing-brightgreen)](https://github.com/jongio/azd-app/actions/workflows/govulncheck.yml)
 [![golangci-lint](https://img.shields.io/badge/golangci--lint-enabled-blue)](https://github.com/jongio/azd-app/actions/workflows/ci.yml)
-[![Go Version](https://img.shields.io/github/go-mod-go-version/jongio/azd-app?filename=cli/go.mod&label=go&color=blue)](https://go.dev/)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/jongio/azd-app?filename=cli/go.mod&label=go&color=blue)](https://go.dev/)
 [![Platform Support](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey)](https://github.com/jongio/azd-app)
 
 <br />
@@ -273,4 +273,3 @@ MIT License - see [LICENSE](./LICENSE) for details.
 Built with ❤️ for Azure developers
 
 </div>
-

--- a/README.md
+++ b/README.md
@@ -273,3 +273,4 @@ MIT License - see [LICENSE](./LICENSE) for details.
 Built with ❤️ for Azure developers
 
 </div>
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ One command starts all services, manages dependencies, and provides real-time mo
 [![Go Reference](https://pkg.go.dev/badge/github.com/jongio/azd-app/cli.svg)](https://pkg.go.dev/github.com/jongio/azd-app/cli)
 [![govulncheck](https://img.shields.io/badge/govulncheck-passing-brightgreen)](https://github.com/jongio/azd-app/actions/workflows/govulncheck.yml)
 [![golangci-lint](https://img.shields.io/badge/golangci--lint-enabled-blue)](https://github.com/jongio/azd-app/actions/workflows/ci.yml)
-[![Go Version](https://img.shields.io/badge/go-1.26.6-blue)](https://go.dev/)
+[![Go Version](https://img.shields.io/github/go-mod-go-version/jongio/azd-app?filename=cli/go.mod&label=go&color=blue)](https://go.dev/)
 [![Platform Support](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey)](https://github.com/jongio/azd-app)
 
 <br />

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ One command starts all services, manages dependencies, and provides real-time mo
 [![Go Reference](https://pkg.go.dev/badge/github.com/jongio/azd-app/cli.svg)](https://pkg.go.dev/github.com/jongio/azd-app/cli)
 [![govulncheck](https://img.shields.io/badge/govulncheck-passing-brightgreen)](https://github.com/jongio/azd-app/actions/workflows/govulncheck.yml)
 [![golangci-lint](https://img.shields.io/badge/golangci--lint-enabled-blue)](https://github.com/jongio/azd-app/actions/workflows/ci.yml)
-[![Go Version](https://img.shields.io/badge/go-1.26.5-blue)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/go-1.26.6-blue)](https://go.dev/)
 [![Platform Support](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey)](https://github.com/jongio/azd-app)
 
 <br />
@@ -273,4 +273,3 @@ MIT License - see [LICENSE](./LICENSE) for details.
 Built with ❤️ for Azure developers
 
 </div>
-

--- a/cli/README.md
+++ b/cli/README.md
@@ -130,7 +130,7 @@ See [.devcontainer/README.md](.devcontainer/README.md) for details.
 ### Prerequisites
 
 - [Azure Developer CLI (azd)](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) installed
-- Go 1.26.5 or later (for building from source)
+- Go 1.26.6 or later (for building from source)
 - Node.js 22.0.0 or later (for building dashboard)
 - npm 10.0.0 or later (for building dashboard)
 - PowerShell 7.4 or later (recommended: 7.5.4 for full compatibility with build scripts)

--- a/cli/README.md
+++ b/cli/README.md
@@ -130,7 +130,7 @@ See [.devcontainer/README.md](.devcontainer/README.md) for details.
 ### Prerequisites
 
 - [Azure Developer CLI (azd)](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) installed
-- Go 1.26.6 or later (for building from source)
+- The Go version declared in [`go.mod`](go.mod) or later (for building from source)
 - Node.js 22.0.0 or later (for building dashboard)
 - npm 10.0.0 or later (for building dashboard)
 - PowerShell 7.4 or later (recommended: 7.5.4 for full compatibility with build scripts)

--- a/cli/docs/contributing/azd-core-integration.md
+++ b/cli/docs/contributing/azd-core-integration.md
@@ -60,11 +60,10 @@ c:\code\
 
 3. **Create a workspace using the installed Go toolchain**:
    ```bash
-   go work init
-   go work use ./azd-app/cli ./azd-core
+   go work init ./azd-app/cli ./azd-core
    ```
 
-   These commands generate a `go.work` directive compatible with both modules.
+   This command generates a `go.work` file whose `go` directive matches your installed toolchain, with `use` directives for both modules.
 
 ### Building and Testing
 

--- a/cli/docs/contributing/azd-core-integration.md
+++ b/cli/docs/contributing/azd-core-integration.md
@@ -42,7 +42,7 @@ c:\code\
 
 ### Prerequisites
 
-- Go 1.25.5 or later
+- The Go version declared in [`../../go.mod`](../../go.mod) or later
 - Azure CLI (`az` command available)
 
 ### Initial Setup
@@ -58,15 +58,13 @@ c:\code\
    cd c:\code
    ```
 
-3. **The `go.work` file automatically enables the workspace**:
+3. **Create a workspace using the installed Go toolchain**:
+   ```bash
+   go work init
+   go work use ./azd-app/cli ./azd-core
    ```
-   go 1.25.5
-   
-   use (
-       ./azd-app/cli
-       ./azd-core
-   )
-   ```
+
+   These commands generate a `go.work` directive compatible with both modules.
 
 ### Building and Testing
 

--- a/cli/docs/dev/e2e-testing.md
+++ b/cli/docs/dev/e2e-testing.md
@@ -70,7 +70,7 @@ gh workflow run health-e2e.yml
 - ✅ Ubuntu (latest)
 - ✅ Windows (latest)
 - ✅ macOS (latest)
-- ✅ Go 1.25.5
+- ✅ Go version declared in `cli/go.mod`
 
 ## Test Project
 
@@ -188,7 +188,7 @@ pkill -9 node
 - **Individual commands**: 10-30 seconds (context timeout)
 
 ### Dependencies
-- Go 1.25.5
+- Go version declared in `cli/go.mod`
 - Node.js 20
 - Python 3.11
 - Platform-specific tools (npm, pip)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/jongio/azd-app/cli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	connectrpc.com/connect v1.20.0

--- a/docs/task-4-completion-report.md
+++ b/docs/task-4-completion-report.md
@@ -78,7 +78,7 @@ Successfully migrated azd-app to use azd-core/testutil package, demonstrating pr
 
 ### What We Didn't Change
 - **t.TempDir()**: Go 1.16+ has built-in `t.TempDir()` which is the standard approach
-  - testutil.TempDir is available but not needed for azd-app (Go 1.25.5)
+  - testutil.TempDir is available but not needed for azd-app
   - Kept existing `t.TempDir()` usage unchanged
   
 - **FindTestData**: azd-app tests create fixtures with `t.TempDir()` rather than searching for test data directories

--- a/docs/task-4-completion-report.md
+++ b/docs/task-4-completion-report.md
@@ -78,7 +78,7 @@ Successfully migrated azd-app to use azd-core/testutil package, demonstrating pr
 
 ### What We Didn't Change
 - **t.TempDir()**: Go 1.16+ has built-in `t.TempDir()` which is the standard approach
-  - testutil.TempDir is available but not needed for azd-app
+  - testutil.TempDir is available but not needed for azd-app (Go 1.25.5)
   - Kept existing `t.TempDir()` usage unchanged
   
 - **FindTestData**: azd-app tests create fixtures with `t.TempDir()` rather than searching for test data directories


### PR DESCRIPTION
## Summary

1. Updates the Go module from 1.26.5 to 1.26.6.
2. Makes `cli/go.mod` the single Go version source for CI setup, tool caches, contributor documentation, and the README badge.
3. Uses the catalog-backed `1.26-bookworm` devcontainer image channel and documents how Go resolves the exact module toolchain.
4. Adds a docs gate that prevents hard-coded Go patch versions from returning to active documentation and workflows while preserving historical records.
5. Adds platform cache fallbacks for Go tools when unrelated `cli/go.mod` content changes.
6. Resolves seven reachable Go standard-library vulnerabilities reported by `govulncheck`.

## Verification

1. All required GitHub checks pass on head `b38fa986`.
2. `mage preflight` passes every gate on Windows with CI-compatible pnpm 9.
3. Go vulnerability scanning reports zero reachable vulnerabilities.
4. Go tests pass with 65.6% total coverage after configured exclusions.
5. All 1,436 dashboard tests pass.
6. Changed GitHub Actions workflows pass `actionlint`.
7. The Go version guard passes clean-tree and synthetic failure cases.
8. The documented single-command workspace setup generates a valid Go 1.26.6 workspace.
