### PR TITLE
fix(ci): make latest release cutover recoverable

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -9,25 +9,52 @@ on:
     paths:
       - 'cli/**'
       - '.github/workflows/latest.yml'
+      - 'scripts/publish-latest-release.sh'
+      - 'scripts/test-publish-latest-release.sh'
+      - 'scripts/testdata/fake-gh.sh'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/latest.yml'
+      - 'scripts/publish-latest-release.sh'
+      - 'scripts/test-publish-latest-release.sh'
+      - 'scripts/testdata/fake-gh.sh'
   workflow_dispatch:
 
-concurrency:
-  group: latest-build
-  cancel-in-progress: false
-
 permissions:
-  contents: write
-
-defaults:
-  run:
-    shell: bash
-    working-directory: cli
+  contents: read
 
 jobs:
+  verify:
+    name: Verify Latest Workflow
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+      - name: Lint workflows
+        run: actionlint -ignore 'unknown permission scope "copilot-requests"'
+
+      - name: Test latest release publisher
+        run: bash scripts/test-publish-latest-release.sh
+
   build:
     name: Build Latest
+    if: github.event_name != 'pull_request'
+    needs: [verify]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    concurrency:
+      group: latest-build
+      cancel-in-progress: true
+    defaults:
+      run:
+        shell: bash
+        working-directory: cli
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -73,117 +100,55 @@ jobs:
         run: azd x pack
 
       - name: Prepare release assets
-        id: assets
         run: |
-          echo "sha_short=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
-          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
-          # List what was built
           echo "=== Build output ==="
           find output/ -type f 2>/dev/null || find bin/ -type f 2>/dev/null || echo "No output found"
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: latest-release-assets
+          path: cli/bin/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish Latest
+    if: github.event_name != 'pull_request'
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: latest-publish
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: latest-release-assets
+          path: release-assets
+
+      - name: Recover interrupted publication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: bash scripts/publish-latest-release.sh recover
 
       - name: Update latest release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: .
+          REPO: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          BUILD_DATE: ${{ github.event.head_commit.timestamp }}
         run: |
-          SHA_SHORT="${{ steps.assets.outputs.sha_short }}"
-          BUILD_DATE="${{ steps.assets.outputs.date }}"
-          
-          cat > /tmp/release-notes.md << EOF
-          ## Latest Build from main
-
-          **Commit:** [${SHA_SHORT}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
-          **Built:** ${BUILD_DATE}
-
-          ---
-
-          > ⚠️ This is an automatically-built pre-release from the main branch.
-          > It may contain bugs. For stable releases, see the [Releases page](https://github.com/${{ github.repository }}/releases).
-
-          ### Install
-
-          azd extension install jongio.azd.app --version latest
-          EOF
-
-          # Collect assets into an array
           shopt -s nullglob
-          FILES=(cli/bin/*)
-          if [ ${#FILES[@]} -eq 0 ]; then
-            echo "No assets in cli/bin/, trying cli/output/..."
-            FILES=(cli/output/*)
-          fi
-
-          echo "Found ${#FILES[@]} asset(s)"
-          printf '  %s\n' "${FILES[@]}"
-
-          if [ ${#FILES[@]} -eq 0 ]; then
-            echo "No release assets were built." >&2
-            exit 1
-          fi
-
-          STAGING_TAG="latest-staging-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          CUTOVER_STARTED=false
-          cleanup_staging_release() {
-            if [ "$CUTOVER_STARTED" = true ]; then
-              echo "Cutover failed; retaining draft release $STAGING_TAG for recovery." >&2
-              return
-            fi
-            gh release delete "$STAGING_TAG" \
-              --repo "${{ github.repository }}" \
-              --yes \
-              --cleanup-tag \
-              >/dev/null 2>&1 || true
-          }
-          trap cleanup_staging_release EXIT
-
-          gh release create "$STAGING_TAG" "${FILES[@]}" \
-            --repo "${{ github.repository }}" \
-            --title "Latest Build (${SHA_SHORT})" \
-            --notes-file /tmp/release-notes.md \
-            --draft \
-            --target "${{ github.sha }}"
-
-          set +e
-          release_lookup="$(gh api "repos/${{ github.repository }}/releases/tags/latest" --jq '.id' 2>&1)"
-          release_status=$?
-          set -e
-
-          if [ "$release_status" -eq 0 ]; then
-            CUTOVER_STARTED=true
-            gh release delete latest \
-              --repo "${{ github.repository }}" \
-              --yes
-          elif ! printf '%s' "$release_lookup" | grep -q '(HTTP 404)'; then
-            echo "Failed to inspect the existing latest release:" >&2
-            printf '%s\n' "$release_lookup" >&2
-            exit "$release_status"
-          fi
-
-          # Delete a surviving tag when the release was already absent or tag cleanup was incomplete.
-          set +e
-          tag_lookup="$(gh api "repos/${{ github.repository }}/git/ref/tags/latest" --jq '.ref' 2>&1)"
-          tag_status=$?
-          set -e
-
-          if [ "$tag_status" -eq 0 ]; then
-            CUTOVER_STARTED=true
-            gh api --method DELETE \
-              "repos/${{ github.repository }}/git/refs/tags/latest"
-          elif ! printf '%s' "$tag_lookup" | grep -q '(HTTP 404)'; then
-            echo "Failed to inspect the existing latest tag:" >&2
-            printf '%s\n' "$tag_lookup" >&2
-            exit "$tag_status"
-          fi
-
-          CUTOVER_STARTED=true
-          gh release edit "$STAGING_TAG" \
-            --repo "${{ github.repository }}" \
-            --tag latest \
-            --title "Latest Build (${SHA_SHORT})" \
-            --notes-file /tmp/release-notes.md \
-            --draft=false \
-            --prerelease \
-            --target "${{ github.sha }}"
-          trap - EXIT
-          
-          echo "✅ Latest release updated: https://github.com/${{ github.repository }}/releases/tag/latest"
+          files=(release-assets/*)
+          bash scripts/publish-latest-release.sh publish "${files[@]}"

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: latest-build
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -105,9 +105,6 @@ jobs:
           azd extension install jongio.azd.app --version latest
           EOF
 
-          # Delete existing latest release (if any) to recreate it
-          gh release delete latest --yes --cleanup-tag 2>/dev/null || true
-          
           # Collect assets into an array
           shopt -s nullglob
           FILES=(cli/bin/*)
@@ -119,18 +116,74 @@ jobs:
           echo "Found ${#FILES[@]} asset(s)"
           printf '  %s\n' "${FILES[@]}"
 
-          if [ ${#FILES[@]} -gt 0 ]; then
-            gh release create latest "${FILES[@]}" \
-              --title "Latest Build (${SHA_SHORT})" \
-              --notes-file /tmp/release-notes.md \
-              --prerelease \
-              --target "${{ github.sha }}"
-          else
-            gh release create latest \
-              --title "Latest Build (${SHA_SHORT})" \
-              --notes-file /tmp/release-notes.md \
-              --prerelease \
-              --target "${{ github.sha }}"
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No release assets were built." >&2
+            exit 1
           fi
+
+          STAGING_TAG="latest-staging-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          CUTOVER_STARTED=false
+          cleanup_staging_release() {
+            if [ "$CUTOVER_STARTED" = true ]; then
+              echo "Cutover failed; retaining draft release $STAGING_TAG for recovery." >&2
+              return
+            fi
+            gh release delete "$STAGING_TAG" \
+              --repo "${{ github.repository }}" \
+              --yes \
+              --cleanup-tag \
+              >/dev/null 2>&1 || true
+          }
+          trap cleanup_staging_release EXIT
+
+          gh release create "$STAGING_TAG" "${FILES[@]}" \
+            --repo "${{ github.repository }}" \
+            --title "Latest Build (${SHA_SHORT})" \
+            --notes-file /tmp/release-notes.md \
+            --draft \
+            --target "${{ github.sha }}"
+
+          set +e
+          release_lookup="$(gh api "repos/${{ github.repository }}/releases/tags/latest" --jq '.id' 2>&1)"
+          release_status=$?
+          set -e
+
+          if [ "$release_status" -eq 0 ]; then
+            CUTOVER_STARTED=true
+            gh release delete latest \
+              --repo "${{ github.repository }}" \
+              --yes
+          elif ! printf '%s' "$release_lookup" | grep -q '(HTTP 404)'; then
+            echo "Failed to inspect the existing latest release:" >&2
+            printf '%s\n' "$release_lookup" >&2
+            exit "$release_status"
+          fi
+
+          # Delete a surviving tag when the release was already absent or tag cleanup was incomplete.
+          set +e
+          tag_lookup="$(gh api "repos/${{ github.repository }}/git/ref/tags/latest" --jq '.ref' 2>&1)"
+          tag_status=$?
+          set -e
+
+          if [ "$tag_status" -eq 0 ]; then
+            CUTOVER_STARTED=true
+            gh api --method DELETE \
+              "repos/${{ github.repository }}/git/refs/tags/latest"
+          elif ! printf '%s' "$tag_lookup" | grep -q '(HTTP 404)'; then
+            echo "Failed to inspect the existing latest tag:" >&2
+            printf '%s\n' "$tag_lookup" >&2
+            exit "$tag_status"
+          fi
+
+          CUTOVER_STARTED=true
+          gh release edit "$STAGING_TAG" \
+            --repo "${{ github.repository }}" \
+            --tag latest \
+            --title "Latest Build (${SHA_SHORT})" \
+            --notes-file /tmp/release-notes.md \
+            --draft=false \
+            --prerelease \
+            --target "${{ github.sha }}"
+          trap - EXIT
           
           echo "✅ Latest release updated: https://github.com/${{ github.repository }}/releases/tag/latest"

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -33,11 +33,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: cli/go.mod
+          cache: false
+
       - name: Install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
       - name: Lint workflows
-        run: $(go env GOPATH)/bin/actionlint -ignore 'unknown permission scope "copilot-requests"'
+        run: '"$(go env GOPATH)/bin/actionlint" .github/workflows/latest.yml'
+
+      - name: Shellcheck publisher scripts
+        run: shellcheck scripts/publish-latest-release.sh scripts/test-publish-latest-release.sh scripts/testdata/fake-gh.sh
 
       - name: Test latest release publisher
         run: bash scripts/test-publish-latest-release.sh
@@ -79,7 +88,7 @@ jobs:
       - name: Build dashboard
         run: |
           cd dashboard
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm run build
 
       - name: Install azd
@@ -93,7 +102,8 @@ jobs:
       - name: Build binaries
         run: |
           export EXTENSION_ID="jongio.azd.app"
-          export EXTENSION_VERSION="0.0.0-dev.$(date +%Y%m%d).$(echo $GITHUB_SHA | cut -c1-7)"
+          EXTENSION_VERSION="0.0.0-dev.$(date +%Y%m%d).${GITHUB_SHA:0:7}"
+          export EXTENSION_VERSION
           azd x build --all
 
       - name: Package
@@ -102,7 +112,7 @@ jobs:
       - name: Prepare release assets
         run: |
           echo "=== Build output ==="
-          find output/ -type f 2>/dev/null || find bin/ -type f 2>/dev/null || echo "No output found"
+          find bin/ -type f
 
       - name: Upload release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -37,7 +37,7 @@ jobs:
         run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
       - name: Lint workflows
-        run: actionlint -ignore 'unknown permission scope "copilot-requests"'
+        run: $(go env GOPATH)/bin/actionlint -ignore 'unknown permission scope "copilot-requests"'
 
       - name: Test latest release publisher
         run: bash scripts/test-publish-latest-release.sh

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build dashboard
         run: |
           cd dashboard
-          pnpm install --frozen-lockfile
+          pnpm install
           pnpm run build
 
       - name: Install azd

--- a/cli/magefile.go
+++ b/cli/magefile.go
@@ -352,15 +352,24 @@ func buildAllPlatforms() error {
 	return nil
 }
 
-// Test runs unit tests only (with -short flag).
+// Test runs unit tests and the latest release publisher harness.
 func Test() error {
+	mg.Deps(DashboardBuild)
+
 	fmt.Println("Running unit tests...")
 	// Use full module path in workspace mode
 	pkgPath := goSrcPattern
 	if _, err := os.Stat("../go.work"); err == nil {
 		pkgPath = "github.com/jongio/azd-app/cli/src/..."
 	}
-	return sh.RunV("go", "test", "-v", "-short", pkgPath)
+	if err := sh.RunV("go", "test", "-v", "-short", pkgPath); err != nil {
+		return err
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		fmt.Println("Warning: bash not installed; skipping latest release publisher harness")
+		return nil
+	}
+	return sh.RunV("bash", "../scripts/test-publish-latest-release.sh")
 }
 
 // TestIntegration runs integration tests only.
@@ -1555,9 +1564,15 @@ func preflightDeadcode() error {
 	return nil
 }
 
-// dashboardInstall runs pnpm install for the dashboard project.
+// dashboardInstall installs dashboard dependencies without changing the lockfile.
 func dashboardInstall() error {
-	return runQuiet("pnpm", "install", "--dir", dashboardDir)
+	args := []string{"install", "--dir", dashboardDir}
+	if _, err := os.Stat(filepath.Join(dashboardDir, "pnpm-lock.yaml")); err == nil {
+		args = append(args, "--frozen-lockfile")
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to inspect dashboard lockfile: %w", err)
+	}
+	return runQuiet("pnpm", args...)
 }
 
 // dashboardBuildOnly builds the dashboard without running pnpm install.
@@ -2316,7 +2331,7 @@ func DashboardBuild() error {
 
 	// Install dependencies
 	fmt.Println("Installing dashboard dependencies...")
-	if err := sh.RunV("pnpm", "install", "--dir", dashboardDir); err != nil {
+	if err := dashboardInstall(); err != nil {
 		return fmt.Errorf(errPnpmFailedFmt, err)
 	}
 

--- a/cli/magefile.go
+++ b/cli/magefile.go
@@ -160,7 +160,10 @@ func patchExtensionVersion(version string) (func(), error) {
 // All runs lint, test, and build in dependency order.
 // Set ALL_PLATFORMS=true to build for all platforms instead of current platform.
 func All() error {
-	mg.Deps(Fmt, DashboardBuild, Lint, Test)
+	mg.Deps(Fmt, DashboardBuild, Lint)
+	if err := Test(); err != nil {
+		return err
+	}
 	return Build()
 }
 
@@ -354,7 +357,9 @@ func buildAllPlatforms() error {
 
 // Test runs unit tests and the latest release publisher harness.
 func Test() error {
-	mg.Deps(DashboardBuild)
+	if err := ensureDashboardDist(); err != nil {
+		return err
+	}
 
 	fmt.Println("Running unit tests...")
 	// Use full module path in workspace mode
@@ -366,8 +371,7 @@ func Test() error {
 		return err
 	}
 	if _, err := exec.LookPath("bash"); err != nil {
-		fmt.Println("Warning: bash not installed; skipping latest release publisher harness")
-		return nil
+		return fmt.Errorf("bash is required to run the release publisher harness: %w", err)
 	}
 	return sh.RunV("bash", "../scripts/test-publish-latest-release.sh")
 }
@@ -1564,15 +1568,9 @@ func preflightDeadcode() error {
 	return nil
 }
 
-// dashboardInstall installs dashboard dependencies without changing the lockfile.
+// dashboardInstall runs pnpm install for the dashboard project.
 func dashboardInstall() error {
-	args := []string{"install", "--dir", dashboardDir}
-	if _, err := os.Stat(filepath.Join(dashboardDir, "pnpm-lock.yaml")); err == nil {
-		args = append(args, "--frozen-lockfile")
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to inspect dashboard lockfile: %w", err)
-	}
-	return runQuiet("pnpm", args...)
+	return runQuiet("pnpm", "install", "--dir", dashboardDir)
 }
 
 // dashboardBuildOnly builds the dashboard without running pnpm install.

--- a/scripts/publish-latest-release.sh
+++ b/scripts/publish-latest-release.sh
@@ -6,12 +6,18 @@ readonly REPO="${REPO:?REPO is required}"
 readonly GITHUB_SHA="${GITHUB_SHA:?GITHUB_SHA is required}"
 readonly STAGING_PREFIX="latest-staging-"
 readonly BACKUP_PREFIX="latest-backup-"
+readonly MAIN_TIP_STALE_STATUS=10
+readonly MAIN_TIP_API_FAILURE_STATUS=11
 
 HTTP_STATUS=
 WORK_DIR=
 STAGING_TAG=
 BACKUP_TAG=
+BACKUP_TARGET=
 CUTOVER_STARTED=false
+REMOTE_PROMOTION_APPLIED=false
+PROMOTION_IN_PROGRESS=false
+PENDING_SIGNAL_STATUS=0
 PUBLISH_COMPLETE=false
 LATEST_EXISTED=false
 
@@ -19,20 +25,30 @@ probe_api() {
   local endpoint="$1"
   local headers
   local errors
+  local result
   local status
+  local was_errexit=false
 
   headers="$(mktemp)"
   errors="$(mktemp)"
+  HTTP_STATUS=
+  [[ $- == *e* ]] && was_errexit=true
   set +e
   gh api --include --silent "$endpoint" >"$headers" 2>"$errors"
-  set -e
+  result=$?
+  if [[ "$was_errexit" == true ]]; then
+    set -e
+  fi
 
   status="$(awk 'NR == 1 && $1 ~ /^HTTP/ { print $2 }' "$headers")"
   if [[ ! "$status" =~ ^[0-9]{3}$ ]]; then
     echo "GitHub API request failed without an HTTP status: $endpoint" >&2
     cat "$errors" >&2
     rm -f "$headers" "$errors"
-    return 1
+    if [[ "$result" -eq 0 ]]; then
+      return 1
+    fi
+    return "$result"
   fi
 
   HTTP_STATUS="$status"
@@ -69,7 +85,7 @@ latest_tag_status() {
 
 list_recovery_artifacts() {
   gh api --paginate "repos/$REPO/releases?per_page=100" \
-    --jq '.[] | select(.draft and ((.tag_name | startswith("latest-staging-")) or (.tag_name | startswith("latest-backup-")))) | [.created_at, .tag_name] | @tsv' \
+    --jq '.[] | select(.draft and ((.tag_name | startswith("latest-staging-")) or (.tag_name | startswith("latest-backup-")))) | [.created_at, .tag_name, .target_commitish] | @tsv' \
     | sort -r
 }
 
@@ -79,38 +95,34 @@ delete_draft() {
 }
 
 prune_recovery_artifacts() {
-  local keep="${1:-}"
+  local artifacts
   local tag
 
-  while IFS=$'\t' read -r _ tag; do
-    if [[ -n "$tag" && "$tag" != "$keep" ]]; then
+  artifacts="$(list_recovery_artifacts)"
+  while IFS=$'\t' read -r _ tag _; do
+    if [[ -n "$tag" ]]; then
       echo "Deleting stale recovery draft $tag."
       delete_draft "$tag"
     fi
-  done < <(list_recovery_artifacts)
+  done <<<"$artifacts"
 }
 
 delete_latest_objects() {
-  latest_release_status
+  latest_release_status || return 1
   if [[ "$HTTP_STATUS" == 200 ]]; then
     echo "Deleting the current latest release."
-    gh release delete latest --repo "$REPO" --yes
+    gh release delete latest --repo "$REPO" --yes || return 1
   else
     echo "No latest release exists."
   fi
 
-  latest_tag_status
+  latest_tag_status || return 1
   if [[ "$HTTP_STATUS" == 200 ]]; then
     echo "Deleting the current latest tag."
-    gh api --method DELETE "repos/$REPO/git/refs/tags/latest"
+    gh api --method DELETE "repos/$REPO/git/refs/tags/latest" || return 1
   else
     echo "No latest tag exists."
   fi
-}
-
-release_target() {
-  local tag="$1"
-  gh api "repos/$REPO/releases/tags/$tag" --jq '.target_commitish'
 }
 
 verify_latest() {
@@ -139,13 +151,29 @@ verify_latest() {
 promote_draft() {
   local tag="$1"
   local expected_sha="$2"
+  local edit_result
 
   echo "Promoting recovery draft $tag to latest."
-  gh release edit "$tag" \
-    --repo "$REPO" \
-    --tag latest \
-    --draft=false \
-    --prerelease
+  PROMOTION_IN_PROGRESS=true
+  if gh release edit "$tag" \
+      --repo "$REPO" \
+      --tag latest \
+      --draft=false \
+      --prerelease; then
+    edit_result=0
+    REMOTE_PROMOTION_APPLIED=true
+  else
+    edit_result=$?
+  fi
+  PROMOTION_IN_PROGRESS=false
+
+  if [[ "$PENDING_SIGNAL_STATUS" -ne 0 ]]; then
+    exit "$PENDING_SIGNAL_STATUS"
+  fi
+  if [[ "$edit_result" -ne 0 ]]; then
+    return "$edit_result"
+  fi
+
   verify_latest "$expected_sha"
 }
 
@@ -153,9 +181,9 @@ select_recovery_artifact() {
   local artifacts="$1"
   local candidate
 
-  candidate="$(printf '%s\n' "$artifacts" | awk -F '\t' '$2 ~ /^latest-backup-/ { print $2; exit }')"
+  candidate="$(printf '%s\n' "$artifacts" | awk -F '\t' '$2 ~ /^latest-backup-/ { print; exit }')"
   if [[ -z "$candidate" ]]; then
-    candidate="$(printf '%s\n' "$artifacts" | awk -F '\t' '$2 ~ /^latest-staging-/ { print $2; exit }')"
+    candidate="$(printf '%s\n' "$artifacts" | awk -F '\t' -v sha="$GITHUB_SHA" '$2 ~ /^latest-staging-/ && $3 == sha { print; exit }')"
   fi
   printf '%s' "$candidate"
 }
@@ -163,6 +191,7 @@ select_recovery_artifact() {
 recover_latest() {
   local artifacts
   local candidate
+  local candidate_row
   local release_status
   local tag_status
   local target
@@ -178,26 +207,20 @@ recover_latest() {
   fi
 
   artifacts="$(list_recovery_artifacts)"
-  candidate="$(select_recovery_artifact "$artifacts")"
-  if [[ -z "$candidate" ]]; then
-    if [[ "$release_status" == 404 && "$tag_status" == 404 ]]; then
-      echo "No latest release or recovery draft exists."
-      return
+  candidate_row="$(select_recovery_artifact "$artifacts")"
+  if [[ -z "$candidate_row" ]]; then
+    if [[ "$release_status" == 200 || "$tag_status" == 200 ]]; then
+      echo "Removing incomplete latest state so the current build can republish it."
+      delete_latest_objects
+    else
+      echo "No latest release or matching recovery draft exists."
     fi
-    echo "The latest release is incomplete and no recovery draft exists." >&2
-    return 1
+    prune_recovery_artifacts
+    return
   fi
 
-  target="$(release_target "$candidate")"
-  if [[ "$release_status" == 200 ]]; then
-    echo "Deleting the incomplete latest release before recovery."
-    gh release delete latest --repo "$REPO" --yes
-  fi
-  if [[ "$tag_status" == 200 ]]; then
-    echo "Deleting the surviving latest tag before recovery."
-    gh api --method DELETE "repos/$REPO/git/refs/tags/latest"
-  fi
-
+  IFS=$'\t' read -r _ candidate target <<<"$candidate_row"
+  delete_latest_objects
   promote_draft "$candidate" "$target"
   prune_recovery_artifacts
   echo "Recovered the latest release from $candidate."
@@ -205,10 +228,14 @@ recover_latest() {
 
 assert_main_tip() {
   local main_sha
-  main_sha="$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')"
+
+  if ! main_sha="$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')"; then
+    echo "Failed to determine the current main tip." >&2
+    return "$MAIN_TIP_API_FAILURE_STATUS"
+  fi
   if [[ "$main_sha" != "$GITHUB_SHA" ]]; then
     echo "Skipping publication because main advanced to $main_sha."
-    return 1
+    return "$MAIN_TIP_STALE_STATUS"
   fi
 }
 
@@ -227,6 +254,7 @@ stage_backup() {
   fi
 
   backup_target="$(gh api "$(latest_tag_endpoint)" --jq '.object.sha')"
+  BACKUP_TARGET="$backup_target"
   backup_title="$(gh api "$(latest_release_endpoint)" --jq '.name // "Latest Build"')"
   gh api "$(latest_release_endpoint)" --jq '.body // ""' >"$backup_notes"
   asset_count="$(gh api "$(latest_release_endpoint)" --jq '.assets | length')"
@@ -253,10 +281,11 @@ restore_after_failure() {
 
   if [[ "$LATEST_EXISTED" == true ]]; then
     candidate="$BACKUP_TAG"
+    target="$BACKUP_TARGET"
   else
     candidate="$STAGING_TAG"
+    target="$GITHUB_SHA"
   fi
-  target="$(release_target "$candidate" 2>/dev/null || true)"
 
   echo "Cutover failed. Restoring latest from $candidate." >&2
   set +e
@@ -290,7 +319,10 @@ on_exit() {
     exit "$status"
   fi
 
-  if [[ "$CUTOVER_STARTED" == true ]]; then
+  if [[ "$REMOTE_PROMOTION_APPLIED" == true ]]; then
+    echo "Promotion succeeded, but completion could not be verified." >&2
+    echo "Preserving the promoted latest release and recovery artifacts." >&2
+  elif [[ "$CUTOVER_STARTED" == true ]]; then
     if ! restore_after_failure; then
       status=1
     fi
@@ -305,11 +337,22 @@ on_exit() {
   exit "$status"
 }
 
+on_signal() {
+  local status="$1"
+
+  if [[ "$PROMOTION_IN_PROGRESS" == true ]]; then
+    PENDING_SIGNAL_STATUS="$status"
+    return
+  fi
+  exit "$status"
+}
+
 publish_latest() {
   local -a files=("$@")
   local notes
   local short_sha="${GITHUB_SHA:0:7}"
   local build_date="${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+  local main_tip_status
 
   if [[ "${#files[@]}" -eq 0 ]]; then
     echo "No release assets were provided." >&2
@@ -322,14 +365,22 @@ publish_latest() {
     fi
   done
 
-  if ! assert_main_tip; then
-    return
-  fi
+  main_tip_status=0
+  assert_main_tip || main_tip_status=$?
+  case "$main_tip_status" in
+    0) ;;
+    "$MAIN_TIP_STALE_STATUS") return 0 ;;
+    *) return "$main_tip_status" ;;
+  esac
 
   WORK_DIR="$(mktemp -d)"
   STAGING_TAG="${STAGING_PREFIX}${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}-${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}"
   BACKUP_TAG="${BACKUP_PREFIX}${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
   notes="$WORK_DIR/release-notes.md"
+
+  trap on_exit EXIT
+  trap 'on_signal 130' INT
+  trap 'on_signal 143' TERM
 
   cat >"$notes" <<EOF
 ## Latest Build from main
@@ -339,10 +390,6 @@ publish_latest() {
 
 > This is an automatically built prerelease from the main branch.
 > It may contain bugs. For stable releases, see the [Releases page](https://github.com/$REPO/releases).
-
-### Install
-
-\`azd extension install jongio.azd.app --version latest\`
 EOF
 
   gh release create "$STAGING_TAG" "${files[@]}" \
@@ -352,10 +399,6 @@ EOF
     --draft \
     --target "$GITHUB_SHA"
 
-  trap on_exit EXIT
-  trap 'exit 130' INT
-  trap 'exit 143' TERM
-
   latest_release_status
   if [[ "$HTTP_STATUS" == 200 ]]; then
     LATEST_EXISTED=true
@@ -364,9 +407,13 @@ EOF
     echo "No latest release exists; the staged release is the recovery artifact."
   fi
 
-  if ! assert_main_tip; then
-    return
-  fi
+  main_tip_status=0
+  assert_main_tip || main_tip_status=$?
+  case "$main_tip_status" in
+    0) ;;
+    "$MAIN_TIP_STALE_STATUS") return 0 ;;
+    *) return "$main_tip_status" ;;
+  esac
 
   CUTOVER_STARTED=true
   delete_latest_objects

--- a/scripts/publish-latest-release.sh
+++ b/scripts/publish-latest-release.sh
@@ -98,13 +98,20 @@ prune_recovery_artifacts() {
   local artifacts
   local tag
 
-  artifacts="$(list_recovery_artifacts)"
+  artifacts="$(list_recovery_artifacts)" || return $?
   while IFS=$'\t' read -r _ tag _; do
     if [[ -n "$tag" ]]; then
       echo "Deleting stale recovery draft $tag."
-      delete_draft "$tag"
+      delete_draft "$tag" || return $?
     fi
   done <<<"$artifacts"
+}
+
+prune_after_success() {
+  if ! prune_recovery_artifacts; then
+    echo "The latest release is healthy, but stale recovery artifacts could not be pruned." >&2
+    return 1
+  fi
 }
 
 delete_latest_objects() {
@@ -222,7 +229,7 @@ recover_latest() {
   IFS=$'\t' read -r _ candidate target <<<"$candidate_row"
   delete_latest_objects
   promote_draft "$candidate" "$target"
-  prune_recovery_artifacts
+  prune_after_success
   echo "Recovered the latest release from $candidate."
 }
 
@@ -420,7 +427,7 @@ EOF
   promote_draft "$STAGING_TAG" "$GITHUB_SHA"
   PUBLISH_COMPLETE=true
 
-  prune_recovery_artifacts
+  prune_after_success
   echo "Latest release updated: https://github.com/$REPO/releases/tag/latest"
 }
 

--- a/scripts/publish-latest-release.sh
+++ b/scripts/publish-latest-release.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly REPO="${REPO:?REPO is required}"
+readonly GITHUB_SHA="${GITHUB_SHA:?GITHUB_SHA is required}"
+readonly STAGING_PREFIX="latest-staging-"
+readonly BACKUP_PREFIX="latest-backup-"
+
+HTTP_STATUS=
+WORK_DIR=
+STAGING_TAG=
+BACKUP_TAG=
+CUTOVER_STARTED=false
+PUBLISH_COMPLETE=false
+LATEST_EXISTED=false
+
+probe_api() {
+  local endpoint="$1"
+  local headers
+  local errors
+  local status
+
+  headers="$(mktemp)"
+  errors="$(mktemp)"
+  set +e
+  gh api --include --silent "$endpoint" >"$headers" 2>"$errors"
+  set -e
+
+  status="$(awk 'NR == 1 && $1 ~ /^HTTP/ { print $2 }' "$headers")"
+  if [[ ! "$status" =~ ^[0-9]{3}$ ]]; then
+    echo "GitHub API request failed without an HTTP status: $endpoint" >&2
+    cat "$errors" >&2
+    rm -f "$headers" "$errors"
+    return 1
+  fi
+
+  HTTP_STATUS="$status"
+  rm -f "$headers" "$errors"
+}
+
+expect_present_or_missing() {
+  local endpoint="$1"
+  probe_api "$endpoint"
+  case "$HTTP_STATUS" in
+    200 | 404) ;;
+    *)
+      echo "GitHub API request returned HTTP $HTTP_STATUS: $endpoint" >&2
+      return 1
+      ;;
+  esac
+}
+
+latest_release_endpoint() {
+  printf 'repos/%s/releases/tags/latest' "$REPO"
+}
+
+latest_tag_endpoint() {
+  printf 'repos/%s/git/ref/tags/latest' "$REPO"
+}
+
+latest_release_status() {
+  expect_present_or_missing "$(latest_release_endpoint)"
+}
+
+latest_tag_status() {
+  expect_present_or_missing "$(latest_tag_endpoint)"
+}
+
+list_recovery_artifacts() {
+  gh api --paginate "repos/$REPO/releases?per_page=100" \
+    --jq '.[] | select(.draft and ((.tag_name | startswith("latest-staging-")) or (.tag_name | startswith("latest-backup-")))) | [.created_at, .tag_name] | @tsv' \
+    | sort -r
+}
+
+delete_draft() {
+  local tag="$1"
+  gh release delete "$tag" --repo "$REPO" --yes
+}
+
+prune_recovery_artifacts() {
+  local keep="${1:-}"
+  local tag
+
+  while IFS=$'\t' read -r _ tag; do
+    if [[ -n "$tag" && "$tag" != "$keep" ]]; then
+      echo "Deleting stale recovery draft $tag."
+      delete_draft "$tag"
+    fi
+  done < <(list_recovery_artifacts)
+}
+
+delete_latest_objects() {
+  latest_release_status
+  if [[ "$HTTP_STATUS" == 200 ]]; then
+    echo "Deleting the current latest release."
+    gh release delete latest --repo "$REPO" --yes
+  else
+    echo "No latest release exists."
+  fi
+
+  latest_tag_status
+  if [[ "$HTTP_STATUS" == 200 ]]; then
+    echo "Deleting the current latest tag."
+    gh api --method DELETE "repos/$REPO/git/refs/tags/latest"
+  else
+    echo "No latest tag exists."
+  fi
+}
+
+release_target() {
+  local tag="$1"
+  gh api "repos/$REPO/releases/tags/$tag" --jq '.target_commitish'
+}
+
+verify_latest() {
+  local expected_sha="$1"
+  local actual_sha
+
+  latest_release_status
+  if [[ "$HTTP_STATUS" != 200 ]]; then
+    echo "The latest release was not published." >&2
+    return 1
+  fi
+
+  latest_tag_status
+  if [[ "$HTTP_STATUS" != 200 ]]; then
+    echo "The latest tag was not published." >&2
+    return 1
+  fi
+
+  actual_sha="$(gh api "$(latest_tag_endpoint)" --jq '.object.sha')"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    echo "The latest tag targets $actual_sha, expected $expected_sha." >&2
+    return 1
+  fi
+}
+
+promote_draft() {
+  local tag="$1"
+  local expected_sha="$2"
+
+  echo "Promoting recovery draft $tag to latest."
+  gh release edit "$tag" \
+    --repo "$REPO" \
+    --tag latest \
+    --draft=false \
+    --prerelease
+  verify_latest "$expected_sha"
+}
+
+select_recovery_artifact() {
+  local artifacts="$1"
+  local candidate
+
+  candidate="$(printf '%s\n' "$artifacts" | awk -F '\t' '$2 ~ /^latest-backup-/ { print $2; exit }')"
+  if [[ -z "$candidate" ]]; then
+    candidate="$(printf '%s\n' "$artifacts" | awk -F '\t' '$2 ~ /^latest-staging-/ { print $2; exit }')"
+  fi
+  printf '%s' "$candidate"
+}
+
+recover_latest() {
+  local artifacts
+  local candidate
+  local release_status
+  local tag_status
+  local target
+
+  latest_release_status
+  release_status="$HTTP_STATUS"
+  latest_tag_status
+  tag_status="$HTTP_STATUS"
+  if [[ "$release_status" == 200 && "$tag_status" == 200 ]]; then
+    prune_recovery_artifacts
+    echo "The latest release is healthy."
+    return
+  fi
+
+  artifacts="$(list_recovery_artifacts)"
+  candidate="$(select_recovery_artifact "$artifacts")"
+  if [[ -z "$candidate" ]]; then
+    if [[ "$release_status" == 404 && "$tag_status" == 404 ]]; then
+      echo "No latest release or recovery draft exists."
+      return
+    fi
+    echo "The latest release is incomplete and no recovery draft exists." >&2
+    return 1
+  fi
+
+  target="$(release_target "$candidate")"
+  if [[ "$release_status" == 200 ]]; then
+    echo "Deleting the incomplete latest release before recovery."
+    gh release delete latest --repo "$REPO" --yes
+  fi
+  if [[ "$tag_status" == 200 ]]; then
+    echo "Deleting the surviving latest tag before recovery."
+    gh api --method DELETE "repos/$REPO/git/refs/tags/latest"
+  fi
+
+  promote_draft "$candidate" "$target"
+  prune_recovery_artifacts
+  echo "Recovered the latest release from $candidate."
+}
+
+assert_main_tip() {
+  local main_sha
+  main_sha="$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')"
+  if [[ "$main_sha" != "$GITHUB_SHA" ]]; then
+    echo "Skipping publication because main advanced to $main_sha."
+    return 1
+  fi
+}
+
+stage_backup() {
+  local backup_assets="$WORK_DIR/backup-assets"
+  local backup_notes="$WORK_DIR/backup-notes.md"
+  local backup_title
+  local backup_target
+  local asset_count
+  local -a files=()
+
+  latest_tag_status
+  if [[ "$HTTP_STATUS" != 200 ]]; then
+    echo "The latest release has no tag to back up." >&2
+    return 1
+  fi
+
+  backup_target="$(gh api "$(latest_tag_endpoint)" --jq '.object.sha')"
+  backup_title="$(gh api "$(latest_release_endpoint)" --jq '.name // "Latest Build"')"
+  gh api "$(latest_release_endpoint)" --jq '.body // ""' >"$backup_notes"
+  asset_count="$(gh api "$(latest_release_endpoint)" --jq '.assets | length')"
+
+  mkdir -p "$backup_assets"
+  if [[ "$asset_count" -gt 0 ]]; then
+    gh release download latest --repo "$REPO" --dir "$backup_assets"
+    shopt -s nullglob
+    files=("$backup_assets"/*)
+    shopt -u nullglob
+  fi
+
+  gh release create "$BACKUP_TAG" "${files[@]}" \
+    --repo "$REPO" \
+    --title "$backup_title" \
+    --notes-file "$backup_notes" \
+    --draft \
+    --target "$backup_target"
+}
+
+restore_after_failure() {
+  local candidate
+  local target
+
+  if [[ "$LATEST_EXISTED" == true ]]; then
+    candidate="$BACKUP_TAG"
+  else
+    candidate="$STAGING_TAG"
+  fi
+  target="$(release_target "$candidate" 2>/dev/null || true)"
+
+  echo "Cutover failed. Restoring latest from $candidate." >&2
+  set +e
+  delete_latest_objects
+  local delete_result=$?
+  if [[ "$delete_result" -eq 0 && -n "$target" ]]; then
+    promote_draft "$candidate" "$target"
+    local promote_result=$?
+  else
+    local promote_result=1
+  fi
+  set -e
+
+  if [[ "$promote_result" -ne 0 ]]; then
+    echo "Automatic recovery failed. Recovery draft:" >&2
+    echo "  https://github.com/$REPO/releases/tag/$candidate" >&2
+    echo "After removing any partial latest release and tag, run:" >&2
+    echo "  gh release edit $candidate --repo $REPO --tag latest --draft=false --prerelease" >&2
+    return 1
+  fi
+
+  echo "Automatic recovery restored latest from $candidate." >&2
+}
+
+on_exit() {
+  local status=$?
+  trap - EXIT INT TERM
+
+  if [[ "$PUBLISH_COMPLETE" == true ]]; then
+    rm -rf "$WORK_DIR"
+    exit "$status"
+  fi
+
+  if [[ "$CUTOVER_STARTED" == true ]]; then
+    if ! restore_after_failure; then
+      status=1
+    fi
+  else
+    set +e
+    [[ -n "$STAGING_TAG" ]] && delete_draft "$STAGING_TAG" >/dev/null 2>&1
+    [[ -n "$BACKUP_TAG" ]] && delete_draft "$BACKUP_TAG" >/dev/null 2>&1
+    set -e
+  fi
+
+  [[ -n "$WORK_DIR" ]] && rm -rf "$WORK_DIR"
+  exit "$status"
+}
+
+publish_latest() {
+  local -a files=("$@")
+  local notes
+  local short_sha="${GITHUB_SHA:0:7}"
+  local build_date="${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+  if [[ "${#files[@]}" -eq 0 ]]; then
+    echo "No release assets were provided." >&2
+    return 1
+  fi
+  for file in "${files[@]}"; do
+    if [[ ! -f "$file" ]]; then
+      echo "Release asset does not exist: $file" >&2
+      return 1
+    fi
+  done
+
+  if ! assert_main_tip; then
+    return
+  fi
+
+  WORK_DIR="$(mktemp -d)"
+  STAGING_TAG="${STAGING_PREFIX}${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}-${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}"
+  BACKUP_TAG="${BACKUP_PREFIX}${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+  notes="$WORK_DIR/release-notes.md"
+
+  cat >"$notes" <<EOF
+## Latest Build from main
+
+**Commit:** [$short_sha](https://github.com/$REPO/commit/$GITHUB_SHA)
+**Built:** $build_date
+
+> This is an automatically built prerelease from the main branch.
+> It may contain bugs. For stable releases, see the [Releases page](https://github.com/$REPO/releases).
+
+### Install
+
+\`azd extension install jongio.azd.app --version latest\`
+EOF
+
+  gh release create "$STAGING_TAG" "${files[@]}" \
+    --repo "$REPO" \
+    --title "Latest Build ($short_sha)" \
+    --notes-file "$notes" \
+    --draft \
+    --target "$GITHUB_SHA"
+
+  trap on_exit EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  latest_release_status
+  if [[ "$HTTP_STATUS" == 200 ]]; then
+    LATEST_EXISTED=true
+    stage_backup
+  else
+    echo "No latest release exists; the staged release is the recovery artifact."
+  fi
+
+  if ! assert_main_tip; then
+    return
+  fi
+
+  CUTOVER_STARTED=true
+  delete_latest_objects
+  promote_draft "$STAGING_TAG" "$GITHUB_SHA"
+  PUBLISH_COMPLETE=true
+
+  prune_recovery_artifacts
+  echo "Latest release updated: https://github.com/$REPO/releases/tag/latest"
+}
+
+case "${1:-}" in
+  recover)
+    recover_latest
+    ;;
+  publish)
+    shift
+    publish_latest "$@"
+    ;;
+  *)
+    echo "Usage: $0 recover | publish <asset>..." >&2
+    exit 2
+    ;;
+esac

--- a/scripts/test-publish-latest-release.sh
+++ b/scripts/test-publish-latest-release.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly PUBLISHER="$SCRIPT_DIR/publish-latest-release.sh"
+PASSED=0
+
+new_fixture() {
+  FIXTURE="$(mktemp -d)"
+  export FAKE_STATE="$FIXTURE/state"
+  export FAKE_LOG="$FIXTURE/commands.log"
+  export PATH="$FIXTURE/bin:$ORIGINAL_PATH"
+  export REPO="example/repo"
+  export GITHUB_SHA="new-sha"
+  export GITHUB_RUN_ID="42"
+  export GITHUB_RUN_ATTEMPT="1"
+  export BUILD_DATE="2026-08-17T00:00:00Z"
+  export MAIN_SHA="$GITHUB_SHA"
+  unset FAIL_MATCH
+  mkdir -p "$FAKE_STATE/releases" "$FAKE_STATE/tags" "$FIXTURE/bin"
+  printf '%s' "$MAIN_SHA" >"$FAKE_STATE/main-sha"
+  printf 'new asset' >"$FIXTURE/new.bin"
+  cp "$SCRIPT_DIR/testdata/fake-gh.sh" "$FIXTURE/bin/gh"
+  chmod +x "$FIXTURE/bin/gh"
+}
+
+cleanup_fixture() {
+  rm -rf "$FIXTURE"
+}
+
+add_release() {
+  local tag="$1"
+  local draft="$2"
+  local sha="$3"
+  local dir="$FAKE_STATE/releases/$tag"
+  mkdir -p "$dir/assets"
+  printf '%s' "$draft" >"$dir/draft"
+  printf '%s' "$sha" >"$dir/sha"
+  printf 'Latest Build' >"$dir/title"
+  printf 'notes' >"$dir/body"
+  printf 'old asset' >"$dir/assets/app.bin"
+  if [[ "$draft" == false ]]; then
+    printf '%s' "$sha" >"$FAKE_STATE/tags/$tag"
+  fi
+}
+
+assert_file() {
+  [[ -f "$1" ]] || { echo "Expected file: $1" >&2; return 1; }
+}
+
+assert_no_file() {
+  [[ ! -e "$1" ]] || { echo "Unexpected file: $1" >&2; return 1; }
+}
+
+run_case() {
+  local name="$1"
+  shift
+  new_fixture
+  if "$@"; then
+    PASSED=$((PASSED + 1))
+    echo "ok $PASSED - $name"
+  else
+    echo "not ok $((PASSED + 1)) - $name" >&2
+    cleanup_fixture
+    exit 1
+  fi
+  cleanup_fixture
+}
+
+case_first_publish() {
+  bash "$PUBLISHER" publish "$FIXTURE/new.bin"
+  assert_file "$FAKE_STATE/releases/latest/assets/new.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == new-sha ]]
+}
+
+case_replace_release() {
+  add_release latest false old-sha
+  bash "$PUBLISHER" publish "$FIXTURE/new.bin"
+  assert_file "$FAKE_STATE/releases/latest/assets/new.bin"
+  assert_no_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  assert_no_file "$FAKE_STATE/releases/latest-backup-42-1"
+}
+
+case_restore_on_promotion_failure() {
+  add_release latest false old-sha
+  export FAIL_MATCH="release edit latest-staging-42-1"
+  if bash "$PUBLISHER" publish "$FIXTURE/new.bin"; then return 1; fi
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == old-sha ]]
+}
+
+case_recover_backup() {
+  add_release latest-backup-old true old-sha
+  bash "$PUBLISHER" recover
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == old-sha ]]
+}
+
+case_recover_staging() {
+  add_release latest-staging-old true staged-sha
+  bash "$PUBLISHER" recover
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == staged-sha ]]
+}
+
+case_recover_incomplete_release() {
+  add_release latest false partial-sha
+  rm -f "$FAKE_STATE/tags/latest"
+  add_release latest-backup-old true old-sha
+  bash "$PUBLISHER" recover
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == old-sha ]]
+}
+
+case_prune_stale_drafts() {
+  add_release latest false old-sha
+  add_release latest-staging-old true stale-sha
+  add_release latest-backup-old true stale-sha
+  bash "$PUBLISHER" recover
+  assert_no_file "$FAKE_STATE/releases/latest-staging-old"
+  assert_no_file "$FAKE_STATE/releases/latest-backup-old"
+}
+
+case_surviving_tag() {
+  printf 'old-sha' >"$FAKE_STATE/tags/latest"
+  bash "$PUBLISHER" publish "$FIXTURE/new.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == new-sha ]]
+}
+
+case_stale_main() {
+  printf 'newer-sha' >"$FAKE_STATE/main-sha"
+  bash "$PUBLISHER" publish "$FIXTURE/new.bin"
+  assert_no_file "$FAKE_STATE/releases/latest"
+}
+
+case_missing_asset() {
+  if bash "$PUBLISHER" publish "$FIXTURE/missing.bin"; then return 1; fi
+  assert_no_file "$FAKE_STATE/releases/latest"
+}
+
+case_empty_assets() {
+  if bash "$PUBLISHER" publish; then return 1; fi
+  assert_no_file "$FAKE_STATE/releases/latest"
+}
+
+case_backup_failure_preserves_latest() {
+  add_release latest false old-sha
+  export FAIL_MATCH="release create latest-backup-42-1"
+  if bash "$PUBLISHER" publish "$FIXTURE/new.bin"; then return 1; fi
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == old-sha ]]
+}
+
+case_recover_without_artifacts() {
+  bash "$PUBLISHER" recover
+  assert_no_file "$FAKE_STATE/releases/latest"
+}
+
+case_api_failure_stops_before_cutover() {
+  add_release latest false old-sha
+  export FAIL_MATCH="api --include --silent repos/example/repo/releases/tags/latest"
+  if bash "$PUBLISHER" publish "$FIXTURE/new.bin"; then return 1; fi
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == old-sha ]]
+}
+
+ORIGINAL_PATH="$PATH"
+run_case "publishes when latest is absent" case_first_publish
+run_case "replaces a complete existing release" case_replace_release
+run_case "restores the prior release when promotion fails" case_restore_on_promotion_failure
+run_case "recovers a retained backup" case_recover_backup
+run_case "recovers a retained staging release" case_recover_staging
+run_case "recovers when the latest tag is missing" case_recover_incomplete_release
+run_case "prunes stale recovery drafts" case_prune_stale_drafts
+run_case "replaces a surviving latest tag" case_surviving_tag
+run_case "skips a stale main commit" case_stale_main
+run_case "rejects a missing asset" case_missing_asset
+run_case "rejects an empty asset list" case_empty_assets
+run_case "preserves latest when backup staging fails" case_backup_failure_preserves_latest
+run_case "allows an initial repository with no recovery artifacts" case_recover_without_artifacts
+run_case "stops on an API failure before cutover" case_api_failure_stops_before_cutover
+
+echo "1..$PASSED"

--- a/scripts/test-publish-latest-release.sh
+++ b/scripts/test-publish-latest-release.sh
@@ -25,6 +25,7 @@ new_fixture() {
   unset PAUSE_MATCH
   unset ADVANCE_MAIN_MATCH
   mkdir -p "$FAKE_STATE/releases" "$FAKE_STATE/tags" "$FIXTURE/bin"
+  : >"$FAKE_LOG"
   printf '%s' "$MAIN_SHA" >"$FAKE_STATE/main-sha"
   printf 'new asset' >"$FIXTURE/new.bin"
   cp "$SCRIPT_DIR/testdata/fake-gh.sh" "$FIXTURE/bin/gh"

--- a/scripts/test-publish-latest-release.sh
+++ b/scripts/test-publish-latest-release.sh
@@ -261,6 +261,16 @@ case_list_failure_is_reported() {
   assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
 }
 
+case_post_publish_prune_failure_is_reported() {
+  local output
+  add_release latest false old-sha
+  export POST_EDIT_FAIL_MATCH="api --paginate repos/example/repo/releases?per_page=100"
+  if output="$(bash "$PUBLISHER" publish "$FIXTURE/new.bin" 2>&1)"; then return 1; fi
+  [[ "$output" == *"The latest release is healthy, but stale recovery artifacts could not be pruned."* ]]
+  assert_file "$FAKE_STATE/releases/latest/assets/new.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == new-sha ]]
+}
+
 case_api_failure_stops_before_cutover() {
   add_release latest false old-sha
   export FAIL_MATCH="api --include --silent repos/example/repo/releases/tags/latest"
@@ -292,6 +302,7 @@ run_case "preserves promoted latest after TERM" case_preserve_promoted_latest_af
 run_case "preserves promoted latest when verification fails" case_preserve_promoted_latest_when_verification_fails
 run_case "stops on HTTP 500 before cutover" case_http_500_stops_before_cutover
 run_case "reports recovery artifact list failures" case_list_failure_is_reported
+run_case "reports cleanup failure after publication" case_post_publish_prune_failure_is_reported
 run_case "stops on an API failure before cutover" case_api_failure_stops_before_cutover
 
 echo "1..$PASSED"

--- a/scripts/test-publish-latest-release.sh
+++ b/scripts/test-publish-latest-release.sh
@@ -19,6 +19,11 @@ new_fixture() {
   export BUILD_DATE="2026-08-17T00:00:00Z"
   export MAIN_SHA="$GITHUB_SHA"
   unset FAIL_MATCH
+  unset FAIL_MATCH_OCCURRENCE
+  unset HTTP_FAIL_MATCH
+  unset POST_EDIT_FAIL_MATCH
+  unset PAUSE_MATCH
+  unset ADVANCE_MAIN_MATCH
   mkdir -p "$FAKE_STATE/releases" "$FAKE_STATE/tags" "$FIXTURE/bin"
   printf '%s' "$MAIN_SHA" >"$FAKE_STATE/main-sha"
   printf 'new asset' >"$FIXTURE/new.bin"
@@ -56,14 +61,20 @@ assert_no_file() {
 
 run_case() {
   local name="$1"
+  local result
   shift
   new_fixture
-  if "$@"; then
+  set +e
+  (set -e; "$@")
+  result=$?
+  set -e
+  if [[ "$result" -eq 0 ]]; then
     PASSED=$((PASSED + 1))
     echo "ok $PASSED - $name"
   else
     echo "not ok $((PASSED + 1)) - $name" >&2
-    cleanup_fixture
+    echo "fixture: $FIXTURE" >&2
+    sed 's/^/  /' "$FAKE_LOG" >&2
     exit 1
   fi
   cleanup_fixture
@@ -99,9 +110,16 @@ case_recover_backup() {
 }
 
 case_recover_staging() {
-  add_release latest-staging-old true staged-sha
+  add_release latest-staging-old true new-sha
   bash "$PUBLISHER" recover
-  [[ "$(cat "$FAKE_STATE/tags/latest")" == staged-sha ]]
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == new-sha ]]
+}
+
+case_discard_stale_staging() {
+  add_release latest-staging-old true stale-sha
+  bash "$PUBLISHER" recover
+  assert_no_file "$FAKE_STATE/releases/latest"
+  assert_no_file "$FAKE_STATE/releases/latest-staging-old"
 }
 
 case_recover_incomplete_release() {
@@ -134,6 +152,18 @@ case_stale_main() {
   assert_no_file "$FAKE_STATE/releases/latest"
 }
 
+case_main_tip_lookup_failure() {
+  add_release latest false old-sha
+  export FAIL_MATCH="api repos/example/repo/git/ref/heads/main --jq .object.sha"
+  export FAIL_MATCH_OCCURRENCE=2
+  if bash "$PUBLISHER" publish "$FIXTURE/new.bin"; then return 1; fi
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  assert_no_file "$FAKE_STATE/releases/latest/assets/new.bin"
+  assert_no_file "$FAKE_STATE/releases/latest-staging-42-1"
+  assert_no_file "$FAKE_STATE/releases/latest-backup-42-1"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == old-sha ]]
+}
+
 case_missing_asset() {
   if bash "$PUBLISHER" publish "$FIXTURE/missing.bin"; then return 1; fi
   assert_no_file "$FAKE_STATE/releases/latest"
@@ -157,6 +187,79 @@ case_recover_without_artifacts() {
   assert_no_file "$FAKE_STATE/releases/latest"
 }
 
+case_repair_partial_without_artifacts() {
+  add_release latest false partial-sha
+  rm -f "$FAKE_STATE/tags/latest"
+  bash "$PUBLISHER" recover
+  assert_no_file "$FAKE_STATE/releases/latest"
+}
+
+case_stale_after_backup() {
+  add_release latest false old-sha
+  export ADVANCE_MAIN_MATCH="release create latest-backup-42-1"
+  bash "$PUBLISHER" publish "$FIXTURE/new.bin"
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  assert_no_file "$FAKE_STATE/releases/latest-staging-42-1"
+  assert_no_file "$FAKE_STATE/releases/latest-backup-42-1"
+}
+
+case_restore_when_tag_delete_fails() {
+  add_release latest false old-sha
+  export FAIL_MATCH="api --method DELETE repos/example/repo/git/refs/tags/latest"
+  if bash "$PUBLISHER" publish "$FIXTURE/new.bin"; then return 1; fi
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == old-sha ]]
+}
+
+case_preserve_promoted_latest_after_term() {
+  local pid
+  local result
+  add_release latest false old-sha
+  export PAUSE_MATCH="release edit latest-staging-42-1"
+  bash "$PUBLISHER" publish "$FIXTURE/new.bin" &
+  pid=$!
+  for _ in {1..100}; do
+    [[ -f "$FAKE_STATE/pause-started" ]] && break
+    sleep 0.02
+  done
+  assert_file "$FAKE_STATE/pause-started"
+  kill -TERM "$pid"
+  set +e
+  wait "$pid"
+  result=$?
+  set -e
+  [[ "$result" -eq 143 ]]
+  assert_file "$FAKE_STATE/releases/latest/assets/new.bin"
+  assert_no_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  assert_file "$FAKE_STATE/releases/latest-backup-42-1/assets/app.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == new-sha ]]
+}
+
+case_preserve_promoted_latest_when_verification_fails() {
+  add_release latest false old-sha
+  export POST_EDIT_FAIL_MATCH="api --include --silent repos/example/repo/releases/tags/latest"
+  if bash "$PUBLISHER" publish "$FIXTURE/new.bin"; then return 1; fi
+  assert_file "$FAKE_STATE/releases/latest/assets/new.bin"
+  assert_no_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  assert_file "$FAKE_STATE/releases/latest-backup-42-1/assets/app.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == new-sha ]]
+}
+
+case_http_500_stops_before_cutover() {
+  add_release latest false old-sha
+  export HTTP_FAIL_MATCH="repos/example/repo/releases/tags/latest"
+  if bash "$PUBLISHER" publish "$FIXTURE/new.bin"; then return 1; fi
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+  [[ "$(cat "$FAKE_STATE/tags/latest")" == old-sha ]]
+}
+
+case_list_failure_is_reported() {
+  add_release latest false old-sha
+  export FAIL_MATCH="api --paginate repos/example/repo/releases?per_page=100"
+  if bash "$PUBLISHER" recover; then return 1; fi
+  assert_file "$FAKE_STATE/releases/latest/assets/app.bin"
+}
+
 case_api_failure_stops_before_cutover() {
   add_release latest false old-sha
   export FAIL_MATCH="api --include --silent repos/example/repo/releases/tags/latest"
@@ -171,14 +274,23 @@ run_case "replaces a complete existing release" case_replace_release
 run_case "restores the prior release when promotion fails" case_restore_on_promotion_failure
 run_case "recovers a retained backup" case_recover_backup
 run_case "recovers a retained staging release" case_recover_staging
+run_case "discards a retained staging release for a stale commit" case_discard_stale_staging
 run_case "recovers when the latest tag is missing" case_recover_incomplete_release
 run_case "prunes stale recovery drafts" case_prune_stale_drafts
 run_case "replaces a surviving latest tag" case_surviving_tag
 run_case "skips a stale main commit" case_stale_main
+run_case "fails when the main-tip lookup fails" case_main_tip_lookup_failure
 run_case "rejects a missing asset" case_missing_asset
 run_case "rejects an empty asset list" case_empty_assets
 run_case "preserves latest when backup staging fails" case_backup_failure_preserves_latest
 run_case "allows an initial repository with no recovery artifacts" case_recover_without_artifacts
+run_case "repairs partial latest state without recovery artifacts" case_repair_partial_without_artifacts
+run_case "skips cutover when main advances after backup" case_stale_after_backup
+run_case "restores latest when tag deletion fails" case_restore_when_tag_delete_fails
+run_case "preserves promoted latest after TERM" case_preserve_promoted_latest_after_term
+run_case "preserves promoted latest when verification fails" case_preserve_promoted_latest_when_verification_fails
+run_case "stops on HTTP 500 before cutover" case_http_500_stops_before_cutover
+run_case "reports recovery artifact list failures" case_list_failure_is_reported
 run_case "stops on an API failure before cutover" case_api_failure_stops_before_cutover
 
 echo "1..$PASSED"

--- a/scripts/testdata/fake-gh.sh
+++ b/scripts/testdata/fake-gh.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+command_text="$*"
+printf '%s\n' "$command_text" >>"$FAKE_LOG"
+if [[ -n "${FAIL_MATCH:-}" && "$command_text" == *"$FAIL_MATCH"* && ! -f "$FAKE_STATE/failure-used" ]]; then
+  touch "$FAKE_STATE/failure-used"
+  echo "injected failure" >&2
+  exit 1
+fi
+
+release_dir() {
+  printf '%s/releases/%s' "$FAKE_STATE" "$1"
+}
+
+api_status() {
+  local endpoint="$1"
+  local path=
+  case "$endpoint" in
+    repos/*/releases/tags/*)
+      path="$(release_dir "${endpoint##*/}")"
+      ;;
+    repos/*/git/ref/tags/*)
+      path="$FAKE_STATE/tags/${endpoint##*/}"
+      ;;
+  esac
+  if [[ -e "$path" ]]; then
+    printf 'HTTP/2.0 200 OK\n'
+    return
+  fi
+  printf 'HTTP/2.0 404 Not Found\n'
+  return 1
+}
+
+if [[ "$1" == api ]]; then
+  shift
+  if [[ "$1" == --include ]]; then
+    shift 2
+    api_status "$1"
+    exit
+  fi
+  if [[ "$1" == --paginate ]]; then
+    find "$FAKE_STATE/releases" -mindepth 1 -maxdepth 1 -type d \
+      | while read -r dir; do
+          tag="$(basename "$dir")"
+          if [[ "$(cat "$dir/draft")" == true && "$tag" == latest-* ]]; then
+            printf '2026-08-17T00:00:00Z\t%s\n' "$tag"
+          fi
+        done
+    exit
+  fi
+  if [[ "$1" == --method && "$2" == DELETE ]]; then
+    endpoint="$3"
+    rm -f "$FAKE_STATE/tags/${endpoint##*/}"
+    exit
+  fi
+
+  endpoint="$1"
+  shift
+  jq_filter=
+  if [[ "${1:-}" == --jq ]]; then
+    jq_filter="$2"
+  fi
+  case "$endpoint" in
+    repos/*/git/ref/heads/main)
+      cat "$FAKE_STATE/main-sha"
+      ;;
+    repos/*/git/ref/tags/*)
+      cat "$FAKE_STATE/tags/${endpoint##*/}"
+      ;;
+    repos/*/releases/tags/*)
+      dir="$(release_dir "${endpoint##*/}")"
+      case "$jq_filter" in
+        '.target_commitish') cat "$dir/sha" ;;
+        '.name // "Latest Build"') cat "$dir/title" ;;
+        '.body // ""') cat "$dir/body" ;;
+        '.assets | length') find "$dir/assets" -type f | wc -l | tr -d ' ' ;;
+        *) echo 1 ;;
+      esac
+      ;;
+  esac
+  exit
+fi
+
+if [[ "$1" == release ]]; then
+  action="$2"
+  tag="$3"
+  shift 3
+  case "$action" in
+    create)
+      dir="$(release_dir "$tag")"
+      mkdir -p "$dir/assets"
+      draft=false
+      target=
+      title=
+      notes=
+      while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+          --repo) shift 2 ;;
+          --title) title="$2"; shift 2 ;;
+          --notes-file) notes="$2"; shift 2 ;;
+          --draft) draft=true; shift ;;
+          --target) target="$2"; shift 2 ;;
+          --*) shift ;;
+          *) cp "$1" "$dir/assets/"; shift ;;
+        esac
+      done
+      printf '%s' "$draft" >"$dir/draft"
+      printf '%s' "$target" >"$dir/sha"
+      printf '%s' "$title" >"$dir/title"
+      if [[ -n "$notes" ]]; then cp "$notes" "$dir/body"; else : >"$dir/body"; fi
+      ;;
+    edit)
+      new_tag=
+      while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+          --tag) new_tag="$2"; shift 2 ;;
+          *) shift ;;
+        esac
+      done
+      dir="$(release_dir "$tag")"
+      target="$(cat "$dir/sha")"
+      mv "$dir" "$(release_dir "$new_tag")"
+      printf 'false' >"$(release_dir "$new_tag")/draft"
+      printf '%s' "$target" >"$FAKE_STATE/tags/$new_tag"
+      ;;
+    delete)
+      rm -rf "$(release_dir "$tag")"
+      ;;
+    download)
+      dir=
+      while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+          --dir) dir="$2"; shift 2 ;;
+          *) shift ;;
+        esac
+      done
+      mkdir -p "$dir"
+      cp "$(release_dir "$tag")/assets/"* "$dir/"
+      ;;
+  esac
+fi

--- a/scripts/testdata/fake-gh.sh
+++ b/scripts/testdata/fake-gh.sh
@@ -5,9 +5,27 @@ set -euo pipefail
 command_text="$*"
 printf '%s\n' "$command_text" >>"$FAKE_LOG"
 if [[ -n "${FAIL_MATCH:-}" && "$command_text" == *"$FAIL_MATCH"* && ! -f "$FAKE_STATE/failure-used" ]]; then
-  touch "$FAKE_STATE/failure-used"
-  echo "injected failure" >&2
+  failure_match_count=0
+  if [[ -f "$FAKE_STATE/failure-match-count" ]]; then
+    read -r failure_match_count <"$FAKE_STATE/failure-match-count"
+  fi
+  failure_match_count=$((failure_match_count + 1))
+  printf '%s' "$failure_match_count" >"$FAKE_STATE/failure-match-count"
+  if [[ "$failure_match_count" -eq "${FAIL_MATCH_OCCURRENCE:-1}" ]]; then
+    touch "$FAKE_STATE/failure-used"
+    echo "injected failure" >&2
+    exit 1
+  fi
+fi
+if [[ -n "${POST_EDIT_FAIL_MATCH:-}" &&
+      -f "$FAKE_STATE/promotion-applied" &&
+      "$command_text" == *"$POST_EDIT_FAIL_MATCH"* ]]; then
+  echo "injected post-edit failure" >&2
   exit 1
+fi
+if [[ -n "${PAUSE_MATCH:-}" && "$command_text" == *"$PAUSE_MATCH"* ]]; then
+  touch "$FAKE_STATE/pause-started"
+  sleep 1
 fi
 
 release_dir() {
@@ -20,6 +38,9 @@ api_status() {
   case "$endpoint" in
     repos/*/releases/tags/*)
       path="$(release_dir "${endpoint##*/}")"
+      if [[ -e "$path" && "$(cat "$path/draft")" == true ]]; then
+        path=
+      fi
       ;;
     repos/*/git/ref/tags/*)
       path="$FAKE_STATE/tags/${endpoint##*/}"
@@ -37,15 +58,23 @@ if [[ "$1" == api ]]; then
   shift
   if [[ "$1" == --include ]]; then
     shift 2
+    if [[ -n "${HTTP_FAIL_MATCH:-}" && "$1" == *"$HTTP_FAIL_MATCH"* ]]; then
+      printf 'HTTP/2.0 500 Internal Server Error\n'
+      exit 1
+    fi
     api_status "$1"
     exit
   fi
   if [[ "$1" == --paginate ]]; then
+    expected_filter='.[] | select(.draft and ((.tag_name | startswith("latest-staging-")) or (.tag_name | startswith("latest-backup-")))) | [.created_at, .tag_name, .target_commitish] | @tsv'
+    [[ "$2" == "repos/example/repo/releases?per_page=100" ]]
+    [[ "$3" == --jq ]]
+    [[ "$4" == "$expected_filter" ]]
     find "$FAKE_STATE/releases" -mindepth 1 -maxdepth 1 -type d \
       | while read -r dir; do
           tag="$(basename "$dir")"
-          if [[ "$(cat "$dir/draft")" == true && "$tag" == latest-* ]]; then
-            printf '2026-08-17T00:00:00Z\t%s\n' "$tag"
+          if [[ "$(cat "$dir/draft")" == true && ("$tag" == latest-staging-* || "$tag" == latest-backup-*) ]]; then
+            printf '2026-08-17T00:00:00Z\t%s\t%s\n' "$tag" "$(cat "$dir/sha")"
           fi
         done
     exit
@@ -71,6 +100,7 @@ if [[ "$1" == api ]]; then
       ;;
     repos/*/releases/tags/*)
       dir="$(release_dir "${endpoint##*/}")"
+      [[ "$(cat "$dir/draft")" == false ]]
       case "$jq_filter" in
         '.target_commitish') cat "$dir/sha" ;;
         '.name // "Latest Build"') cat "$dir/title" ;;
@@ -110,6 +140,9 @@ if [[ "$1" == release ]]; then
       printf '%s' "$target" >"$dir/sha"
       printf '%s' "$title" >"$dir/title"
       if [[ -n "$notes" ]]; then cp "$notes" "$dir/body"; else : >"$dir/body"; fi
+      if [[ -n "${ADVANCE_MAIN_MATCH:-}" && "$command_text" == *"$ADVANCE_MAIN_MATCH"* ]]; then
+        printf 'newer-sha' >"$FAKE_STATE/main-sha"
+      fi
       ;;
     edit)
       new_tag=
@@ -124,6 +157,7 @@ if [[ "$1" == release ]]; then
       mv "$dir" "$(release_dir "$new_tag")"
       printf 'false' >"$(release_dir "$new_tag")/draft"
       printf '%s' "$target" >"$FAKE_STATE/tags/$new_tag"
+      touch "$FAKE_STATE/promotion-applied"
       ;;
     delete)
       rm -rf "$(release_dir "$tag")"


### PR DESCRIPTION
## Summary
- split cancellable builds from serialized latest publication
- stage both the new asset set and a complete backup before cutover
- automatically restore the prior release after a failed cutover
- recover and prune retained recovery drafts on later runs
- classify missing resources by HTTP status and propagate API failures
- preserve completed promotions when later verification or signals fail
- remove unsupported `--version latest` guidance from rolling release notes
- verify the workflow, publisher, and recovery paths on pull requests

## Root cause
The workflow suppressed failures from deleting the existing latest release, then attempted to create a duplicate release with the same tag.

## Validation
- `actionlint .github/workflows/latest.yml`
- `docker run --rm -v "${PWD}:/mnt" koalaman/shellcheck:v0.11.0 scripts/publish-latest-release.sh scripts/test-publish-latest-release.sh scripts/testdata/fake-gh.sh`
- `bash scripts/test-publish-latest-release.sh` (24 deterministic lifecycle scenarios)
- `mage test`

Docs: rolling release notes no longer advertise `--version latest` because azd resolves it to the highest registry semantic version, not the rolling GitHub release.
